### PR TITLE
feat(auth): authorize repository write actions

### DIFF
--- a/backend/src/app/fastify-auth.d.ts
+++ b/backend/src/app/fastify-auth.d.ts
@@ -2,10 +2,14 @@ import 'fastify';
 import type { OperatorPrincipal } from '../shared/auth/operator-principal.js';
 
 export type ForgeOpsRouteAccess = 'public' | 'protected';
+export type ForgeOpsRouteCapability =
+  | 'repositories:read'
+  | 'repositories:write';
 
 declare module 'fastify' {
   interface FastifyContextConfig {
     access?: ForgeOpsRouteAccess;
+    requiredCapability?: ForgeOpsRouteCapability;
   }
 
   interface FastifyRequest {

--- a/backend/src/infra/http/auth-guard.ts
+++ b/backend/src/infra/http/auth-guard.ts
@@ -4,9 +4,14 @@ import type { OperatorAuthVerifier } from '../../shared/auth/operator-auth-verif
 import { ApplicationError } from '../../shared/errors/application-error.js';
 import { AuthenticationError } from '../../shared/errors/authentication-error.js';
 import { AuthConfigurationError } from '../../shared/errors/auth-configuration-error.js';
+import { AuthorizationError } from '../../shared/errors/authorization-error.js';
 
 const getAccessMode = (request: FastifyRequest): 'public' | 'protected' => {
   return request.routeOptions.config.access ?? 'protected';
+};
+
+const getRequiredCapability = (request: FastifyRequest): string | null => {
+  return request.routeOptions.config.requiredCapability ?? null;
 };
 
 const getBearerToken = (request: FastifyRequest): string => {
@@ -53,5 +58,14 @@ export const createAuthGuard =
       }
 
       throw new AuthenticationError('Authentication failed.');
+    }
+
+    const requiredCapability = getRequiredCapability(request);
+
+    if (
+      requiredCapability !== null &&
+      !request.operatorPrincipal.capabilities.includes(requiredCapability)
+    ) {
+      throw new AuthorizationError();
     }
   };

--- a/backend/src/modules/repository-registry/repository.controller.ts
+++ b/backend/src/modules/repository-registry/repository.controller.ts
@@ -126,6 +126,7 @@ export const registerRepositoryRegistryRoutes = (
     {
       config: {
         access: 'protected',
+        requiredCapability: 'repositories:write',
       },
     },
     async (request, reply) => {

--- a/backend/src/tests/app/create-server.test.ts
+++ b/backend/src/tests/app/create-server.test.ts
@@ -59,6 +59,7 @@ const createProtectedServer = (overrides?: {
   createRepository?: (input: CreateRepositoryInput) => Promise<Repository>;
   installationRepositories?: GitHubInstallationRepository[];
   installationDiscoveryError?: Error;
+  capabilities?: string[];
 }) => {
   const repositories = overrides?.repositories ?? [];
 
@@ -81,7 +82,8 @@ const createProtectedServer = (overrides?: {
         createOperatorPrincipal({
           subject: `operator:${token}`,
           email: 'operator@forgeops.dev',
-          capabilities: ['repositories:read', 'repositories:write'],
+          capabilities:
+            overrides?.capabilities ?? ['repositories:read', 'repositories:write'],
         }),
     },
     githubConfig: null,
@@ -518,6 +520,31 @@ describe('createServer', () => {
         isActive: true,
         createdAt: '2026-03-27T16:45:00.000Z',
         updatedAt: '2026-03-27T16:45:00.000Z',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should forbid repository creation without the write capability', async () => {
+    const server = createProtectedServer({
+      capabilities: ['repositories:read'],
+    });
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/v1/repositories',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+      payload: buildCreateRepositoryInput(),
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'forbidden',
+        message: 'You are not allowed to perform this action.',
       },
     });
 


### PR DESCRIPTION
## Summary
- add explicit capability metadata for protected route authorization
- enforce repository write capability centrally in the auth guard
- cover allowed and forbidden repository creation scenarios with HTTP tests

## How to test
- npm --prefix backend run lint
- npm --prefix backend run typecheck
- npm --prefix backend run test
- npm run lint
- npm run typecheck
- npm run test

## Issue
Closes #42