### PR TITLE
ci(workflows): harden github actions baseline

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,35 @@
+name: Workflow Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actionlint-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate GitHub workflows
+        uses: reviewdog/action-actionlint@a40b7d35e62844ec9c0096ff3f5ff48579c90759
+        with:
+          fail_level: error
+          actionlint_flags: "-color"

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Request Codex review
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const marker = '<!-- forgeops-codex-review -->';

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,18 +23,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 9.15.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,18 +23,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 9.15.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -23,18 +23,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 9.15.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/docs/architecture/repo-protection.md
+++ b/docs/architecture/repo-protection.md
@@ -2,12 +2,13 @@
 
 ## Pull Request Policy
 - Require pull requests before merging into `main`.
-- Require `lint`, `typecheck`, and `test` to pass before merge.
+- Require `actionlint`, `lint`, `typecheck`, and `test` to pass before merge.
 - Require at least one human review once the team grows beyond a single maintainer.
 - Block force pushes and branch deletions on `main`.
 - Keep Codex review as advisory until the team validates its signal quality on this repository.
 
 ## Status Checks
+- `actionlint`
 - `lint`
 - `typecheck`
 - `test`
@@ -17,7 +18,8 @@
 - Use `pull_request`, not `pull_request_target`, for workflows that react to repository code changes.
 - Do not expose secrets to fork pull requests.
 - Set `timeout-minutes` and `concurrency` for every workflow.
-- Prefer first-party actions and pin third-party actions by SHA when introduced.
+- Pin workflow actions by commit SHA instead of floating tags.
+- Prefer first-party actions when possible and validate workflow files with `actionlint`.
 - Keep Codex review limited to PR comments or reviews; it must not mutate repository contents.
 
 ## Codex Review Policy


### PR DESCRIPTION
## Summary
- pin the current GitHub Actions workflows to exact SHAs for safer supply-chain control
- add automated workflow validation with actionlint
- keep Codex review advisory while documenting the updated protection baseline

## How to test
- npm run lint
- npm run typecheck
- npm run test

## Issue
Closes #23