### PR TITLE
feat(github): add repository discovery adapter

### DIFF
--- a/backend/src/app/create-server.ts
+++ b/backend/src/app/create-server.ts
@@ -7,7 +7,10 @@ import { createAuthGuard } from '../infra/http/auth-guard.js';
 import { createLogger } from '../infra/logger/create-logger.js';
 import { createErrorHandler } from '../infra/http/error-handler.js';
 import { createPrismaClient } from '../infra/persistence/prisma-client.js';
-import { createGitHubAppBoundary } from '../modules/github/github-app.boundary.js';
+import {
+  createGitHubAppBoundary,
+  type GitHubAppBoundary,
+} from '../modules/github/github-app.boundary.js';
 import { StaticHealthRepository } from '../modules/health/health.repository.js';
 import { HealthService } from '../modules/health/health.service.js';
 import { PrismaRepositoryRepository } from '../modules/repository-registry/repository.prisma-repository.js';
@@ -20,6 +23,7 @@ export interface CreateServerOptions {
   authConfig?: OperatorAuthEnv | null;
   authVerifier?: OperatorAuthVerifier | null;
   githubConfig?: GitHubAppEnv | null;
+  githubBoundary?: GitHubAppBoundary;
   repositoryRegistryRepository?: RepositoryRepository;
 }
 
@@ -40,7 +44,8 @@ export const createServer = (options: CreateServerOptions) => {
   const prismaClient = options.repositoryRegistryRepository
     ? null
     : createPrismaClient();
-  const githubBoundary = createGitHubAppBoundary(options.githubConfig ?? null);
+  const githubBoundary =
+    options.githubBoundary ?? createGitHubAppBoundary(options.githubConfig ?? null);
   const healthRepository = new StaticHealthRepository({
     environment: options.env.NODE_ENV,
   });
@@ -53,6 +58,7 @@ export const createServer = (options: CreateServerOptions) => {
   });
   const repositoryService = new RepositoryService({
     repository: repositoryRegistryRepository,
+    githubBoundary,
   });
 
   if (prismaClient) {

--- a/backend/src/modules/github/github-app.boundary.ts
+++ b/backend/src/modules/github/github-app.boundary.ts
@@ -1,9 +1,21 @@
 import type { GitHubAppEnv } from '../../infra/config/github-app-env.js';
-import { GitHubAppProvider } from './providers/github-app.provider.js';
+import {
+  GitHubAppProvider,
+  type GitHubAppProviderOptions,
+} from './providers/github-app.provider.js';
 
 export interface GitHubRepositoryDescriptor {
   owner: string;
   name: string;
+}
+
+export interface GitHubInstallationRepository {
+  githubRepoId: string;
+  owner: string;
+  name: string;
+  fullName: string;
+  defaultBranch: string;
+  isPrivate: boolean;
 }
 
 export interface GitHubWorkflowDescriptor {
@@ -17,7 +29,7 @@ export interface GitHubAppBoundary {
   readonly configured: boolean;
   getStatus(): GitHubAppStatus;
   assertConfigured(): void;
-  listInstallationRepositories(): Promise<GitHubRepositoryDescriptor[]>;
+  listInstallationRepositories(): Promise<GitHubInstallationRepository[]>;
   listRepositoryWorkflows(
     repository: GitHubRepositoryDescriptor,
   ): Promise<GitHubWorkflowDescriptor[]>;
@@ -33,4 +45,5 @@ export interface GitHubAppStatus {
 
 export const createGitHubAppBoundary = (
   config: GitHubAppEnv | null,
-): GitHubAppBoundary => new GitHubAppProvider(config);
+  options: GitHubAppProviderOptions = {},
+): GitHubAppBoundary => new GitHubAppProvider(config, options);

--- a/backend/src/modules/github/github-app.errors.ts
+++ b/backend/src/modules/github/github-app.errors.ts
@@ -1,0 +1,11 @@
+import { ApplicationError } from '../../shared/errors/application-error.js';
+
+export class GitHubRepositoryDiscoveryError extends ApplicationError {
+  constructor() {
+    super(
+      'GitHub repository discovery is currently unavailable.',
+      503,
+      'github_repository_discovery_unavailable',
+    );
+  }
+}

--- a/backend/src/modules/github/providers/github-app.provider.ts
+++ b/backend/src/modules/github/providers/github-app.provider.ts
@@ -1,11 +1,45 @@
+import { createPrivateKey, sign } from 'node:crypto';
+import { z } from 'zod';
 import type {
   GitHubAppBoundary,
+  GitHubInstallationRepository,
   GitHubAppStatus,
   GitHubRepositoryDescriptor,
   GitHubWorkflowDescriptor,
 } from '../github-app.boundary.js';
 import type { GitHubAppEnv } from '../../../infra/config/github-app-env.js';
 import { ConfigurationError } from '../../../shared/errors/configuration-error.js';
+import { GitHubRepositoryDiscoveryError } from '../github-app.errors.js';
+
+const githubInstallationAccessTokenSchema = z.object({
+  token: z.string().trim().min(1),
+});
+
+const githubInstallationRepositoriesSchema = z.object({
+  repositories: z.array(
+    z.object({
+      id: z.number().int().nonnegative(),
+      name: z.string().trim().min(1),
+      full_name: z.string().trim().min(1),
+      private: z.boolean(),
+      default_branch: z.string().trim().min(1),
+      owner: z.object({
+        login: z.string().trim().min(1),
+      }),
+    }),
+  ),
+});
+
+const GITHUB_API_VERSION = '2022-11-28';
+const DEFAULT_GITHUB_API_BASE_URL = 'https://api.github.com';
+const DEFAULT_TIMEOUT_MS = 5000;
+
+export interface GitHubAppProviderOptions {
+  apiBaseUrl?: string;
+  fetchImplementation?: typeof fetch;
+  now?: () => Date;
+  appJwtFactory?: (config: GitHubAppEnv, now: Date) => string;
+}
 
 const maskIdentifier = (value: string): string => {
   if (value.length <= 4) {
@@ -20,10 +54,21 @@ export class GitHubAppProvider implements GitHubAppBoundary {
   public readonly configured: boolean;
 
   private readonly config: GitHubAppEnv | null;
+  private readonly apiBaseUrl: string;
+  private readonly fetchImplementation: typeof fetch;
+  private readonly now: () => Date;
+  private readonly appJwtFactory: (config: GitHubAppEnv, now: Date) => string;
 
-  public constructor(config: GitHubAppEnv | null) {
+  public constructor(
+    config: GitHubAppEnv | null,
+    options: GitHubAppProviderOptions = {},
+  ) {
     this.config = config;
     this.configured = config !== null;
+    this.apiBaseUrl = options.apiBaseUrl ?? DEFAULT_GITHUB_API_BASE_URL;
+    this.fetchImplementation = options.fetchImplementation ?? fetch;
+    this.now = options.now ?? (() => new Date());
+    this.appJwtFactory = options.appJwtFactory ?? createGitHubAppJwt;
   }
 
   public getStatus(): GitHubAppStatus {
@@ -47,9 +92,38 @@ export class GitHubAppProvider implements GitHubAppBoundary {
     }
   }
 
-  public async listInstallationRepositories(): Promise<GitHubRepositoryDescriptor[]> {
+  public async listInstallationRepositories(): Promise<GitHubInstallationRepository[]> {
     this.assertConfigured();
-    return [];
+
+    try {
+      const installationToken = await this.createInstallationAccessToken();
+      const payload = await this.requestJson(
+        `${this.apiBaseUrl}/installation/repositories?per_page=100`,
+        {
+          method: 'GET',
+          headers: this.createJsonHeaders(`Bearer ${installationToken}`),
+        },
+        githubInstallationRepositoriesSchema,
+      );
+
+      return payload.repositories.map((repository) => ({
+        githubRepoId: String(repository.id),
+        owner: repository.owner.login,
+        name: repository.name,
+        fullName: repository.full_name,
+        defaultBranch: repository.default_branch,
+        isPrivate: repository.private,
+      }));
+    } catch (error) {
+      if (
+        error instanceof ConfigurationError ||
+        error instanceof GitHubRepositoryDiscoveryError
+      ) {
+        throw error;
+      }
+
+      throw new GitHubRepositoryDiscoveryError();
+    }
   }
 
   public async listRepositoryWorkflows(
@@ -59,4 +133,86 @@ export class GitHubAppProvider implements GitHubAppBoundary {
     void repository;
     return [];
   }
+
+  private async createInstallationAccessToken(): Promise<string> {
+    const config = this.config;
+
+    if (config === null) {
+      throw new ConfigurationError(
+        'GitHub App configuration is required before using the integration boundary.',
+        'github_app_not_configured',
+      );
+    }
+
+    const jwt = this.appJwtFactory(config, this.now());
+    const payload = await this.requestJson(
+      `${this.apiBaseUrl}/app/installations/${config.GITHUB_APP_INSTALLATION_ID}/access_tokens`,
+      {
+        method: 'POST',
+        headers: this.createJsonHeaders(`Bearer ${jwt}`),
+      },
+      githubInstallationAccessTokenSchema,
+    );
+
+    return payload.token;
+  }
+
+  private createJsonHeaders(authorization: string): Record<string, string> {
+    return {
+      Accept: 'application/vnd.github+json',
+      Authorization: authorization,
+      'User-Agent': 'ForgeOps',
+      'X-GitHub-Api-Version': GITHUB_API_VERSION,
+    };
+  }
+
+  private async requestJson<T>(
+    input: string,
+    init: RequestInit,
+    schema: z.ZodSchema<T>,
+  ): Promise<T> {
+    const response = await this.fetchImplementation(input, {
+      ...init,
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      throw new GitHubRepositoryDiscoveryError();
+    }
+
+    const payload: unknown = await response.json();
+    return schema.parse(payload);
+  }
 }
+
+const normalizePrivateKey = (value: string): string =>
+  value.replace(/\\n/g, '\n');
+
+const encodeBase64Url = (value: string): string =>
+  Buffer.from(value, 'utf8').toString('base64url');
+
+const createGitHubAppJwt = (config: GitHubAppEnv, now: Date): string => {
+  const issuedAt = Math.floor(now.getTime() / 1000) - 60;
+  const expiresAt = issuedAt + 9 * 60;
+  const header = encodeBase64Url(
+    JSON.stringify({
+      alg: 'RS256',
+      typ: 'JWT',
+    }),
+  );
+  const payload = encodeBase64Url(
+    JSON.stringify({
+      iat: issuedAt,
+      exp: expiresAt,
+      iss: config.GITHUB_APP_ID,
+    }),
+  );
+  const signingInput = `${header}.${payload}`;
+  const signature = sign(
+    'RSA-SHA256',
+    Buffer.from(signingInput),
+    createPrivateKey(normalizePrivateKey(config.GITHUB_APP_PRIVATE_KEY)),
+  ).toString('base64url');
+
+  return `${signingInput}.${signature}`;
+};

--- a/backend/src/modules/repository-registry/repository.controller.ts
+++ b/backend/src/modules/repository-registry/repository.controller.ts
@@ -1,6 +1,7 @@
 import type { RouteGenericInterface } from 'fastify';
 import { z } from 'zod';
 import type { ForgeOpsFastifyInstance } from '../../app/register-routes.js';
+import type { GitHubInstallationRepository } from '../github/github-app.boundary.js';
 import type {
   CreateRepositoryInput,
   Repository,
@@ -41,6 +42,21 @@ interface CreateRepositoryRoute extends RouteGenericInterface {
   };
 }
 
+interface InstallationRepositoryResponse {
+  githubRepoId: string;
+  owner: string;
+  name: string;
+  fullName: string;
+  defaultBranch: string;
+  isPrivate: boolean;
+}
+
+interface DiscoverRepositoriesRoute extends RouteGenericInterface {
+  Reply: {
+    repositories: InstallationRepositoryResponse[];
+  };
+}
+
 const toRepositoryResponse = (repository: Repository): RepositoryResponse => {
   return {
     id: repository.id,
@@ -55,10 +71,40 @@ const toRepositoryResponse = (repository: Repository): RepositoryResponse => {
   };
 };
 
+const toInstallationRepositoryResponse = (
+  repository: GitHubInstallationRepository,
+): InstallationRepositoryResponse => {
+  return {
+    githubRepoId: repository.githubRepoId,
+    owner: repository.owner,
+    name: repository.name,
+    fullName: repository.fullName,
+    defaultBranch: repository.defaultBranch,
+    isPrivate: repository.isPrivate,
+  };
+};
+
 export const registerRepositoryRegistryRoutes = (
   app: ForgeOpsFastifyInstance,
   repositoryService: RepositoryService,
 ): void => {
+  app.get<DiscoverRepositoriesRoute>(
+    '/api/v1/repositories/discovery',
+    {
+      config: {
+        access: 'protected',
+      },
+    },
+    async () => {
+      const repositories =
+        await repositoryService.listInstallationRepositories();
+
+      return {
+        repositories: repositories.map(toInstallationRepositoryResponse),
+      };
+    },
+  );
+
   app.get<ListRepositoriesRoute>(
     '/api/v1/repositories',
     {

--- a/backend/src/modules/repository-registry/repository.service.ts
+++ b/backend/src/modules/repository-registry/repository.service.ts
@@ -2,10 +2,15 @@ import type {
   CreateRepositoryInput,
   Repository,
 } from './repository.entity.js';
+import type {
+  GitHubAppBoundary,
+  GitHubInstallationRepository,
+} from '../github/github-app.boundary.js';
 import type { RepositoryRepository } from './repository.repository.js';
 
 export interface RepositoryServiceOptions {
   repository: RepositoryRepository;
+  githubBoundary: GitHubAppBoundary;
 }
 
 export class RepositoryService {
@@ -17,5 +22,9 @@ export class RepositoryService {
 
   create(input: CreateRepositoryInput): Promise<Repository> {
     return this.options.repository.create(input);
+  }
+
+  listInstallationRepositories(): Promise<GitHubInstallationRepository[]> {
+    return this.options.githubBoundary.listInstallationRepositories();
   }
 }

--- a/backend/src/tests/app/create-server.test.ts
+++ b/backend/src/tests/app/create-server.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { createServer } from '../../app/create-server.js';
+import { GitHubRepositoryDiscoveryError } from '../../modules/github/github-app.errors.js';
 import { createOperatorPrincipal } from '../../shared/auth/operator-principal.js';
 import type {
   CreateRepositoryInput,
   Repository,
 } from '../../modules/repository-registry/repository.entity.js';
+import type { GitHubInstallationRepository } from '../../modules/github/github-app.boundary.js';
 
 const buildRepository = (
   overrides: Partial<Repository> = {},
@@ -38,9 +40,25 @@ const buildCreateRepositoryInput = (
   };
 };
 
+const buildInstallationRepository = (
+  overrides: Partial<GitHubInstallationRepository> = {},
+): GitHubInstallationRepository => {
+  return {
+    githubRepoId: '123456789',
+    owner: 'forgeops',
+    name: 'backend',
+    fullName: 'forgeops/backend',
+    defaultBranch: 'main',
+    isPrivate: true,
+    ...overrides,
+  };
+};
+
 const createProtectedServer = (overrides?: {
   repositories?: Repository[];
   createRepository?: (input: CreateRepositoryInput) => Promise<Repository>;
+  installationRepositories?: GitHubInstallationRepository[];
+  installationDiscoveryError?: Error;
 }) => {
   const repositories = overrides?.repositories ?? [];
 
@@ -67,6 +85,26 @@ const createProtectedServer = (overrides?: {
         }),
     },
     githubConfig: null,
+    githubBoundary: {
+      mode: 'github-app',
+      configured: true,
+      getStatus: () => ({
+        mode: 'github-app',
+        configured: true,
+        appId: '12****56',
+        installationId: '78****10',
+        webhookConfigured: true,
+      }),
+      assertConfigured: () => undefined,
+      listInstallationRepositories: async () => {
+        if (overrides?.installationDiscoveryError) {
+          throw overrides.installationDiscoveryError;
+        }
+
+        return overrides?.installationRepositories ?? [];
+      },
+      listRepositoryWorkflows: async () => [],
+    },
     repositoryRegistryRepository: {
       list: async () => repositories,
       create:
@@ -499,6 +537,67 @@ describe('createServer', () => {
       error: {
         code: 'authentication_required',
         message: 'Authentication is required.',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should list discoverable installation repositories for an authenticated operator', async () => {
+    const server = createProtectedServer({
+      installationRepositories: [
+        buildInstallationRepository(),
+        buildInstallationRepository({
+          githubRepoId: '987654321',
+          name: 'frontend',
+          fullName: 'forgeops/frontend',
+          isPrivate: false,
+        }),
+      ],
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories/discovery',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      repositories: [
+        buildInstallationRepository(),
+        buildInstallationRepository({
+          githubRepoId: '987654321',
+          name: 'frontend',
+          fullName: 'forgeops/frontend',
+          isPrivate: false,
+        }),
+      ],
+    });
+
+    await server.close();
+  });
+
+  it('should return a safe error when repository discovery fails', async () => {
+    const server = createProtectedServer({
+      installationDiscoveryError: new GitHubRepositoryDiscoveryError(),
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories/discovery',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(503);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'github_repository_discovery_unavailable',
+        message: 'GitHub repository discovery is currently unavailable.',
       },
     });
 

--- a/backend/src/tests/modules/github/github-app.provider.test.ts
+++ b/backend/src/tests/modules/github/github-app.provider.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createGitHubAppBoundary } from '../../../modules/github/github-app.boundary.js';
+import { GitHubRepositoryDiscoveryError } from '../../../modules/github/github-app.errors.js';
+
+const buildConfig = () => ({
+  GITHUB_APP_ID: '123456',
+  GITHUB_APP_INSTALLATION_ID: '78910',
+  GITHUB_APP_PRIVATE_KEY: 'private-key',
+  GITHUB_APP_WEBHOOK_SECRET: 'webhook-secret',
+});
+
+describe('GitHubAppProvider', () => {
+  it('should exchange credentials and normalize installation repositories', async () => {
+    const fetchImplementation = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: 'installation-token' }), {
+          status: 201,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            repositories: [
+              {
+                id: 123456789,
+                name: 'backend',
+                full_name: 'forgeops/backend',
+                private: true,
+                default_branch: 'main',
+                owner: {
+                  login: 'forgeops',
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+    const boundary = createGitHubAppBoundary(buildConfig(), {
+      apiBaseUrl: 'https://api.github.test',
+      fetchImplementation,
+      appJwtFactory: () => 'app-jwt',
+      now: () => new Date('2026-03-28T12:00:00.000Z'),
+    });
+
+    await expect(boundary.listInstallationRepositories()).resolves.toEqual([
+      {
+        githubRepoId: '123456789',
+        owner: 'forgeops',
+        name: 'backend',
+        fullName: 'forgeops/backend',
+        defaultBranch: 'main',
+        isPrivate: true,
+      },
+    ]);
+
+    expect(fetchImplementation).toHaveBeenCalledTimes(2);
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      1,
+      'https://api.github.test/app/installations/78910/access_tokens',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Accept: 'application/vnd.github+json',
+          Authorization: expect.stringMatching(/^Bearer /),
+        }),
+      }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.test/installation/repositories?per_page=100',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Accept: 'application/vnd.github+json',
+          Authorization: 'Bearer installation-token',
+        }),
+      }),
+    );
+  });
+
+  it('should raise a safe discovery error when GitHub discovery fails', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'rate limited' }), {
+        status: 403,
+        headers: {
+          'content-type': 'application/json',
+        },
+      }),
+    );
+    const boundary = createGitHubAppBoundary(buildConfig(), {
+      apiBaseUrl: 'https://api.github.test',
+      fetchImplementation,
+      appJwtFactory: () => 'app-jwt',
+      now: () => new Date('2026-03-28T12:00:00.000Z'),
+    });
+
+    await expect(boundary.listInstallationRepositories()).rejects.toBeInstanceOf(
+      GitHubRepositoryDiscoveryError,
+    );
+    await expect(boundary.listInstallationRepositories()).rejects.toMatchObject({
+      code: 'github_repository_discovery_unavailable',
+      message: 'GitHub repository discovery is currently unavailable.',
+      statusCode: 503,
+    });
+  });
+});

--- a/backend/src/tests/modules/repository-registry/repository.service.test.ts
+++ b/backend/src/tests/modules/repository-registry/repository.service.test.ts
@@ -3,6 +3,7 @@ import type {
   CreateRepositoryInput,
   Repository,
 } from '../../../modules/repository-registry/repository.entity.js';
+import type { GitHubInstallationRepository } from '../../../modules/github/github-app.boundary.js';
 import { RepositoryService } from '../../../modules/repository-registry/repository.service.js';
 
 const buildRepository = (
@@ -37,6 +38,20 @@ const buildCreateInput = (
   };
 };
 
+const buildInstallationRepository = (
+  overrides: Partial<GitHubInstallationRepository> = {},
+): GitHubInstallationRepository => {
+  return {
+    githubRepoId: '123456789',
+    owner: 'forgeops',
+    name: 'backend',
+    fullName: 'forgeops/backend',
+    defaultBranch: 'main',
+    isPrivate: true,
+    ...overrides,
+  };
+};
+
 describe('RepositoryService', () => {
   it('should delegate listing repositories to the repository layer', async () => {
     const list = vi.fn().mockResolvedValue([
@@ -53,6 +68,20 @@ describe('RepositoryService', () => {
       repository: {
         list,
         create,
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: false,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: false,
+          appId: null,
+          installationId: null,
+          webhookConfigured: false,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
       },
     });
 
@@ -76,9 +105,70 @@ describe('RepositoryService', () => {
         list,
         create,
       },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: false,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: false,
+          appId: null,
+          installationId: null,
+          webhookConfigured: false,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+      },
     });
 
     await expect(service.create(buildCreateInput())).resolves.toEqual(buildRepository());
     expect(create).toHaveBeenCalledWith(buildCreateInput());
+  });
+
+  it('should delegate repository discovery to the GitHub boundary', async () => {
+    const create = vi.fn();
+    const list = vi.fn();
+    const listInstallationRepositories = vi
+      .fn()
+      .mockResolvedValue([
+        buildInstallationRepository(),
+        buildInstallationRepository({
+          githubRepoId: '987654321',
+          name: 'frontend',
+          fullName: 'forgeops/frontend',
+          isPrivate: false,
+        }),
+      ]);
+    const service = new RepositoryService({
+      repository: {
+        list,
+        create,
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories,
+        listRepositoryWorkflows: async () => [],
+      },
+    });
+
+    await expect(service.listInstallationRepositories()).resolves.toEqual([
+      buildInstallationRepository(),
+      buildInstallationRepository({
+        githubRepoId: '987654321',
+        name: 'frontend',
+        fullName: 'forgeops/frontend',
+        isPrivate: false,
+      }),
+    ]);
+    expect(listInstallationRepositories).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- implement GitHub App repository discovery with a real boundary/provider flow
- expose a protected discovery endpoint under repository registry
- add tests for provider normalization, failure handling, and protected HTTP behavior

## How to test
- npm --prefix backend run lint
- npm --prefix backend run typecheck
- npm --prefix backend run test
- npm run lint
- npm run typecheck
- npm run test

## Issue
Closes #34