### PR TITLE
refactor(backend): harden health route typing

### DIFF
--- a/backend/src/app/register-routes.ts
+++ b/backend/src/app/register-routes.ts
@@ -1,3 +1,10 @@
+import type {
+  FastifyInstance,
+  RawReplyDefaultExpression,
+  RawRequestDefaultExpression,
+  RawServerDefault,
+} from 'fastify';
+import type { Logger } from 'pino';
 import type { HealthService } from '../modules/health/health.service.js';
 import { registerHealthRoutes } from '../modules/health/health.controller.js';
 
@@ -5,12 +12,15 @@ interface RegisterRoutesOptions {
   healthService: HealthService;
 }
 
-interface RouteRegistrar {
-  get(path: string, ...args: readonly unknown[]): unknown;
-}
+export type ForgeOpsFastifyInstance = FastifyInstance<
+  RawServerDefault,
+  RawRequestDefaultExpression<RawServerDefault>,
+  RawReplyDefaultExpression<RawServerDefault>,
+  Logger
+>;
 
 export const registerRoutes = (
-  app: RouteRegistrar,
+  app: ForgeOpsFastifyInstance,
   options: RegisterRoutesOptions,
 ): void => {
   registerHealthRoutes(app, options.healthService);

--- a/backend/src/modules/health/health.controller.ts
+++ b/backend/src/modules/health/health.controller.ts
@@ -1,22 +1,28 @@
+import type { FastifyRequest, RouteGenericInterface } from 'fastify';
 import { z } from 'zod';
-import type { HealthService } from './health.service.js';
+import type { ForgeOpsFastifyInstance } from '../../app/register-routes.js';
+import type { HealthService, HealthSnapshot } from './health.service.js';
 
-interface RouteRegistrar {
-  get(path: string, ...args: readonly unknown[]): unknown;
+interface HealthRouteGeneric extends RouteGenericInterface {
+  Querystring: {
+    verbose?: 'true' | 'false';
+  };
+  Reply: HealthSnapshot;
 }
 
+export type HealthRouteService = Pick<HealthService, 'getSnapshot'>;
+
 const healthQuerySchema = z.object({
-  verbose: z
-    .union([z.literal('true'), z.literal('false')])
-    .optional()
-    .transform((value) => value === 'true'),
+  verbose: z.union([z.literal('true'), z.literal('false')]).optional(),
 });
 
+type HealthRouteRequest = FastifyRequest<HealthRouteGeneric>;
+
 export const registerHealthRoutes = (
-  app: RouteRegistrar,
-  healthService: HealthService,
+  app: ForgeOpsFastifyInstance,
+  healthService: HealthRouteService,
 ): void => {
-  app.get('/api/v1/health', async (request: { query: Record<string, unknown> }) => {
+  app.get<HealthRouteGeneric>('/api/v1/health', async (request: HealthRouteRequest) => {
     healthQuerySchema.parse(request.query);
     return healthService.getSnapshot();
   });

--- a/backend/src/tests/app/create-server.test.ts
+++ b/backend/src/tests/app/create-server.test.ts
@@ -18,7 +18,7 @@ describe('createServer', () => {
 
     const response = await server.inject({
       method: 'GET',
-      url: '/api/v1/health',
+      url: '/api/v1/health?verbose=true',
     });
 
     expect(response.statusCode).toBe(200);

--- a/backend/src/tests/modules/health/health.controller.test.ts
+++ b/backend/src/tests/modules/health/health.controller.test.ts
@@ -1,0 +1,85 @@
+import Fastify from 'fastify';
+import { describe, expect, it, vi } from 'vitest';
+import { createErrorHandler } from '../../../infra/http/error-handler.js';
+import { createLogger } from '../../../infra/logger/create-logger.js';
+import {
+  registerHealthRoutes,
+  type HealthRouteService,
+} from '../../../modules/health/health.controller.js';
+import type { HealthSnapshot } from '../../../modules/health/health.service.js';
+
+describe('registerHealthRoutes', () => {
+  it('should return the health snapshot for valid requests', async () => {
+    const snapshot: HealthSnapshot = {
+      status: 'ok',
+      service: 'forgeops-backend',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      environment: 'test',
+      integrations: {
+        github: {
+          mode: 'github-app',
+          configured: false,
+          appId: null,
+          installationId: null,
+          webhookConfigured: false,
+        },
+      },
+    };
+
+    const healthService: HealthRouteService = {
+      getSnapshot: vi.fn(() => snapshot),
+    };
+
+    const app = Fastify({
+      logger: createLogger('silent'),
+    });
+
+    app.setErrorHandler(createErrorHandler(app.log));
+    registerHealthRoutes(app, healthService);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/health?verbose=true',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      status: 'ok',
+      environment: 'test',
+    });
+    expect(healthService.getSnapshot).toHaveBeenCalledTimes(1);
+
+    await app.close();
+  });
+
+  it('should reject invalid querystring values', async () => {
+    const healthService: HealthRouteService = {
+      getSnapshot: vi.fn(() => {
+        throw new Error('getSnapshot should not be called for invalid requests');
+      }),
+    };
+
+    const app = Fastify({
+      logger: createLogger('silent'),
+    });
+
+    app.setErrorHandler(createErrorHandler(app.log));
+    registerHealthRoutes(app, healthService);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/health?verbose=invalid',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'validation_error',
+        message: 'Invalid input',
+      },
+    });
+    expect(healthService.getSnapshot).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the generic route registrar with a typed Fastify boundary for the backend app
- make the health route contract explicit for query and reply types
- add controller-level HTTP tests to protect the current health endpoint behavior

## How to test
1. npm --prefix backend run lint
2. npm --prefix backend run typecheck
3. npm --prefix backend run test

## Issue
Closes #21