### PR TITLE
feat(auth): add operator auth config boundary

### DIFF
--- a/backend/src/app/create-server.ts
+++ b/backend/src/app/create-server.ts
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import { registerRoutes } from './register-routes.js';
 import type { AppEnv } from '../infra/config/app-env.js';
+import type { OperatorAuthEnv } from '../infra/config/auth-env.js';
 import type { GitHubAppEnv } from '../infra/config/github-app-env.js';
 import { createLogger } from '../infra/logger/create-logger.js';
 import { createErrorHandler } from '../infra/http/error-handler.js';
@@ -10,6 +11,7 @@ import { HealthService } from '../modules/health/health.service.js';
 
 export interface CreateServerOptions {
   env: AppEnv;
+  authConfig?: OperatorAuthEnv | null;
   githubConfig?: GitHubAppEnv | null;
 }
 
@@ -17,6 +19,8 @@ export const createServer = (options: CreateServerOptions) => {
   const app = Fastify({
     logger: createLogger(options.env.LOG_LEVEL),
   });
+
+  app.decorateRequest('operatorPrincipal', null);
 
   const githubBoundary = createGitHubAppBoundary(options.githubConfig ?? null);
   const healthRepository = new StaticHealthRepository({

--- a/backend/src/app/fastify-auth.d.ts
+++ b/backend/src/app/fastify-auth.d.ts
@@ -1,0 +1,10 @@
+import 'fastify';
+import type { OperatorPrincipal } from '../shared/auth/operator-principal.js';
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    operatorPrincipal: OperatorPrincipal | null;
+  }
+}
+
+export {};

--- a/backend/src/infra/config/auth-env.ts
+++ b/backend/src/infra/config/auth-env.ts
@@ -1,0 +1,141 @@
+import { z } from 'zod';
+
+const operatorAuthModeSchema = z.enum(['jwks', 'shared-secret']);
+
+const rawOperatorAuthEnvSchema = z.object({
+  OPERATOR_AUTH_ENABLED: z.enum(['true', 'false']).optional(),
+  OPERATOR_AUTH_ISSUER: z.string().trim().min(1).optional(),
+  OPERATOR_AUTH_AUDIENCE: z.string().trim().min(1).optional(),
+  OPERATOR_AUTH_MODE: operatorAuthModeSchema.optional(),
+  OPERATOR_AUTH_JWKS_URL: z.string().trim().url().optional(),
+  OPERATOR_AUTH_SHARED_SECRET: z.string().trim().min(1).optional(),
+});
+
+const enabledOperatorAuthEnvSchema = z
+  .object({
+    OPERATOR_AUTH_ENABLED: z.literal('true'),
+    OPERATOR_AUTH_ISSUER: z.string().trim().min(1),
+    OPERATOR_AUTH_AUDIENCE: z.string().trim().min(1),
+    OPERATOR_AUTH_MODE: operatorAuthModeSchema,
+    OPERATOR_AUTH_JWKS_URL: z.string().trim().url().optional(),
+    OPERATOR_AUTH_SHARED_SECRET: z.string().trim().min(1).optional(),
+  })
+  .superRefine((value, context) => {
+    if (value.OPERATOR_AUTH_MODE === 'jwks') {
+      if (!value.OPERATOR_AUTH_JWKS_URL) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'OPERATOR_AUTH_JWKS_URL is required when OPERATOR_AUTH_MODE=jwks.',
+          path: ['OPERATOR_AUTH_JWKS_URL'],
+        });
+      }
+
+      if (value.OPERATOR_AUTH_SHARED_SECRET) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'OPERATOR_AUTH_SHARED_SECRET must not be set when OPERATOR_AUTH_MODE=jwks.',
+          path: ['OPERATOR_AUTH_SHARED_SECRET'],
+        });
+      }
+    }
+
+    if (value.OPERATOR_AUTH_MODE === 'shared-secret') {
+      if (!value.OPERATOR_AUTH_SHARED_SECRET) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'OPERATOR_AUTH_SHARED_SECRET is required when OPERATOR_AUTH_MODE=shared-secret.',
+          path: ['OPERATOR_AUTH_SHARED_SECRET'],
+        });
+      }
+
+      if (value.OPERATOR_AUTH_JWKS_URL) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'OPERATOR_AUTH_JWKS_URL must not be set when OPERATOR_AUTH_MODE=shared-secret.',
+          path: ['OPERATOR_AUTH_JWKS_URL'],
+        });
+      }
+    }
+  });
+
+export interface OperatorAuthEnv {
+  issuer: string;
+  audience: string;
+  verifierSource:
+    | {
+        type: 'jwks';
+        jwksUrl: string;
+      }
+    | {
+        type: 'shared-secret';
+        sharedSecret: string;
+      };
+}
+
+const hasAdditionalConfig = (
+  input: z.infer<typeof rawOperatorAuthEnvSchema>,
+): boolean => {
+  return [
+    input.OPERATOR_AUTH_ISSUER,
+    input.OPERATOR_AUTH_AUDIENCE,
+    input.OPERATOR_AUTH_MODE,
+    input.OPERATOR_AUTH_JWKS_URL,
+    input.OPERATOR_AUTH_SHARED_SECRET,
+  ].some((field) => typeof field !== 'undefined');
+};
+
+const toOperatorAuthEnv = (
+  input: z.infer<typeof enabledOperatorAuthEnvSchema>,
+): OperatorAuthEnv => {
+  if (input.OPERATOR_AUTH_MODE === 'jwks') {
+    return {
+      issuer: input.OPERATOR_AUTH_ISSUER,
+      audience: input.OPERATOR_AUTH_AUDIENCE,
+      verifierSource: {
+        type: 'jwks',
+        jwksUrl: input.OPERATOR_AUTH_JWKS_URL!,
+      },
+    };
+  }
+
+  return {
+    issuer: input.OPERATOR_AUTH_ISSUER,
+    audience: input.OPERATOR_AUTH_AUDIENCE,
+    verifierSource: {
+      type: 'shared-secret',
+      sharedSecret: input.OPERATOR_AUTH_SHARED_SECRET!,
+    },
+  };
+};
+
+export const loadOptionalOperatorAuthEnv = (
+  input: NodeJS.ProcessEnv,
+): OperatorAuthEnv | null => {
+  const rawConfig = rawOperatorAuthEnvSchema.parse(input);
+
+  if (rawConfig.OPERATOR_AUTH_ENABLED !== 'true') {
+    if (hasAdditionalConfig(rawConfig)) {
+      throw new Error(
+        'Operator auth config requires OPERATOR_AUTH_ENABLED=true when auth fields are provided.',
+      );
+    }
+
+    return null;
+  }
+
+  return toOperatorAuthEnv(enabledOperatorAuthEnvSchema.parse(rawConfig));
+};
+
+export const loadOperatorAuthEnv = (input: NodeJS.ProcessEnv): OperatorAuthEnv => {
+  const rawConfig = rawOperatorAuthEnvSchema.parse(input);
+
+  if (rawConfig.OPERATOR_AUTH_ENABLED !== 'true') {
+    throw new Error('OPERATOR_AUTH_ENABLED=true is required for protected operator auth.');
+  }
+
+  return toOperatorAuthEnv(enabledOperatorAuthEnvSchema.parse(rawConfig));
+};

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,12 +1,15 @@
 import { createServer } from './app/create-server.js';
 import { loadAppEnv } from './infra/config/app-env.js';
+import { loadOptionalOperatorAuthEnv } from './infra/config/auth-env.js';
 import { loadOptionalGitHubAppEnv } from './infra/config/github-app-env.js';
 
 const start = async (): Promise<void> => {
   const env = loadAppEnv(process.env);
+  const authConfig = loadOptionalOperatorAuthEnv(process.env);
   const githubConfig = loadOptionalGitHubAppEnv(process.env);
   const server = createServer({
     env,
+    authConfig,
     githubConfig,
   });
 
@@ -22,4 +25,3 @@ const start = async (): Promise<void> => {
 };
 
 void start();
-

--- a/backend/src/shared/auth/operator-auth-verifier.ts
+++ b/backend/src/shared/auth/operator-auth-verifier.ts
@@ -1,0 +1,9 @@
+import type { OperatorPrincipal } from './operator-principal.js';
+
+export interface VerifyOperatorAuthInput {
+  token: string;
+}
+
+export interface OperatorAuthVerifier {
+  verify(input: VerifyOperatorAuthInput): Promise<OperatorPrincipal>;
+}

--- a/backend/src/shared/auth/operator-principal.ts
+++ b/backend/src/shared/auth/operator-principal.ts
@@ -1,0 +1,50 @@
+export interface CreateOperatorPrincipalInput {
+  subject: string;
+  email?: string | null;
+  displayName?: string | null;
+  capabilities?: string[];
+}
+
+export interface OperatorPrincipal {
+  kind: 'operator';
+  subject: string;
+  email: string | null;
+  displayName: string | null;
+  capabilities: string[];
+}
+
+const normalizeOptionalText = (value?: string | null): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+
+  return normalized.length > 0 ? normalized : null;
+};
+
+export const createOperatorPrincipal = (
+  input: CreateOperatorPrincipalInput,
+): OperatorPrincipal => {
+  const subject = input.subject.trim();
+
+  if (subject.length === 0) {
+    throw new Error('Operator principal subject must not be empty.');
+  }
+
+  const capabilities = Array.from(
+    new Set(
+      (input.capabilities ?? [])
+        .map((capability) => capability.trim())
+        .filter((capability) => capability.length > 0),
+    ),
+  ).sort((left, right) => left.localeCompare(right));
+
+  return {
+    kind: 'operator',
+    subject,
+    email: normalizeOptionalText(input.email)?.toLowerCase() ?? null,
+    displayName: normalizeOptionalText(input.displayName),
+    capabilities,
+  };
+};

--- a/backend/src/tests/app/create-server.test.ts
+++ b/backend/src/tests/app/create-server.test.ts
@@ -13,6 +13,7 @@ describe('createServer', () => {
         PORT: 3333,
         LOG_LEVEL: 'silent',
       },
+      authConfig: null,
       githubConfig: null,
     });
 
@@ -42,6 +43,7 @@ describe('createServer', () => {
         PORT: 3333,
         LOG_LEVEL: 'silent',
       },
+      authConfig: null,
       githubConfig: null,
     });
 
@@ -57,6 +59,22 @@ describe('createServer', () => {
         message: 'Invalid input',
       },
     });
+
+    await server.close();
+  });
+
+  it('should decorate requests with an operator principal context slot', async () => {
+    const server = createServer({
+      env: {
+        NODE_ENV: 'test',
+        PORT: 3333,
+        LOG_LEVEL: 'silent',
+      },
+      authConfig: null,
+      githubConfig: null,
+    });
+
+    expect(server.hasRequestDecorator('operatorPrincipal')).toBe(true);
 
     await server.close();
   });

--- a/backend/src/tests/infra/config/auth-env.test.ts
+++ b/backend/src/tests/infra/config/auth-env.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  loadOperatorAuthEnv,
+  loadOptionalOperatorAuthEnv,
+} from '../../../infra/config/auth-env.js';
+
+describe('auth env', () => {
+  it('should return null when operator auth is disabled', () => {
+    expect(loadOptionalOperatorAuthEnv({})).toBeNull();
+    expect(loadOptionalOperatorAuthEnv({ OPERATOR_AUTH_ENABLED: 'false' })).toBeNull();
+  });
+
+  it('should parse a jwks-based operator auth config', () => {
+    expect(
+      loadOperatorAuthEnv({
+        OPERATOR_AUTH_ENABLED: 'true',
+        OPERATOR_AUTH_ISSUER: 'https://forgeops.example.com',
+        OPERATOR_AUTH_AUDIENCE: 'forgeops-api',
+        OPERATOR_AUTH_MODE: 'jwks',
+        OPERATOR_AUTH_JWKS_URL: 'https://forgeops.example.com/.well-known/jwks.json',
+      }),
+    ).toEqual({
+      issuer: 'https://forgeops.example.com',
+      audience: 'forgeops-api',
+      verifierSource: {
+        type: 'jwks',
+        jwksUrl: 'https://forgeops.example.com/.well-known/jwks.json',
+      },
+    });
+  });
+
+  it('should reject partial or contradictory operator auth config', () => {
+    expect(() =>
+      loadOptionalOperatorAuthEnv({
+        OPERATOR_AUTH_ISSUER: 'https://forgeops.example.com',
+      }),
+    ).toThrow(/OPERATOR_AUTH_ENABLED=true/);
+
+    expect(() =>
+      loadOperatorAuthEnv({
+        OPERATOR_AUTH_ENABLED: 'true',
+        OPERATOR_AUTH_ISSUER: 'https://forgeops.example.com',
+        OPERATOR_AUTH_AUDIENCE: 'forgeops-api',
+        OPERATOR_AUTH_MODE: 'jwks',
+        OPERATOR_AUTH_SHARED_SECRET: 'secret',
+      }),
+    ).toThrow(/OPERATOR_AUTH_JWKS_URL/);
+  });
+});

--- a/backend/src/tests/shared/auth/operator-principal.test.ts
+++ b/backend/src/tests/shared/auth/operator-principal.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { createOperatorPrincipal } from '../../../shared/auth/operator-principal.js';
+
+describe('createOperatorPrincipal', () => {
+  it('should normalize optional fields and deduplicate capabilities', () => {
+    expect(
+      createOperatorPrincipal({
+        subject: 'operator-123',
+        email: ' TEAM@ForgeOps.dev ',
+        displayName: ' ForgeOps Operator ',
+        capabilities: ['repositories:write', 'repositories:read', 'repositories:write', ''],
+      }),
+    ).toEqual({
+      kind: 'operator',
+      subject: 'operator-123',
+      email: 'team@forgeops.dev',
+      displayName: 'ForgeOps Operator',
+      capabilities: ['repositories:read', 'repositories:write'],
+    });
+  });
+
+  it('should reject an empty subject', () => {
+    expect(() =>
+      createOperatorPrincipal({
+        subject: '   ',
+      }),
+    ).toThrow(/must not be empty/);
+  });
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -7,7 +7,7 @@
   },
   "include": [
     "src/**/*.ts",
+    "src/**/*.d.ts",
     "vitest.config.ts"
   ]
 }
-


### PR DESCRIPTION
## Summary
- add the operator auth configuration loader separate from GitHub App config
- define a normalized operator principal and verifier contract for the backend
- prepare Fastify request context to carry an operator principal without enabling route protection yet

## How to test
- npm --prefix backend run lint
- npm --prefix backend run typecheck
- npm --prefix backend run test
- npm run lint
- npm run typecheck
- npm run test

## Issue
Closes #30