### PR TITLE
feat: add github app integration boundary

### DIFF
--- a/backend/src/app/create-server.ts
+++ b/backend/src/app/create-server.ts
@@ -1,13 +1,16 @@
 import Fastify from 'fastify';
 import { registerRoutes } from './register-routes.js';
 import type { AppEnv } from '../infra/config/app-env.js';
+import type { GitHubAppEnv } from '../infra/config/github-app-env.js';
 import { createLogger } from '../infra/logger/create-logger.js';
 import { createErrorHandler } from '../infra/http/error-handler.js';
+import { createGitHubAppBoundary } from '../modules/github/github-app.boundary.js';
 import { StaticHealthRepository } from '../modules/health/health.repository.js';
 import { HealthService } from '../modules/health/health.service.js';
 
 export interface CreateServerOptions {
   env: AppEnv;
+  githubConfig?: GitHubAppEnv | null;
 }
 
 export const createServer = (options: CreateServerOptions) => {
@@ -15,10 +18,12 @@ export const createServer = (options: CreateServerOptions) => {
     logger: createLogger(options.env.LOG_LEVEL),
   });
 
+  const githubBoundary = createGitHubAppBoundary(options.githubConfig ?? null);
   const healthRepository = new StaticHealthRepository({
     environment: options.env.NODE_ENV,
   });
   const healthService = new HealthService({
+    githubBoundary,
     repository: healthRepository,
   });
 

--- a/backend/src/infra/config/github-app-env.ts
+++ b/backend/src/infra/config/github-app-env.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+const optionalGitHubAppEnvSchema = z
+  .object({
+    GITHUB_APP_ID: z.string().trim().min(1).optional(),
+    GITHUB_APP_INSTALLATION_ID: z.string().trim().min(1).optional(),
+    GITHUB_APP_PRIVATE_KEY: z.string().trim().min(1).optional(),
+    GITHUB_APP_WEBHOOK_SECRET: z.string().trim().min(1).optional(),
+  })
+  .transform((value) => {
+    const hasValues = Object.values(value).some((field) => field !== undefined);
+
+    if (!hasValues) {
+      return null;
+    }
+
+    return value;
+  });
+
+const requiredGitHubAppEnvSchema = z.object({
+  GITHUB_APP_ID: z.string().trim().min(1),
+  GITHUB_APP_INSTALLATION_ID: z.string().trim().min(1),
+  GITHUB_APP_PRIVATE_KEY: z.string().trim().min(1),
+  GITHUB_APP_WEBHOOK_SECRET: z.string().trim().min(1),
+});
+
+export type GitHubAppEnv = z.infer<typeof requiredGitHubAppEnvSchema>;
+
+export const loadOptionalGitHubAppEnv = (
+  input: NodeJS.ProcessEnv,
+): GitHubAppEnv | null => {
+  const optionalConfig = optionalGitHubAppEnvSchema.parse(input);
+
+  if (optionalConfig === null) {
+    return null;
+  }
+
+  return requiredGitHubAppEnvSchema.parse(optionalConfig);
+};
+
+export const loadGitHubAppEnv = (input: NodeJS.ProcessEnv): GitHubAppEnv =>
+  requiredGitHubAppEnvSchema.parse(input);
+

--- a/backend/src/modules/github/github-app.boundary.ts
+++ b/backend/src/modules/github/github-app.boundary.ts
@@ -1,0 +1,36 @@
+import type { GitHubAppEnv } from '../../infra/config/github-app-env.js';
+import { GitHubAppProvider } from './providers/github-app.provider.js';
+
+export interface GitHubRepositoryDescriptor {
+  owner: string;
+  name: string;
+}
+
+export interface GitHubWorkflowDescriptor {
+  id: string;
+  name: string;
+  path: string;
+}
+
+export interface GitHubAppBoundary {
+  readonly mode: 'github-app';
+  readonly configured: boolean;
+  getStatus(): GitHubAppStatus;
+  assertConfigured(): void;
+  listInstallationRepositories(): Promise<GitHubRepositoryDescriptor[]>;
+  listRepositoryWorkflows(
+    repository: GitHubRepositoryDescriptor,
+  ): Promise<GitHubWorkflowDescriptor[]>;
+}
+
+export interface GitHubAppStatus {
+  mode: 'github-app';
+  configured: boolean;
+  appId: string | null;
+  installationId: string | null;
+  webhookConfigured: boolean;
+}
+
+export const createGitHubAppBoundary = (
+  config: GitHubAppEnv | null,
+): GitHubAppBoundary => new GitHubAppProvider(config);

--- a/backend/src/modules/github/providers/github-app.provider.ts
+++ b/backend/src/modules/github/providers/github-app.provider.ts
@@ -1,0 +1,62 @@
+import type {
+  GitHubAppBoundary,
+  GitHubAppStatus,
+  GitHubRepositoryDescriptor,
+  GitHubWorkflowDescriptor,
+} from '../github-app.boundary.js';
+import type { GitHubAppEnv } from '../../../infra/config/github-app-env.js';
+import { ConfigurationError } from '../../../shared/errors/configuration-error.js';
+
+const maskIdentifier = (value: string): string => {
+  if (value.length <= 4) {
+    return '*'.repeat(value.length);
+  }
+
+  return `${value.slice(0, 2)}${'*'.repeat(value.length - 4)}${value.slice(-2)}`;
+};
+
+export class GitHubAppProvider implements GitHubAppBoundary {
+  public readonly mode = 'github-app' as const;
+  public readonly configured: boolean;
+
+  private readonly config: GitHubAppEnv | null;
+
+  public constructor(config: GitHubAppEnv | null) {
+    this.config = config;
+    this.configured = config !== null;
+  }
+
+  public getStatus(): GitHubAppStatus {
+    return {
+      mode: this.mode,
+      configured: this.configured,
+      appId: this.config ? maskIdentifier(this.config.GITHUB_APP_ID) : null,
+      installationId: this.config
+        ? maskIdentifier(this.config.GITHUB_APP_INSTALLATION_ID)
+        : null,
+      webhookConfigured: this.config !== null,
+    };
+  }
+
+  public assertConfigured(): void {
+    if (this.config === null) {
+      throw new ConfigurationError(
+        'GitHub App configuration is required before using the integration boundary.',
+        'github_app_not_configured',
+      );
+    }
+  }
+
+  public async listInstallationRepositories(): Promise<GitHubRepositoryDescriptor[]> {
+    this.assertConfigured();
+    return [];
+  }
+
+  public async listRepositoryWorkflows(
+    repository: GitHubRepositoryDescriptor,
+  ): Promise<GitHubWorkflowDescriptor[]> {
+    this.assertConfigured();
+    void repository;
+    return [];
+  }
+}

--- a/backend/src/modules/health/health.service.ts
+++ b/backend/src/modules/health/health.service.ts
@@ -1,6 +1,8 @@
+import type { GitHubAppBoundary } from '../github/github-app.boundary.js';
 import type { HealthRepository } from './health.repository.js';
 
 interface HealthServiceOptions {
+  githubBoundary: GitHubAppBoundary;
   repository: HealthRepository;
 }
 
@@ -9,16 +11,28 @@ export interface HealthSnapshot {
   service: 'forgeops-backend';
   timestamp: string;
   environment: 'development' | 'test' | 'production';
+  integrations: {
+    github: ReturnType<GitHubAppBoundary['getStatus']>;
+  };
 }
 
 export class HealthService {
+  private readonly githubBoundary: HealthServiceOptions['githubBoundary'];
   private readonly repository: HealthServiceOptions['repository'];
 
   public constructor(options: HealthServiceOptions) {
+    this.githubBoundary = options.githubBoundary;
     this.repository = options.repository;
   }
 
   public getSnapshot(): HealthSnapshot {
-    return this.repository.getBaseHealthSnapshot();
+    const baseSnapshot = this.repository.getBaseHealthSnapshot();
+
+    return {
+      ...baseSnapshot,
+      integrations: {
+        github: this.githubBoundary.getStatus(),
+      },
+    };
   }
 }

--- a/backend/src/tests/app/create-server.test.ts
+++ b/backend/src/tests/app/create-server.test.ts
@@ -13,6 +13,7 @@ describe('createServer', () => {
         PORT: 3333,
         LOG_LEVEL: 'silent',
       },
+      githubConfig: null,
     });
 
     const response = await server.inject({
@@ -24,6 +25,11 @@ describe('createServer', () => {
     expect(response.json()).toMatchObject({
       status: 'ok',
       environment: 'test',
+      integrations: {
+        github: {
+          configured: false,
+        },
+      },
     });
 
     await server.close();
@@ -36,6 +42,7 @@ describe('createServer', () => {
         PORT: 3333,
         LOG_LEVEL: 'silent',
       },
+      githubConfig: null,
     });
 
     const response = await server.inject({

--- a/backend/src/tests/infra/config/github-app-env.test.ts
+++ b/backend/src/tests/infra/config/github-app-env.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  loadGitHubAppEnv,
+  loadOptionalGitHubAppEnv,
+} from '../../../infra/config/github-app-env.js';
+
+describe('GitHub App env loaders', () => {
+  it('should return null when no GitHub App variables are provided', () => {
+    expect(loadOptionalGitHubAppEnv({})).toBeNull();
+  });
+
+  it('should reject partially configured GitHub App values', () => {
+    expect(() =>
+      loadOptionalGitHubAppEnv({
+        GITHUB_APP_ID: '123',
+      }),
+    ).toThrowError();
+  });
+
+  it('should require all GitHub App variables for strict loading', () => {
+    expect(() => loadGitHubAppEnv({})).toThrowError();
+  });
+});
+

--- a/backend/src/tests/modules/github/github-app.boundary.test.ts
+++ b/backend/src/tests/modules/github/github-app.boundary.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { createGitHubAppBoundary } from '../../../modules/github/github-app.boundary.js';
+
+describe('createGitHubAppBoundary', () => {
+  it('should expose a safe status summary when configured', () => {
+    const boundary = createGitHubAppBoundary({
+      GITHUB_APP_ID: '12345678',
+      GITHUB_APP_INSTALLATION_ID: '87654321',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+      GITHUB_APP_WEBHOOK_SECRET: 'secret',
+    });
+
+    expect(boundary.getStatus()).toEqual({
+      mode: 'github-app',
+      configured: true,
+      appId: '12****78',
+      installationId: '87****21',
+      webhookConfigured: true,
+    });
+  });
+
+  it('should fail fast when the boundary is used without configuration', async () => {
+    const boundary = createGitHubAppBoundary(null);
+
+    expect(() => boundary.assertConfigured()).toThrowError();
+    await expect(boundary.listInstallationRepositories()).rejects.toThrowError();
+  });
+});
+

--- a/backend/src/tests/modules/health/health.service.test.ts
+++ b/backend/src/tests/modules/health/health.service.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
+import { createGitHubAppBoundary } from '../../../modules/github/github-app.boundary.js';
 import { StaticHealthRepository } from '../../../modules/health/health.repository.js';
 import { HealthService } from '../../../modules/health/health.service.js';
 
 describe('HealthService', () => {
   it('should build a deterministic snapshot', () => {
     const service = new HealthService({
+      githubBoundary: createGitHubAppBoundary(null),
       repository: new StaticHealthRepository({
         environment: 'test',
         now: () => new Date('2026-01-01T00:00:00.000Z'),
@@ -16,6 +18,15 @@ describe('HealthService', () => {
       service: 'forgeops-backend',
       timestamp: '2026-01-01T00:00:00.000Z',
       environment: 'test',
+      integrations: {
+        github: {
+          mode: 'github-app',
+          configured: false,
+          appId: null,
+          installationId: null,
+          webhookConfigured: false,
+        },
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary
- add the GitHub App boundary and provider scaffold
- validate GitHub App environment configuration
- expose integration status through the backend health snapshot

## Issue
Closes #10
