### PR TITLE
chore: add local infra and persistence baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+NODE_ENV=development
+PORT=3333
+LOG_LEVEL=info
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3333
+DATABASE_URL=postgresql://forgeops:forgeops@localhost:5432/forgeops
+REDIS_URL=redis://localhost:6379
+GITHUB_APP_ID=
+GITHUB_APP_INSTALLATION_ID=
+GITHUB_APP_PRIVATE_KEY=
+GITHUB_APP_WEBHOOK_SECRET=

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,9 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+

--- a/backend/src/infra/config/persistence-env.ts
+++ b/backend/src/infra/config/persistence-env.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+const persistenceEnvSchema = z.object({
+  DATABASE_URL: z.string().trim().url(),
+  REDIS_URL: z.string().trim().url(),
+});
+
+export type PersistenceEnv = z.infer<typeof persistenceEnvSchema>;
+
+export const loadPersistenceEnv = (input: NodeJS.ProcessEnv): PersistenceEnv =>
+  persistenceEnvSchema.parse(input);
+

--- a/backend/src/tests/infra/config/persistence-env.test.ts
+++ b/backend/src/tests/infra/config/persistence-env.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { loadPersistenceEnv } from '../../../infra/config/persistence-env.js';
+
+describe('loadPersistenceEnv', () => {
+  it('should parse database and redis URLs', () => {
+    expect(
+      loadPersistenceEnv({
+        DATABASE_URL: 'postgresql://forgeops:forgeops@localhost:5432/forgeops',
+        REDIS_URL: 'redis://localhost:6379',
+      }),
+    ).toEqual({
+      DATABASE_URL: 'postgresql://forgeops:forgeops@localhost:5432/forgeops',
+      REDIS_URL: 'redis://localhost:6379',
+    });
+  });
+
+  it('should reject invalid urls', () => {
+    expect(() =>
+      loadPersistenceEnv({
+        DATABASE_URL: 'not-a-url',
+        REDIS_URL: 'redis://localhost:6379',
+      }),
+    ).toThrowError();
+  });
+});
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: forgeops-postgres
+    environment:
+      POSTGRES_DB: forgeops
+      POSTGRES_USER: forgeops
+      POSTGRES_PASSWORD: forgeops
+    ports:
+      - '5432:5432'
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U forgeops -d forgeops']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7.4-alpine
+    container_name: forgeops-redis
+    command: ['redis-server', '--appendonly', 'yes']
+    ports:
+      - '6379:6379'
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/scripts/run-turbo.mjs
+++ b/scripts/run-turbo.mjs
@@ -1,0 +1,14 @@
+import { spawn } from 'node:child_process';
+import process from 'node:process';
+
+const command = process.platform === 'win32' ? 'node_modules\\.bin\\turbo.CMD' : './node_modules/.bin/turbo';
+const args = ['run', ...process.argv.slice(2)];
+
+const child = spawn(command, args, {
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+child.on('exit', (code) => {
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
## Summary
- add docker-compose and environment examples for local infrastructure
- add the initial Prisma schema and persistence env validation
- keep the persistence baseline ready for domain modeling

## Issue
Closes #9
