### PR TITLE
feat(auth): scaffold backend route protection

### DIFF
--- a/backend/src/app/create-server.ts
+++ b/backend/src/app/create-server.ts
@@ -3,15 +3,18 @@ import { registerRoutes } from './register-routes.js';
 import type { AppEnv } from '../infra/config/app-env.js';
 import type { OperatorAuthEnv } from '../infra/config/auth-env.js';
 import type { GitHubAppEnv } from '../infra/config/github-app-env.js';
+import { createAuthGuard } from '../infra/http/auth-guard.js';
 import { createLogger } from '../infra/logger/create-logger.js';
 import { createErrorHandler } from '../infra/http/error-handler.js';
 import { createGitHubAppBoundary } from '../modules/github/github-app.boundary.js';
 import { StaticHealthRepository } from '../modules/health/health.repository.js';
 import { HealthService } from '../modules/health/health.service.js';
+import type { OperatorAuthVerifier } from '../shared/auth/operator-auth-verifier.js';
 
 export interface CreateServerOptions {
   env: AppEnv;
   authConfig?: OperatorAuthEnv | null;
+  authVerifier?: OperatorAuthVerifier | null;
   githubConfig?: GitHubAppEnv | null;
 }
 
@@ -21,6 +24,13 @@ export const createServer = (options: CreateServerOptions) => {
   });
 
   app.decorateRequest('operatorPrincipal', null);
+  app.addHook(
+    'onRequest',
+    createAuthGuard({
+      authConfig: options.authConfig ?? null,
+      authVerifier: options.authVerifier ?? null,
+    }),
+  );
 
   const githubBoundary = createGitHubAppBoundary(options.githubConfig ?? null);
   const healthRepository = new StaticHealthRepository({

--- a/backend/src/app/fastify-auth.d.ts
+++ b/backend/src/app/fastify-auth.d.ts
@@ -1,7 +1,13 @@
 import 'fastify';
 import type { OperatorPrincipal } from '../shared/auth/operator-principal.js';
 
+export type ForgeOpsRouteAccess = 'public' | 'protected';
+
 declare module 'fastify' {
+  interface FastifyContextConfig {
+    access?: ForgeOpsRouteAccess;
+  }
+
   interface FastifyRequest {
     operatorPrincipal: OperatorPrincipal | null;
   }

--- a/backend/src/app/register-routes.ts
+++ b/backend/src/app/register-routes.ts
@@ -6,6 +6,7 @@ import type {
 } from 'fastify';
 import type { Logger } from 'pino';
 import type { HealthService } from '../modules/health/health.service.js';
+import { registerAuthReferenceRoutes } from '../modules/auth/auth-reference.controller.js';
 import { registerHealthRoutes } from '../modules/health/health.controller.js';
 
 interface RegisterRoutesOptions {
@@ -24,4 +25,5 @@ export const registerRoutes = (
   options: RegisterRoutesOptions,
 ): void => {
   registerHealthRoutes(app, options.healthService);
+  registerAuthReferenceRoutes(app);
 };

--- a/backend/src/infra/http/auth-guard.ts
+++ b/backend/src/infra/http/auth-guard.ts
@@ -1,0 +1,57 @@
+import type { FastifyRequest } from 'fastify';
+import type { OperatorAuthEnv } from '../config/auth-env.js';
+import type { OperatorAuthVerifier } from '../../shared/auth/operator-auth-verifier.js';
+import { ApplicationError } from '../../shared/errors/application-error.js';
+import { AuthenticationError } from '../../shared/errors/authentication-error.js';
+import { AuthConfigurationError } from '../../shared/errors/auth-configuration-error.js';
+
+const getAccessMode = (request: FastifyRequest): 'public' | 'protected' => {
+  return request.routeOptions.config.access ?? 'protected';
+};
+
+const getBearerToken = (request: FastifyRequest): string => {
+  const header = request.headers.authorization;
+
+  if (!header) {
+    throw new AuthenticationError();
+  }
+
+  const [scheme, token] = header.split(' ');
+
+  if (scheme !== 'Bearer' || !token || token.trim().length === 0) {
+    throw new AuthenticationError('A valid bearer token is required.');
+  }
+
+  return token.trim();
+};
+
+export interface CreateAuthGuardOptions {
+  authConfig: OperatorAuthEnv | null;
+  authVerifier?: OperatorAuthVerifier | null;
+}
+
+export const createAuthGuard =
+  ({ authConfig, authVerifier }: CreateAuthGuardOptions) =>
+  async (request: FastifyRequest): Promise<void> => {
+    request.operatorPrincipal = null;
+
+    if (getAccessMode(request) === 'public') {
+      return;
+    }
+
+    if (!authConfig || !authVerifier) {
+      throw new AuthConfigurationError();
+    }
+
+    const token = getBearerToken(request);
+
+    try {
+      request.operatorPrincipal = await authVerifier.verify({ token });
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+
+      throw new AuthenticationError('Authentication failed.');
+    }
+  };

--- a/backend/src/modules/auth/auth-reference.controller.ts
+++ b/backend/src/modules/auth/auth-reference.controller.ts
@@ -1,0 +1,22 @@
+import type { ForgeOpsFastifyInstance } from '../../app/register-routes.js';
+import type { OperatorPrincipal } from '../../shared/auth/operator-principal.js';
+
+interface AuthMeReply {
+  principal: OperatorPrincipal;
+}
+
+export const registerAuthReferenceRoutes = (app: ForgeOpsFastifyInstance): void => {
+  app.get<{ Reply: AuthMeReply }>(
+    '/api/v1/auth/me',
+    {
+      config: {
+        access: 'protected',
+      },
+    },
+    async (request) => {
+      return {
+        principal: request.operatorPrincipal!,
+      };
+    },
+  );
+};

--- a/backend/src/modules/health/health.controller.ts
+++ b/backend/src/modules/health/health.controller.ts
@@ -22,8 +22,16 @@ export const registerHealthRoutes = (
   app: ForgeOpsFastifyInstance,
   healthService: HealthRouteService,
 ): void => {
-  app.get<HealthRouteGeneric>('/api/v1/health', async (request: HealthRouteRequest) => {
-    healthQuerySchema.parse(request.query);
-    return healthService.getSnapshot();
-  });
+  app.get<HealthRouteGeneric>(
+    '/api/v1/health',
+    {
+      config: {
+        access: 'public',
+      },
+    },
+    async (request: HealthRouteRequest) => {
+      healthQuerySchema.parse(request.query);
+      return healthService.getSnapshot();
+    },
+  );
 };

--- a/backend/src/shared/errors/auth-configuration-error.ts
+++ b/backend/src/shared/errors/auth-configuration-error.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './application-error.js';
+
+export class AuthConfigurationError extends ApplicationError {
+  constructor(message = 'Operator authentication is not configured.') {
+    super(message, 503, 'auth_not_configured');
+  }
+}

--- a/backend/src/shared/errors/authentication-error.ts
+++ b/backend/src/shared/errors/authentication-error.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './application-error.js';
+
+export class AuthenticationError extends ApplicationError {
+  constructor(message = 'Authentication is required.') {
+    super(message, 401, 'authentication_required');
+  }
+}

--- a/backend/src/shared/errors/authorization-error.ts
+++ b/backend/src/shared/errors/authorization-error.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './application-error.js';
+
+export class AuthorizationError extends ApplicationError {
+  constructor(message = 'You are not allowed to perform this action.') {
+    super(message, 403, 'forbidden');
+  }
+}

--- a/backend/src/tests/app/create-server.test.ts
+++ b/backend/src/tests/app/create-server.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { createServer } from '../../app/create-server.js';
+import { createOperatorPrincipal } from '../../shared/auth/operator-principal.js';
 
 describe('createServer', () => {
   afterEach(async () => {
@@ -14,6 +15,7 @@ describe('createServer', () => {
         LOG_LEVEL: 'silent',
       },
       authConfig: null,
+      authVerifier: null,
       githubConfig: null,
     });
 
@@ -44,6 +46,7 @@ describe('createServer', () => {
         LOG_LEVEL: 'silent',
       },
       authConfig: null,
+      authVerifier: null,
       githubConfig: null,
     });
 
@@ -71,10 +74,171 @@ describe('createServer', () => {
         LOG_LEVEL: 'silent',
       },
       authConfig: null,
+      authVerifier: null,
       githubConfig: null,
     });
 
     expect(server.hasRequestDecorator('operatorPrincipal')).toBe(true);
+
+    await server.close();
+  });
+
+  it('should reject protected routes without authentication', async () => {
+    const server = createServer({
+      env: {
+        NODE_ENV: 'test',
+        PORT: 3333,
+        LOG_LEVEL: 'silent',
+      },
+      authConfig: {
+        issuer: 'https://forgeops.example.com',
+        audience: 'forgeops-api',
+        verifierSource: {
+          type: 'shared-secret',
+          sharedSecret: 'secret',
+        },
+      },
+      authVerifier: {
+        verify: async () => {
+          throw new Error('This should not run without a token.');
+        },
+      },
+      githubConfig: null,
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/me',
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'authentication_required',
+        message: 'Authentication is required.',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should fail safely when protected auth dependencies are missing', async () => {
+    const server = createServer({
+      env: {
+        NODE_ENV: 'test',
+        PORT: 3333,
+        LOG_LEVEL: 'silent',
+      },
+      authConfig: null,
+      authVerifier: null,
+      githubConfig: null,
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/me',
+      headers: {
+        authorization: 'Bearer token',
+      },
+    });
+
+    expect(response.statusCode).toBe(503);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'auth_not_configured',
+        message: 'Operator authentication is not configured.',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should allow protected routes with a verified operator principal', async () => {
+    const server = createServer({
+      env: {
+        NODE_ENV: 'test',
+        PORT: 3333,
+        LOG_LEVEL: 'silent',
+      },
+      authConfig: {
+        issuer: 'https://forgeops.example.com',
+        audience: 'forgeops-api',
+        verifierSource: {
+          type: 'shared-secret',
+          sharedSecret: 'secret',
+        },
+      },
+      authVerifier: {
+        verify: async ({ token }) =>
+          createOperatorPrincipal({
+            subject: `operator:${token}`,
+            email: 'operator@forgeops.dev',
+            capabilities: ['repositories:read'],
+          }),
+      },
+      githubConfig: null,
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/me',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      principal: {
+        kind: 'operator',
+        subject: 'operator:trusted-token',
+        email: 'operator@forgeops.dev',
+        displayName: null,
+        capabilities: ['repositories:read'],
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should return a safe authentication error when token verification fails', async () => {
+    const server = createServer({
+      env: {
+        NODE_ENV: 'test',
+        PORT: 3333,
+        LOG_LEVEL: 'silent',
+      },
+      authConfig: {
+        issuer: 'https://forgeops.example.com',
+        audience: 'forgeops-api',
+        verifierSource: {
+          type: 'shared-secret',
+          sharedSecret: 'secret',
+        },
+      },
+      authVerifier: {
+        verify: async () => {
+          throw new Error('Invalid signature details');
+        },
+      },
+      githubConfig: null,
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/me',
+      headers: {
+        authorization: 'Bearer invalid-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'authentication_required',
+        message: 'Authentication failed.',
+      },
+    });
 
     await server.close();
   });


### PR DESCRIPTION
## Summary
- add an auth guard scaffold with explicit public vs protected route classification
- keep the health endpoint public while adding a minimal protected reference endpoint
- standardize safe auth errors for missing auth, missing config, and failed token verification

## How to test
- npm --prefix backend run lint
- npm --prefix backend run typecheck
- npm --prefix backend run test
- npm run lint
- npm run typecheck
- npm run test

## Issue
Closes #31