### PR TITLE
test(contracts): document and validate health api contract

### DIFF
--- a/backend/src/tests/contracts/health-contract.test.ts
+++ b/backend/src/tests/contracts/health-contract.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer } from '../../../src/app/create-server.js';
+
+const toResponseHeaders = (headers: Record<string, string | string[] | number | undefined>) => {
+  const normalized = new Headers();
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === 'undefined') {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        normalized.append(key, item);
+      }
+
+      continue;
+    }
+
+    normalized.set(key, String(value));
+  }
+
+  return normalized;
+};
+
+const createBackendFetch = (server: ReturnType<typeof createServer>): typeof fetch => {
+  return async (input, init) => {
+    const rawUrl = input instanceof Request ? input.url : input.toString();
+    const url = new URL(rawUrl);
+    const headers = init?.headers
+      ? Object.fromEntries(new Headers(init.headers).entries())
+      : {};
+
+    return new Promise((resolve, reject) => {
+      server.inject(
+        {
+          method: 'GET',
+          url: `${url.pathname}${url.search}`,
+          headers,
+        },
+        (error, response) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          if (!response) {
+            reject(new Error('Fastify inject did not return a response.'));
+            return;
+          }
+
+          resolve(
+            new Response(response.payload, {
+              status: response.statusCode,
+              headers: toResponseHeaders(response.headers),
+            }),
+          );
+        },
+      );
+    });
+  };
+};
+
+describe('health contract', () => {
+  let server: ReturnType<typeof createServer> | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = null;
+    }
+  });
+
+  it('should keep the frontend health parser compatible with the real backend response', async () => {
+    const { createApiClient } = await import(
+      new URL('../../../../frontend/src/lib/api/client.ts', import.meta.url).href
+    );
+
+    server = createServer({
+      env: {
+        NODE_ENV: 'test',
+        PORT: 3333,
+        LOG_LEVEL: 'silent',
+      },
+      githubConfig: null,
+    });
+
+    const client = createApiClient({
+      baseUrl: 'http://forgeops.local',
+      fetcher: createBackendFetch(server),
+    });
+
+    await expect(client.getHealth()).resolves.toMatchObject({
+      status: 'ok',
+      service: 'forgeops-backend',
+      environment: 'test',
+      integrations: {
+        github: {
+          mode: 'github-app',
+          configured: false,
+        },
+      },
+    });
+  });
+});

--- a/docs/architecture/http-contract-strategy.md
+++ b/docs/architecture/http-contract-strategy.md
@@ -1,0 +1,34 @@
+# HTTP Contract Strategy
+
+## Goal
+Keep HTTP contracts between `backend` and `frontend` stable during the hardening stage without introducing a shared runtime package too early.
+
+## Source of truth
+- The `backend` owns the HTTP contract.
+- Route handlers and service output types define the canonical response shape.
+- The `frontend` consumes backend endpoints through an explicit client boundary and validates payloads locally with `zod`.
+
+## Current strategy
+- Keep runtime contract definitions inside each app workspace during the hardening stage.
+- The `frontend` may mirror backend response schemas locally when it needs client-side validation.
+- Every mirrored contract with product impact must be protected by an automated contract test or equivalent coverage.
+
+## Contract validation rule
+- The preferred validation path is an automated test that exercises a real backend response through the consuming frontend client.
+- Unit tests that validate each side independently are useful, but they do not replace a contract test when drift risk is relevant.
+
+## Extraction trigger for `packages/`
+Create a shared runtime contract package only when all conditions below are true:
+- at least two runtime workspaces need the same contract artifact
+- the same contract is duplicated in at least two meaningful places
+- extraction reduces duplication without coupling unstable backend internals into the frontend
+- the decision is documented before introduction
+
+## Current decision for ForgeOps
+- Do not create `packages/contracts` yet.
+- Keep the health contract local to each app.
+- Use a contract test to ensure the frontend parser still accepts the real backend health payload.
+
+## Follow-up guidance
+- Reevaluate extraction when the first real product vertical introduces repeated request/response schemas beyond health.
+- Treat drift between backend output and frontend parser as a blocking regression.

--- a/docs/architecture/monorepo-boundaries.md
+++ b/docs/architecture/monorepo-boundaries.md
@@ -13,8 +13,8 @@
 - `frontend` may depend on public backend HTTP endpoints only.
 - `backend` must isolate providers under `src/infra` or module-specific `providers`.
 - Providers expose internal interfaces so integrations can be mocked in tests.
+- HTTP contract ownership and extraction rules are documented in `docs/architecture/http-contract-strategy.md`.
 
 ## Expansion Triggers
 - Extract a package only when at least two workspaces depend on the same artifact.
 - Write an ADR before introducing a new shared runtime package or cross-cutting infrastructure.
-


### PR DESCRIPTION
## Summary
- document the current frontend/backend HTTP contract strategy during foundation hardening
- define the extraction trigger for shared runtime contracts under packages
- validate the health contract by exercising a real backend response through the frontend API client

## How to test
- npm --prefix backend run lint
- npm --prefix backend run typecheck
- npm --prefix backend run test
- npm run lint
- npm run typecheck
- npm run test

## Issue
Closes #22