### PR TITLE
feat(github): add webhook verification boundary

### DIFF
--- a/backend/src/modules/github/github-app.errors.ts
+++ b/backend/src/modules/github/github-app.errors.ts
@@ -19,3 +19,13 @@ export class GitHubWorkflowCatalogSyncError extends ApplicationError {
     );
   }
 }
+
+export class GitHubWebhookVerificationError extends ApplicationError {
+  constructor() {
+    super(
+      'GitHub webhook verification failed.',
+      401,
+      'github_webhook_verification_failed',
+    );
+  }
+}

--- a/backend/src/modules/github/github-webhook.boundary.ts
+++ b/backend/src/modules/github/github-webhook.boundary.ts
@@ -1,0 +1,21 @@
+import type { GitHubAppEnv } from '../../infra/config/github-app-env.js';
+import {
+  GitHubWebhookProvider,
+  type GitHubWebhookProviderOptions,
+} from './providers/github-webhook.provider.js';
+
+export interface GitHubWebhookVerificationInput {
+  payload: Buffer | string;
+  signatureHeader: string | undefined;
+}
+
+export interface GitHubWebhookBoundary {
+  readonly configured: boolean;
+  assertConfigured(): void;
+  verifySignature(input: GitHubWebhookVerificationInput): void;
+}
+
+export const createGitHubWebhookBoundary = (
+  config: GitHubAppEnv | null,
+  options: GitHubWebhookProviderOptions = {},
+): GitHubWebhookBoundary => new GitHubWebhookProvider(config, options);

--- a/backend/src/modules/github/providers/github-webhook.provider.ts
+++ b/backend/src/modules/github/providers/github-webhook.provider.ts
@@ -1,0 +1,87 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { GitHubAppEnv } from '../../../infra/config/github-app-env.js';
+import { ConfigurationError } from '../../../shared/errors/configuration-error.js';
+import { GitHubWebhookVerificationError } from '../github-app.errors.js';
+import type {
+  GitHubWebhookBoundary,
+  GitHubWebhookVerificationInput,
+} from '../github-webhook.boundary.js';
+
+const GITHUB_WEBHOOK_SIGNATURE_PREFIX = 'sha256=';
+const GITHUB_WEBHOOK_SIGNATURE_PATTERN = /^[a-f0-9]{64}$/;
+
+export interface GitHubWebhookProviderOptions {
+  signatureFactory?: (secret: string, payload: Buffer) => string;
+}
+
+export class GitHubWebhookProvider implements GitHubWebhookBoundary {
+  public readonly configured: boolean;
+
+  private readonly config: GitHubAppEnv | null;
+  private readonly signatureFactory: (secret: string, payload: Buffer) => string;
+
+  public constructor(
+    config: GitHubAppEnv | null,
+    options: GitHubWebhookProviderOptions = {},
+  ) {
+    this.config = config;
+    this.configured = config !== null;
+    this.signatureFactory = options.signatureFactory ?? createGitHubWebhookSignature;
+  }
+
+  public assertConfigured(): void {
+    if (this.config === null) {
+      throw new ConfigurationError(
+        'GitHub webhook configuration is required before verifying webhook signatures.',
+        'github_webhook_not_configured',
+      );
+    }
+  }
+
+  public verifySignature(input: GitHubWebhookVerificationInput): void {
+    this.assertConfigured();
+
+    const receivedSignature = parseSignatureHeader(input.signatureHeader);
+    const payload = normalizePayload(input.payload);
+    const expectedSignature = this.signatureFactory(
+      this.config!.GITHUB_APP_WEBHOOK_SECRET,
+      payload,
+    );
+
+    if (
+      !timingSafeEqual(
+        Buffer.from(receivedSignature, 'utf8'),
+        Buffer.from(expectedSignature, 'utf8'),
+      )
+    ) {
+      throw new GitHubWebhookVerificationError();
+    }
+  }
+}
+
+const parseSignatureHeader = (value: string | undefined): string => {
+  if (!value) {
+    throw new GitHubWebhookVerificationError();
+  }
+
+  if (!value.startsWith(GITHUB_WEBHOOK_SIGNATURE_PREFIX)) {
+    throw new GitHubWebhookVerificationError();
+  }
+
+  const normalizedSignature = value
+    .slice(GITHUB_WEBHOOK_SIGNATURE_PREFIX.length)
+    .trim()
+    .toLowerCase();
+
+  if (!GITHUB_WEBHOOK_SIGNATURE_PATTERN.test(normalizedSignature)) {
+    throw new GitHubWebhookVerificationError();
+  }
+
+  return normalizedSignature;
+};
+
+const normalizePayload = (payload: Buffer | string): Buffer =>
+  typeof payload === 'string' ? Buffer.from(payload, 'utf8') : payload;
+
+const createGitHubWebhookSignature = (secret: string, payload: Buffer): string =>
+  createHmac('sha256', secret).update(payload).digest('hex');

--- a/backend/src/tests/modules/github/github-webhook.boundary.test.ts
+++ b/backend/src/tests/modules/github/github-webhook.boundary.test.ts
@@ -1,0 +1,67 @@
+import { createHmac } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { createGitHubWebhookBoundary } from '../../../modules/github/github-webhook.boundary.js';
+import { GitHubWebhookVerificationError } from '../../../modules/github/github-app.errors.js';
+import { ConfigurationError } from '../../../shared/errors/configuration-error.js';
+
+const createSignatureHeader = (secret: string, payload: string): string => {
+  const digest = createHmac('sha256', secret).update(payload).digest('hex');
+  return `sha256=${digest}`;
+};
+
+describe('createGitHubWebhookBoundary', () => {
+  it('should accept a valid webhook signature', () => {
+    const payload = JSON.stringify({
+      action: 'completed',
+      workflow_run: {
+        id: 123,
+      },
+    });
+    const boundary = createGitHubWebhookBoundary({
+      GITHUB_APP_ID: '12345678',
+      GITHUB_APP_INSTALLATION_ID: '87654321',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+      GITHUB_APP_WEBHOOK_SECRET: 'webhook-secret',
+    });
+
+    expect(() =>
+      boundary.verifySignature({
+        payload,
+        signatureHeader: createSignatureHeader('webhook-secret', payload),
+      }),
+    ).not.toThrow();
+  });
+
+  it('should reject an invalid webhook signature with a safe error', () => {
+    const boundary = createGitHubWebhookBoundary({
+      GITHUB_APP_ID: '12345678',
+      GITHUB_APP_INSTALLATION_ID: '87654321',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+      GITHUB_APP_WEBHOOK_SECRET: 'webhook-secret',
+    });
+
+    expect(() =>
+      boundary.verifySignature({
+        payload: '{"action":"completed"}',
+        signatureHeader: 'sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      }),
+    ).toThrowError(GitHubWebhookVerificationError);
+  });
+
+  it('should fail closed when webhook verification is used without configuration', () => {
+    const boundary = createGitHubWebhookBoundary(null);
+
+    expect(() =>
+      boundary.verifySignature({
+        payload: '{"action":"completed"}',
+        signatureHeader:
+          'sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      }),
+    ).toThrowError(
+      new ConfigurationError(
+        'GitHub webhook configuration is required before verifying webhook signatures.',
+        'github_webhook_not_configured',
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated GitHub webhook verification boundary and provider
- verify GitHub webhook signatures with HMAC SHA-256 and timing-safe comparison
- cover valid, invalid, and missing-configuration scenarios with unit tests

## Issue
Closes #48