### PR TITLE
feat(frontend): add repository onboarding flow

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -299,6 +299,73 @@ pre {
   overflow: auto;
 }
 
+.repository-access {
+  display: grid;
+  gap: 16px;
+}
+
+.repository-access__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.repository-access__hint,
+.empty-state {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.status-banner {
+  padding: 16px 18px;
+  border: 1px solid rgba(17, 94, 89, 0.18);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.86);
+  color: var(--foreground);
+  box-shadow: var(--shadow);
+}
+
+.repository-list {
+  display: grid;
+  gap: 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.repository-list__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.repository-list__summary {
+  display: grid;
+  gap: 6px;
+}
+
+.repository-list__summary span {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.repository-list__badge {
+  width: fit-content;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.82rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
 @media (max-width: 980px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -328,5 +395,10 @@ pre {
   .panel {
     padding: 20px;
     border-radius: 22px;
+  }
+
+  .repository-list__item {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/frontend/src/features/repositories/repositories-view.tsx
+++ b/frontend/src/features/repositories/repositories-view.tsx
@@ -1,36 +1,244 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { RepositoryConnectionForm } from './forms/repository-connection-form';
-import type { RepositoryConnectionValues } from './forms/repository-connection.schema';
+import { Input } from '@/components/ui/input';
+import {
+  ApiClientError,
+  createApiClient,
+  type ForgeOpsApiClient,
+  type RepositoryDiscoveryItem,
+} from '@/lib/api/client';
 
-export function RepositoriesView() {
-  const [preview, setPreview] = useState<RepositoryConnectionValues | null>(null);
+const STORAGE_KEY = 'forgeops.operator-access-token';
+
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  if (error instanceof ApiClientError) {
+    return error.message;
+  }
+
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return fallback;
+};
+
+interface RepositoriesViewProps {
+  client?: ForgeOpsApiClient;
+}
+
+export function RepositoriesView({ client = createApiClient() }: RepositoriesViewProps) {
+  const queryClient = useQueryClient();
+  const [draftAccessToken, setDraftAccessToken] = useState('');
+  const [accessToken, setAccessToken] = useState('');
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+  const hasAccessToken = accessToken.trim().length > 0;
+
+  useEffect(() => {
+    const storedToken = window.localStorage.getItem(STORAGE_KEY);
+
+    if (!storedToken) {
+      return;
+    }
+
+    setAccessToken(storedToken);
+    setDraftAccessToken(storedToken);
+  }, []);
+
+  const monitoredRepositoriesQuery = useQuery({
+    queryKey: ['repositories', accessToken],
+    queryFn: () => client.getRepositories(accessToken),
+    enabled: hasAccessToken,
+    retry: false,
+  });
+
+  const discoveryQuery = useQuery({
+    queryKey: ['repository-discovery', accessToken],
+    queryFn: () => client.getRepositoryDiscovery(accessToken),
+    enabled: hasAccessToken,
+    retry: false,
+  });
+
+  const createRepositoryMutation = useMutation({
+    mutationFn: (repository: RepositoryDiscoveryItem) =>
+      client.createRepository(accessToken, {
+        githubRepoId: repository.githubRepoId,
+        owner: repository.owner,
+        name: repository.name,
+        fullName: repository.fullName,
+        defaultBranch: repository.defaultBranch,
+      }),
+    onSuccess: async (repository) => {
+      setStatusMessage(`Repository ${repository.fullName} is now monitored.`);
+      await queryClient.invalidateQueries({
+        queryKey: ['repositories', accessToken],
+      });
+    },
+    onError: (error) => {
+      setStatusMessage(getErrorMessage(error, 'Unable to connect the repository right now.'));
+    },
+  });
+
+  const monitoredRepositories = monitoredRepositoriesQuery.data ?? [];
+  const discoveredRepositories = discoveryQuery.data ?? [];
+  const monitoredRepositoryNames = new Set(
+    monitoredRepositories.map((repository) => repository.fullName),
+  );
+
+  const submitAccessToken = () => {
+    const normalizedToken = draftAccessToken.trim();
+
+    if (normalizedToken.length === 0) {
+      setTokenError('Provide an operator access token to query protected repository APIs.');
+      return;
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, normalizedToken);
+    setAccessToken(normalizedToken);
+    setTokenError(null);
+    setStatusMessage(null);
+  };
+
+  const clearAccessToken = () => {
+    window.localStorage.removeItem(STORAGE_KEY);
+    setDraftAccessToken('');
+    setAccessToken('');
+    setTokenError(null);
+    setStatusMessage(null);
+    void queryClient.removeQueries({
+      queryKey: ['repositories'],
+    });
+    void queryClient.removeQueries({
+      queryKey: ['repository-discovery'],
+    });
+  };
 
   return (
     <div className="page-stack">
       <section className="page-header">
         <span className="page-header__eyebrow">Repositories</span>
-        <h2 className="page-header__title">Prepare the onboarding surface before domain flows.</h2>
+        <h2 className="page-header__title">Connect repositories with the real backend flow.</h2>
         <p className="page-header__description">
-          This page keeps the repository registry feature isolated and introduces the first form
-          boundary for future GitHub connection flows.
+          Discovery and onboarding now use the protected Repository Registry API so the operator can
+          see what is available, what is already monitored, and what should be connected next.
         </p>
       </section>
 
+      <Card eyebrow="Operator access" title="Protected backend access">
+        <div className="repository-access">
+          <Input
+            id="operatorAccessToken"
+            label="Operator bearer token"
+            placeholder="Paste a bearer token for protected repository APIs"
+            autoComplete="off"
+            value={draftAccessToken}
+            onChange={(event) => setDraftAccessToken(event.target.value)}
+            error={tokenError ?? undefined}
+          />
+          <div className="repository-access__actions">
+            <Button onClick={submitAccessToken}>Use access token</Button>
+            <Button variant="secondary" onClick={clearAccessToken}>
+              Clear token
+            </Button>
+          </div>
+          <p className="repository-access__hint">
+            The token is stored only in this browser session so the frontend can call the protected
+            backend endpoints while the dedicated auth flow is still pending.
+          </p>
+        </div>
+      </Card>
+
+      {statusMessage ? (
+        <div className="status-banner" role="status">
+          {statusMessage}
+        </div>
+      ) : null}
+
       <div className="grid grid--two">
-        <Card eyebrow="Onboarding" title="Connection payload validation">
-          <RepositoryConnectionForm onSubmit={setPreview} />
-        </Card>
-        <Card eyebrow="Preview" title="Normalized payload snapshot">
-          {preview ? (
-            <pre className="code-block">{JSON.stringify(preview, null, 2)}</pre>
-          ) : (
-            <p>
-              Submit a valid payload to preview the normalized data that a future repository
-              onboarding mutation will send to the backend.
+        <Card eyebrow="Connected" title="Monitored repositories">
+          {!hasAccessToken ? (
+            <p className="empty-state">
+              Add an operator token to load the repositories already monitored by ForgeOps.
             </p>
+          ) : monitoredRepositoriesQuery.isLoading ? (
+            <p className="empty-state">Loading monitored repositories...</p>
+          ) : monitoredRepositoriesQuery.isError ? (
+            <p className="empty-state">
+              {getErrorMessage(
+                monitoredRepositoriesQuery.error,
+                'Unable to load monitored repositories.',
+              )}
+            </p>
+          ) : monitoredRepositories.length === 0 ? (
+            <p className="empty-state">
+              No repositories are monitored yet. Use discovery to connect the first one.
+            </p>
+          ) : (
+            <ul className="repository-list">
+              {monitoredRepositories.map((repository) => (
+                <li key={repository.id} className="repository-list__item">
+                  <div className="repository-list__summary">
+                    <strong>{repository.fullName}</strong>
+                    <span>Default branch: {repository.defaultBranch}</span>
+                  </div>
+                  <span className="repository-list__badge">
+                    {repository.isActive ? 'Monitoring active' : 'Paused'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+
+        <Card eyebrow="Discovery" title="Available GitHub repositories">
+          {!hasAccessToken ? (
+            <p className="empty-state">
+              Add an operator token to query repository discovery through the backend.
+            </p>
+          ) : discoveryQuery.isLoading ? (
+            <p className="empty-state">Loading available repositories...</p>
+          ) : discoveryQuery.isError ? (
+            <p className="empty-state">
+              {getErrorMessage(discoveryQuery.error, 'Unable to load repository discovery.')}
+            </p>
+          ) : discoveredRepositories.length === 0 ? (
+            <p className="empty-state">
+              No repositories were returned by the GitHub App installation right now.
+            </p>
+          ) : (
+            <ul className="repository-list">
+              {discoveredRepositories.map((repository) => {
+                const isMonitored = monitoredRepositoryNames.has(repository.fullName);
+
+                return (
+                  <li key={repository.githubRepoId} className="repository-list__item">
+                    <div className="repository-list__summary">
+                      <strong>{repository.fullName}</strong>
+                      <span>
+                        Default branch: {repository.defaultBranch} -{' '}
+                        {repository.isPrivate ? 'Private' : 'Public'}
+                      </span>
+                    </div>
+                    {isMonitored ? (
+                      <span className="repository-list__badge">Already monitored</span>
+                    ) : (
+                      <Button
+                        onClick={() => createRepositoryMutation.mutate(repository)}
+                        disabled={createRepositoryMutation.isPending}
+                      >
+                        {createRepositoryMutation.isPending
+                          ? 'Connecting...'
+                          : 'Connect repository'}
+                      </Button>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
           )}
         </Card>
       </div>

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod';
 import { getApiBaseUrl } from '../config/public-env';
 
+const apiErrorSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }),
+});
+
 const healthResponseSchema = z.object({
   status: z.literal('ok'),
   service: z.literal('forgeops-backend'),
@@ -19,16 +26,97 @@ const healthResponseSchema = z.object({
 
 export type BackendHealthResponse = z.infer<typeof healthResponseSchema>;
 
+const monitoredRepositorySchema = z.object({
+  id: z.string().min(1),
+  githubRepoId: z.string().min(1),
+  owner: z.string().min(1),
+  name: z.string().min(1),
+  fullName: z.string().min(1),
+  defaultBranch: z.string().min(1),
+  isActive: z.boolean(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+const monitoredRepositoriesResponseSchema = z.object({
+  repositories: z.array(monitoredRepositorySchema),
+});
+
+const repositoryDiscoveryItemSchema = z.object({
+  githubRepoId: z.string().min(1),
+  owner: z.string().min(1),
+  name: z.string().min(1),
+  fullName: z.string().min(1),
+  defaultBranch: z.string().min(1),
+  isPrivate: z.boolean(),
+});
+
+const repositoryDiscoveryResponseSchema = z.object({
+  repositories: z.array(repositoryDiscoveryItemSchema),
+});
+
+const createRepositoryInputSchema = z.object({
+  githubRepoId: z.string().min(1),
+  owner: z.string().min(1),
+  name: z.string().min(1),
+  fullName: z.string().min(1),
+  defaultBranch: z.string().min(1),
+  isActive: z.boolean().optional(),
+});
+
+const createRepositoryResponseSchema = z.object({
+  repository: monitoredRepositorySchema,
+});
+
+export type MonitoredRepository = z.infer<typeof monitoredRepositorySchema>;
+export type RepositoryDiscoveryItem = z.infer<typeof repositoryDiscoveryItemSchema>;
+export type CreateRepositoryInput = z.infer<typeof createRepositoryInputSchema>;
+
 interface CreateApiClientOptions {
   baseUrl?: string;
   fetcher?: typeof fetch;
 }
 
+export class ApiClientError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code: string | null = null,
+  ) {
+    super(message);
+    this.name = 'ApiClientError';
+  }
+}
+
 const normalizeBaseUrl = (value: string): string => value.replace(/\/+$/, '');
 
-export const createApiClient = (options: CreateApiClientOptions = {}) => {
+export interface ForgeOpsApiClient {
+  getHealth(): Promise<BackendHealthResponse>;
+  getRepositories(accessToken: string): Promise<MonitoredRepository[]>;
+  getRepositoryDiscovery(accessToken: string): Promise<RepositoryDiscoveryItem[]>;
+  createRepository(
+    accessToken: string,
+    input: CreateRepositoryInput,
+  ): Promise<MonitoredRepository>;
+}
+
+const createApiError = async (response: Response, fallbackMessage: string) => {
+  try {
+    const payload = apiErrorSchema.parse(await response.json());
+    return new ApiClientError(payload.error.message, response.status, payload.error.code);
+  } catch {
+    return new ApiClientError(fallbackMessage, response.status);
+  }
+};
+
+export const createApiClient = (options: CreateApiClientOptions = {}): ForgeOpsApiClient => {
   const fetcher = options.fetcher ?? fetch;
   const baseUrl = normalizeBaseUrl(options.baseUrl ?? getApiBaseUrl());
+  const buildHeaders = (accessToken?: string, contentType?: string) => ({
+    accept: 'application/json',
+    ...(contentType ? { 'content-type': contentType } : {}),
+    ...(accessToken ? { authorization: `Bearer ${accessToken}` } : {}),
+  });
 
   return {
     async getHealth(): Promise<BackendHealthResponse> {
@@ -43,6 +131,51 @@ export const createApiClient = (options: CreateApiClientOptions = {}) => {
       }
 
       return healthResponseSchema.parse(await response.json());
+    },
+
+    async getRepositories(accessToken: string): Promise<MonitoredRepository[]> {
+      const response = await fetcher(`${baseUrl}/api/v1/repositories`, {
+        headers: buildHeaders(accessToken),
+      });
+
+      if (!response.ok) {
+        throw await createApiError(response, `Failed to fetch repositories (${response.status})`);
+      }
+
+      return monitoredRepositoriesResponseSchema.parse(await response.json()).repositories;
+    },
+
+    async getRepositoryDiscovery(accessToken: string): Promise<RepositoryDiscoveryItem[]> {
+      const response = await fetcher(`${baseUrl}/api/v1/repositories/discovery`, {
+        headers: buildHeaders(accessToken),
+      });
+
+      if (!response.ok) {
+        throw await createApiError(
+          response,
+          `Failed to fetch repository discovery (${response.status})`,
+        );
+      }
+
+      return repositoryDiscoveryResponseSchema.parse(await response.json()).repositories;
+    },
+
+    async createRepository(
+      accessToken: string,
+      input: CreateRepositoryInput,
+    ): Promise<MonitoredRepository> {
+      const payload = createRepositoryInputSchema.parse(input);
+      const response = await fetcher(`${baseUrl}/api/v1/repositories`, {
+        method: 'POST',
+        headers: buildHeaders(accessToken, 'application/json'),
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw await createApiError(response, `Failed to create repository (${response.status})`);
+      }
+
+      return createRepositoryResponseSchema.parse(await response.json()).repository;
     },
   };
 };

--- a/frontend/src/tests/api-client.test.ts
+++ b/frontend/src/tests/api-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createApiClient } from '@/lib/api/client';
+import { ApiClientError, createApiClient } from '@/lib/api/client';
 
 describe('createApiClient', () => {
   it('should fetch and parse backend health', async () => {
@@ -57,6 +57,200 @@ describe('createApiClient', () => {
 
     await expect(client.getHealth()).rejects.toThrowError(
       'Failed to fetch backend health (503)',
+    );
+  });
+
+  it('should fetch monitored repositories with operator authorization', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          repositories: [
+            {
+              id: 'repo_123',
+              githubRepoId: '123456789',
+              owner: 'forgeops',
+              name: 'backend',
+              fullName: 'forgeops/backend',
+              defaultBranch: 'main',
+              isActive: true,
+              createdAt: '2026-03-28T00:00:00.000Z',
+              updatedAt: '2026-03-28T00:00:00.000Z',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+      ),
+    );
+    const client = createApiClient({
+      baseUrl: 'http://localhost:3333',
+      fetcher,
+    });
+
+    await expect(client.getRepositories('trusted-token')).resolves.toEqual([
+      {
+        id: 'repo_123',
+        githubRepoId: '123456789',
+        owner: 'forgeops',
+        name: 'backend',
+        fullName: 'forgeops/backend',
+        defaultBranch: 'main',
+        isActive: true,
+        createdAt: '2026-03-28T00:00:00.000Z',
+        updatedAt: '2026-03-28T00:00:00.000Z',
+      },
+    ]);
+    expect(fetcher).toHaveBeenCalledWith('http://localhost:3333/api/v1/repositories', {
+      headers: {
+        accept: 'application/json',
+        authorization: 'Bearer trusted-token',
+      },
+    });
+  });
+
+  it('should fetch repository discovery with operator authorization', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          repositories: [
+            {
+              githubRepoId: '123456789',
+              owner: 'forgeops',
+              name: 'backend',
+              fullName: 'forgeops/backend',
+              defaultBranch: 'main',
+              isPrivate: true,
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+      ),
+    );
+    const client = createApiClient({
+      baseUrl: 'http://localhost:3333',
+      fetcher,
+    });
+
+    await expect(client.getRepositoryDiscovery('trusted-token')).resolves.toEqual([
+      {
+        githubRepoId: '123456789',
+        owner: 'forgeops',
+        name: 'backend',
+        fullName: 'forgeops/backend',
+        defaultBranch: 'main',
+        isPrivate: true,
+      },
+    ]);
+    expect(fetcher).toHaveBeenCalledWith(
+      'http://localhost:3333/api/v1/repositories/discovery',
+      {
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer trusted-token',
+        },
+      },
+    );
+  });
+
+  it('should create repositories and surface structured API errors', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            repository: {
+              id: 'repo_123',
+              githubRepoId: '123456789',
+              owner: 'forgeops',
+              name: 'backend',
+              fullName: 'forgeops/backend',
+              defaultBranch: 'main',
+              isActive: true,
+              createdAt: '2026-03-28T00:00:00.000Z',
+              updatedAt: '2026-03-28T00:00:00.000Z',
+            },
+          }),
+          {
+            status: 201,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'forbidden',
+              message: 'You are not allowed to perform this action.',
+            },
+          }),
+          {
+            status: 403,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+    const client = createApiClient({
+      baseUrl: 'http://localhost:3333',
+      fetcher,
+    });
+
+    await expect(
+      client.createRepository('trusted-token', {
+        githubRepoId: '123456789',
+        owner: 'forgeops',
+        name: 'backend',
+        fullName: 'forgeops/backend',
+        defaultBranch: 'main',
+      }),
+    ).resolves.toMatchObject({
+      id: 'repo_123',
+      fullName: 'forgeops/backend',
+    });
+
+    await expect(
+      client.createRepository('trusted-token', {
+        githubRepoId: '123456789',
+        owner: 'forgeops',
+        name: 'backend',
+        fullName: 'forgeops/backend',
+        defaultBranch: 'main',
+      }),
+    ).rejects.toEqual(
+      new ApiClientError('You are not allowed to perform this action.', 403, 'forbidden'),
+    );
+
+    expect(fetcher).toHaveBeenNthCalledWith(
+      1,
+      'http://localhost:3333/api/v1/repositories',
+      {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer trusted-token',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+        }),
+      },
     );
   });
 });

--- a/frontend/src/tests/repositories-view.test.tsx
+++ b/frontend/src/tests/repositories-view.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Providers } from '@/app/providers';
+import type { ForgeOpsApiClient } from '@/lib/api/client';
+import { ApiClientError } from '@/lib/api/client';
+import { RepositoriesView } from '@/features/repositories/repositories-view';
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+
+const renderRepositoriesView = (client: ForgeOpsApiClient) => {
+  render(
+    <Providers>
+      <RepositoriesView client={client} />
+    </Providers>,
+  );
+};
+
+describe('RepositoriesView', () => {
+  it('should wait for an operator token before querying protected repository APIs', () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn(),
+      getRepositoryDiscovery: vi.fn(),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    expect(
+      screen.getByText(
+        'Add an operator token to load the repositories already monitored by ForgeOps.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Add an operator token to query repository discovery through the backend.',
+      ),
+    ).toBeInTheDocument();
+    expect(client.getRepositories).not.toHaveBeenCalled();
+    expect(client.getRepositoryDiscovery).not.toHaveBeenCalled();
+  });
+
+  it('should load discovery and connect a repository through the backend client', async () => {
+    const getRepositories = vi
+      .fn<ForgeOpsApiClient['getRepositories']>()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]);
+    const getRepositoryDiscovery = vi
+      .fn<ForgeOpsApiClient['getRepositoryDiscovery']>()
+      .mockResolvedValue([
+        {
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isPrivate: true,
+        },
+      ]);
+    const createRepository = vi
+      .fn<ForgeOpsApiClient['createRepository']>()
+      .mockResolvedValue({
+        id: 'repo_123',
+        githubRepoId: '123456789',
+        owner: 'forgeops',
+        name: 'backend',
+        fullName: 'forgeops/backend',
+        defaultBranch: 'main',
+        isActive: true,
+        createdAt: '2026-03-28T00:00:00.000Z',
+        updatedAt: '2026-03-28T00:00:00.000Z',
+      });
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories,
+      getRepositoryDiscovery,
+      createRepository,
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('forgeops/backend')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Connect repository' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect repository' }));
+
+    await waitFor(() => {
+      expect(createRepository).toHaveBeenCalledWith('trusted-token', {
+        githubRepoId: '123456789',
+        owner: 'forgeops',
+        name: 'backend',
+        fullName: 'forgeops/backend',
+        defaultBranch: 'main',
+      });
+      expect(
+        screen.getByText('Repository forgeops/backend is now monitored.'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Already monitored')).toBeInTheDocument();
+    });
+  });
+
+  it('should surface backend discovery errors clearly', async () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([]),
+      getRepositoryDiscovery: vi
+        .fn()
+        .mockRejectedValue(
+          new ApiClientError('GitHub repository discovery is currently unavailable.', 503),
+        ),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('GitHub repository discovery is currently unavailable.'),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace the repositories placeholder with a real onboarding flow backed by protected backend endpoints
- load repository discovery and monitored repositories from the frontend API client
- connect repositories from the UI and cover the flow with feature and API boundary tests

## Issue
Closes #43