### PR TITLE
fix(repository): handle duplicate repository conflicts

### DIFF
--- a/backend/src/modules/repository-registry/repository.errors.ts
+++ b/backend/src/modules/repository-registry/repository.errors.ts
@@ -1,7 +1,7 @@
 import { ApplicationError } from '../../shared/errors/application-error.js';
 
 export class RepositoryAlreadyExistsError extends ApplicationError {
-  constructor(message = 'Repository is already registered.') {
+  constructor(message = 'Repository is already monitored.') {
     super(message, 409, 'repository_already_exists');
   }
 }

--- a/backend/src/tests/app/create-server.test.ts
+++ b/backend/src/tests/app/create-server.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { createServer } from '../../app/create-server.js';
 import { GitHubRepositoryDiscoveryError } from '../../modules/github/github-app.errors.js';
+import { RepositoryAlreadyExistsError } from '../../modules/repository-registry/repository.errors.js';
 import { createOperatorPrincipal } from '../../shared/auth/operator-principal.js';
 import type {
   CreateRepositoryInput,
@@ -520,6 +521,33 @@ describe('createServer', () => {
         isActive: true,
         createdAt: '2026-03-27T16:45:00.000Z',
         updatedAt: '2026-03-27T16:45:00.000Z',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should return a consistent conflict response when the repository already exists', async () => {
+    const server = createProtectedServer({
+      createRepository: async () => {
+        throw new RepositoryAlreadyExistsError();
+      },
+    });
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/v1/repositories',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+      payload: buildCreateRepositoryInput(),
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'repository_already_exists',
+        message: 'Repository is already monitored.',
       },
     });
 

--- a/frontend/src/features/repositories/repositories-view.tsx
+++ b/frontend/src/features/repositories/repositories-view.tsx
@@ -79,6 +79,15 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
       });
     },
     onError: (error) => {
+      if (
+        error instanceof ApiClientError &&
+        error.code === 'repository_already_exists'
+      ) {
+        void queryClient.invalidateQueries({
+          queryKey: ['repositories', accessToken],
+        });
+      }
+
       setStatusMessage(getErrorMessage(error, 'Unable to connect the repository right now.'));
     },
   });

--- a/frontend/src/tests/api-client.test.ts
+++ b/frontend/src/tests/api-client.test.ts
@@ -191,12 +191,12 @@ describe('createApiClient', () => {
         new Response(
           JSON.stringify({
             error: {
-              code: 'forbidden',
-              message: 'You are not allowed to perform this action.',
+              code: 'repository_already_exists',
+              message: 'Repository is already monitored.',
             },
           }),
           {
-            status: 403,
+            status: 409,
             headers: {
               'content-type': 'application/json',
             },
@@ -230,7 +230,7 @@ describe('createApiClient', () => {
         defaultBranch: 'main',
       }),
     ).rejects.toEqual(
-      new ApiClientError('You are not allowed to perform this action.', 403, 'forbidden'),
+      new ApiClientError('Repository is already monitored.', 409, 'repository_already_exists'),
     );
 
     expect(fetcher).toHaveBeenNthCalledWith(

--- a/frontend/src/tests/repositories-view.test.tsx
+++ b/frontend/src/tests/repositories-view.test.tsx
@@ -147,4 +147,61 @@ describe('RepositoriesView', () => {
       ).toBeInTheDocument();
     });
   });
+
+  it('should surface repository conflicts clearly and refresh monitored repositories', async () => {
+    const getRepositories = vi
+      .fn<ForgeOpsApiClient['getRepositories']>()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]);
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories,
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([
+        {
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isPrivate: true,
+        },
+      ]),
+      createRepository: vi
+        .fn()
+        .mockRejectedValue(
+          new ApiClientError('Repository is already monitored.', 409, 'repository_already_exists'),
+        ),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Connect repository' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect repository' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Repository is already monitored.')).toBeInTheDocument();
+      expect(screen.getByText('Already monitored')).toBeInTheDocument();
+      expect(getRepositories).toHaveBeenCalledTimes(2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- return a stable repository conflict response when the backend receives a duplicate repository create request
- refresh monitored repositories on the frontend when the backend reports a conflict so the operator sees the current state
- cover the duplicate repository flow with backend and frontend tests

## Issue
Closes #50