### PR TITLE
feat(workflow-runs): add persistence baseline for runs and jobs

### DIFF
--- a/backend/prisma/migrations/20260330220500_add_workflow_runs/migration.sql
+++ b/backend/prisma/migrations/20260330220500_add_workflow_runs/migration.sql
@@ -1,0 +1,87 @@
+-- CreateEnum
+CREATE TYPE "WorkflowExecutionStatus" AS ENUM (
+  'queued',
+  'in_progress',
+  'completed',
+  'pending',
+  'waiting',
+  'requested'
+);
+
+-- CreateEnum
+CREATE TYPE "WorkflowExecutionConclusion" AS ENUM (
+  'success',
+  'failure',
+  'neutral',
+  'cancelled',
+  'skipped',
+  'timed_out',
+  'action_required',
+  'stale',
+  'startup_failure'
+);
+
+-- CreateTable
+CREATE TABLE "WorkflowRun" (
+  "id" TEXT NOT NULL,
+  "workflowId" TEXT NOT NULL,
+  "githubRunId" TEXT NOT NULL,
+  "status" "WorkflowExecutionStatus" NOT NULL,
+  "conclusion" "WorkflowExecutionConclusion",
+  "branch" TEXT NOT NULL,
+  "sha" TEXT NOT NULL,
+  "event" TEXT NOT NULL,
+  "startedAt" TIMESTAMP(3),
+  "finishedAt" TIMESTAMP(3),
+  "durationMs" INTEGER,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "WorkflowRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WorkflowJob" (
+  "id" TEXT NOT NULL,
+  "workflowRunId" TEXT NOT NULL,
+  "githubJobId" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "status" "WorkflowExecutionStatus" NOT NULL,
+  "conclusion" "WorkflowExecutionConclusion",
+  "startedAt" TIMESTAMP(3),
+  "finishedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "WorkflowJob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WorkflowRun_workflowId_githubRunId_key"
+ON "WorkflowRun"("workflowId", "githubRunId");
+
+-- CreateIndex
+CREATE INDEX "WorkflowRun_workflowId_startedAt_idx"
+ON "WorkflowRun"("workflowId", "startedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WorkflowJob_workflowRunId_githubJobId_key"
+ON "WorkflowJob"("workflowRunId", "githubJobId");
+
+-- CreateIndex
+CREATE INDEX "WorkflowJob_workflowRunId_startedAt_idx"
+ON "WorkflowJob"("workflowRunId", "startedAt");
+
+-- AddForeignKey
+ALTER TABLE "WorkflowRun"
+ADD CONSTRAINT "WorkflowRun_workflowId_fkey"
+FOREIGN KEY ("workflowId") REFERENCES "Workflow"("id")
+ON DELETE CASCADE
+ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkflowJob"
+ADD CONSTRAINT "WorkflowJob_workflowRunId_fkey"
+FOREIGN KEY ("workflowRunId") REFERENCES "WorkflowRun"("id")
+ON DELETE CASCADE
+ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -33,9 +33,48 @@ model Workflow {
   createdAt        DateTime           @default(now())
   updatedAt        DateTime           @updatedAt
   repository       Repository         @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
+  runs             WorkflowRun[]
 
   @@unique([repositoryId, githubWorkflowId])
   @@index([repositoryId, createdAt])
+}
+
+model WorkflowRun {
+  id         String                      @id @default(cuid())
+  workflowId String
+  githubRunId String
+  status     WorkflowExecutionStatus
+  conclusion WorkflowExecutionConclusion?
+  branch     String
+  sha        String
+  event      String
+  startedAt  DateTime?
+  finishedAt DateTime?
+  durationMs Int?
+  createdAt  DateTime                    @default(now())
+  updatedAt  DateTime                    @updatedAt
+  workflow   Workflow                    @relation(fields: [workflowId], references: [id], onDelete: Cascade)
+  jobs       WorkflowJob[]
+
+  @@unique([workflowId, githubRunId])
+  @@index([workflowId, startedAt])
+}
+
+model WorkflowJob {
+  id            String                      @id @default(cuid())
+  workflowRunId String
+  githubJobId   String
+  name          String
+  status        WorkflowExecutionStatus
+  conclusion    WorkflowExecutionConclusion?
+  startedAt     DateTime?
+  finishedAt    DateTime?
+  createdAt     DateTime                    @default(now())
+  updatedAt     DateTime                    @updatedAt
+  workflowRun   WorkflowRun                 @relation(fields: [workflowRunId], references: [id], onDelete: Cascade)
+
+  @@unique([workflowRunId, githubJobId])
+  @@index([workflowRunId, startedAt])
 }
 
 enum WorkflowState {
@@ -49,5 +88,26 @@ enum WorkflowState {
 enum WorkflowSourceType {
   local
   reusable
+}
+
+enum WorkflowExecutionStatus {
+  queued
+  in_progress
+  completed
+  pending
+  waiting
+  requested
+}
+
+enum WorkflowExecutionConclusion {
+  success
+  failure
+  neutral
+  cancelled
+  skipped
+  timed_out
+  action_required
+  stale
+  startup_failure
 }
 

--- a/backend/src/modules/workflow-runs/workflow-run.entity.ts
+++ b/backend/src/modules/workflow-runs/workflow-run.entity.ts
@@ -1,0 +1,70 @@
+export type WorkflowExecutionStatus =
+  | 'queued'
+  | 'in_progress'
+  | 'completed'
+  | 'pending'
+  | 'waiting'
+  | 'requested';
+
+export type WorkflowExecutionConclusion =
+  | 'success'
+  | 'failure'
+  | 'neutral'
+  | 'cancelled'
+  | 'skipped'
+  | 'timed_out'
+  | 'action_required'
+  | 'stale'
+  | 'startup_failure';
+
+export interface WorkflowRun {
+  id: string;
+  workflowId: string;
+  githubRunId: string;
+  status: WorkflowExecutionStatus;
+  conclusion: WorkflowExecutionConclusion | null;
+  branch: string;
+  sha: string;
+  event: string;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  durationMs: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface WorkflowJob {
+  id: string;
+  workflowRunId: string;
+  githubJobId: string;
+  name: string;
+  status: WorkflowExecutionStatus;
+  conclusion: WorkflowExecutionConclusion | null;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateWorkflowRunInput {
+  workflowId: string;
+  githubRunId: string;
+  status: WorkflowExecutionStatus;
+  conclusion: WorkflowExecutionConclusion | null;
+  branch: string;
+  sha: string;
+  event: string;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  durationMs: number | null;
+}
+
+export interface CreateWorkflowJobInput {
+  workflowRunId: string;
+  githubJobId: string;
+  name: string;
+  status: WorkflowExecutionStatus;
+  conclusion: WorkflowExecutionConclusion | null;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+}

--- a/backend/src/modules/workflow-runs/workflow-run.errors.ts
+++ b/backend/src/modules/workflow-runs/workflow-run.errors.ts
@@ -1,0 +1,13 @@
+import { ApplicationError } from '../../shared/errors/application-error.js';
+
+export class WorkflowRunAlreadyExistsError extends ApplicationError {
+  constructor(message = 'Workflow run is already synchronized.') {
+    super(message, 409, 'workflow_run_already_exists');
+  }
+}
+
+export class WorkflowJobAlreadyExistsError extends ApplicationError {
+  constructor(message = 'Workflow job is already synchronized.') {
+    super(message, 409, 'workflow_job_already_exists');
+  }
+}

--- a/backend/src/modules/workflow-runs/workflow-run.prisma-repository.ts
+++ b/backend/src/modules/workflow-runs/workflow-run.prisma-repository.ts
@@ -1,0 +1,328 @@
+import {
+  WorkflowJobAlreadyExistsError,
+  WorkflowRunAlreadyExistsError,
+} from './workflow-run.errors.js';
+import type {
+  CreateWorkflowJobInput,
+  CreateWorkflowRunInput,
+  WorkflowExecutionConclusion,
+  WorkflowExecutionStatus,
+  WorkflowJob,
+  WorkflowRun,
+} from './workflow-run.entity.js';
+import type { WorkflowRunRepository } from './workflow-run.repository.js';
+
+interface WorkflowRunRecord {
+  id: string;
+  workflowId: string;
+  githubRunId: string;
+  status: WorkflowExecutionStatus;
+  conclusion: WorkflowExecutionConclusion | null;
+  branch: string;
+  sha: string;
+  event: string;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  durationMs: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface WorkflowJobRecord {
+  id: string;
+  workflowRunId: string;
+  githubJobId: string;
+  name: string;
+  status: WorkflowExecutionStatus;
+  conclusion: WorkflowExecutionConclusion | null;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+type WorkflowRunDelegate = {
+  create(args: {
+    data: {
+      workflowId: string;
+      githubRunId: string;
+      status: WorkflowExecutionStatus;
+      conclusion: WorkflowExecutionConclusion | null;
+      branch: string;
+      sha: string;
+      event: string;
+      startedAt: Date | null;
+      finishedAt: Date | null;
+      durationMs: number | null;
+    };
+  }): Promise<WorkflowRunRecord>;
+  upsert(args: {
+    where: {
+      workflowId_githubRunId: {
+        workflowId: string;
+        githubRunId: string;
+      };
+    };
+    create: {
+      workflowId: string;
+      githubRunId: string;
+      status: WorkflowExecutionStatus;
+      conclusion: WorkflowExecutionConclusion | null;
+      branch: string;
+      sha: string;
+      event: string;
+      startedAt: Date | null;
+      finishedAt: Date | null;
+      durationMs: number | null;
+    };
+    update: {
+      status: WorkflowExecutionStatus;
+      conclusion: WorkflowExecutionConclusion | null;
+      branch: string;
+      sha: string;
+      event: string;
+      startedAt: Date | null;
+      finishedAt: Date | null;
+      durationMs: number | null;
+    };
+  }): Promise<WorkflowRunRecord>;
+  findMany(args: {
+    where: {
+      workflowId: string;
+    };
+    orderBy: Array<{
+      startedAt?: 'asc' | 'desc';
+      createdAt?: 'asc' | 'desc';
+    }>;
+  }): Promise<WorkflowRunRecord[]>;
+};
+
+type WorkflowJobDelegate = {
+  create(args: {
+    data: {
+      workflowRunId: string;
+      githubJobId: string;
+      name: string;
+      status: WorkflowExecutionStatus;
+      conclusion: WorkflowExecutionConclusion | null;
+      startedAt: Date | null;
+      finishedAt: Date | null;
+    };
+  }): Promise<WorkflowJobRecord>;
+  upsert(args: {
+    where: {
+      workflowRunId_githubJobId: {
+        workflowRunId: string;
+        githubJobId: string;
+      };
+    };
+    create: {
+      workflowRunId: string;
+      githubJobId: string;
+      name: string;
+      status: WorkflowExecutionStatus;
+      conclusion: WorkflowExecutionConclusion | null;
+      startedAt: Date | null;
+      finishedAt: Date | null;
+    };
+    update: {
+      name: string;
+      status: WorkflowExecutionStatus;
+      conclusion: WorkflowExecutionConclusion | null;
+      startedAt: Date | null;
+      finishedAt: Date | null;
+    };
+  }): Promise<WorkflowJobRecord>;
+  findMany(args: {
+    where: {
+      workflowRunId: string;
+    };
+    orderBy: Array<{
+      startedAt?: 'asc' | 'desc';
+      createdAt?: 'asc' | 'desc';
+    }>;
+  }): Promise<WorkflowJobRecord[]>;
+};
+
+const isUniqueConstraintError = (error: unknown): boolean => {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'P2002';
+};
+
+const toWorkflowRun = (record: WorkflowRunRecord): WorkflowRun => {
+  return {
+    id: record.id,
+    workflowId: record.workflowId,
+    githubRunId: record.githubRunId,
+    status: record.status,
+    conclusion: record.conclusion,
+    branch: record.branch,
+    sha: record.sha,
+    event: record.event,
+    startedAt: record.startedAt,
+    finishedAt: record.finishedAt,
+    durationMs: record.durationMs,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+};
+
+const toWorkflowJob = (record: WorkflowJobRecord): WorkflowJob => {
+  return {
+    id: record.id,
+    workflowRunId: record.workflowRunId,
+    githubJobId: record.githubJobId,
+    name: record.name,
+    status: record.status,
+    conclusion: record.conclusion,
+    startedAt: record.startedAt,
+    finishedAt: record.finishedAt,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+};
+
+export interface PrismaWorkflowRunRepositoryOptions {
+  workflowRun: WorkflowRunDelegate;
+  workflowJob: WorkflowJobDelegate;
+}
+
+export class PrismaWorkflowRunRepository implements WorkflowRunRepository {
+  constructor(private readonly options: PrismaWorkflowRunRepositoryOptions) {}
+
+  async createRun(input: CreateWorkflowRunInput): Promise<WorkflowRun> {
+    try {
+      const record = await this.options.workflowRun.create({
+        data: {
+          workflowId: input.workflowId,
+          githubRunId: input.githubRunId,
+          status: input.status,
+          conclusion: input.conclusion,
+          branch: input.branch,
+          sha: input.sha,
+          event: input.event,
+          startedAt: input.startedAt,
+          finishedAt: input.finishedAt,
+          durationMs: input.durationMs,
+        },
+      });
+
+      return toWorkflowRun(record);
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw new WorkflowRunAlreadyExistsError();
+      }
+
+      throw error;
+    }
+  }
+
+  async upsertRun(input: CreateWorkflowRunInput): Promise<WorkflowRun> {
+    const record = await this.options.workflowRun.upsert({
+      where: {
+        workflowId_githubRunId: {
+          workflowId: input.workflowId,
+          githubRunId: input.githubRunId,
+        },
+      },
+      create: {
+        workflowId: input.workflowId,
+        githubRunId: input.githubRunId,
+        status: input.status,
+        conclusion: input.conclusion,
+        branch: input.branch,
+        sha: input.sha,
+        event: input.event,
+        startedAt: input.startedAt,
+        finishedAt: input.finishedAt,
+        durationMs: input.durationMs,
+      },
+      update: {
+        status: input.status,
+        conclusion: input.conclusion,
+        branch: input.branch,
+        sha: input.sha,
+        event: input.event,
+        startedAt: input.startedAt,
+        finishedAt: input.finishedAt,
+        durationMs: input.durationMs,
+      },
+    });
+
+    return toWorkflowRun(record);
+  }
+
+  async listRunsByWorkflowId(workflowId: string): Promise<WorkflowRun[]> {
+    const records = await this.options.workflowRun.findMany({
+      where: {
+        workflowId,
+      },
+      orderBy: [{ startedAt: 'desc' }, { createdAt: 'desc' }],
+    });
+
+    return records.map(toWorkflowRun);
+  }
+
+  async createJob(input: CreateWorkflowJobInput): Promise<WorkflowJob> {
+    try {
+      const record = await this.options.workflowJob.create({
+        data: {
+          workflowRunId: input.workflowRunId,
+          githubJobId: input.githubJobId,
+          name: input.name,
+          status: input.status,
+          conclusion: input.conclusion,
+          startedAt: input.startedAt,
+          finishedAt: input.finishedAt,
+        },
+      });
+
+      return toWorkflowJob(record);
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw new WorkflowJobAlreadyExistsError();
+      }
+
+      throw error;
+    }
+  }
+
+  async upsertJob(input: CreateWorkflowJobInput): Promise<WorkflowJob> {
+    const record = await this.options.workflowJob.upsert({
+      where: {
+        workflowRunId_githubJobId: {
+          workflowRunId: input.workflowRunId,
+          githubJobId: input.githubJobId,
+        },
+      },
+      create: {
+        workflowRunId: input.workflowRunId,
+        githubJobId: input.githubJobId,
+        name: input.name,
+        status: input.status,
+        conclusion: input.conclusion,
+        startedAt: input.startedAt,
+        finishedAt: input.finishedAt,
+      },
+      update: {
+        name: input.name,
+        status: input.status,
+        conclusion: input.conclusion,
+        startedAt: input.startedAt,
+        finishedAt: input.finishedAt,
+      },
+    });
+
+    return toWorkflowJob(record);
+  }
+
+  async listJobsByWorkflowRunId(workflowRunId: string): Promise<WorkflowJob[]> {
+    const records = await this.options.workflowJob.findMany({
+      where: {
+        workflowRunId,
+      },
+      orderBy: [{ startedAt: 'desc' }, { createdAt: 'desc' }],
+    });
+
+    return records.map(toWorkflowJob);
+  }
+}

--- a/backend/src/modules/workflow-runs/workflow-run.repository.ts
+++ b/backend/src/modules/workflow-runs/workflow-run.repository.ts
@@ -1,0 +1,15 @@
+import type {
+  CreateWorkflowJobInput,
+  CreateWorkflowRunInput,
+  WorkflowJob,
+  WorkflowRun,
+} from './workflow-run.entity.js';
+
+export interface WorkflowRunRepository {
+  createRun(input: CreateWorkflowRunInput): Promise<WorkflowRun>;
+  upsertRun(input: CreateWorkflowRunInput): Promise<WorkflowRun>;
+  listRunsByWorkflowId(workflowId: string): Promise<WorkflowRun[]>;
+  createJob(input: CreateWorkflowJobInput): Promise<WorkflowJob>;
+  upsertJob(input: CreateWorkflowJobInput): Promise<WorkflowJob>;
+  listJobsByWorkflowRunId(workflowRunId: string): Promise<WorkflowJob[]>;
+}

--- a/backend/src/tests/modules/workflow-runs/workflow-run.prisma-repository.test.ts
+++ b/backend/src/tests/modules/workflow-runs/workflow-run.prisma-repository.test.ts
@@ -1,0 +1,514 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  WorkflowJobAlreadyExistsError,
+  WorkflowRunAlreadyExistsError,
+} from '../../../modules/workflow-runs/workflow-run.errors.js';
+import { PrismaWorkflowRunRepository } from '../../../modules/workflow-runs/workflow-run.prisma-repository.js';
+
+interface WorkflowRunRecord {
+  id: string;
+  workflowId: string;
+  githubRunId: string;
+  status:
+    | 'queued'
+    | 'in_progress'
+    | 'completed'
+    | 'pending'
+    | 'waiting'
+    | 'requested';
+  conclusion:
+    | 'success'
+    | 'failure'
+    | 'neutral'
+    | 'cancelled'
+    | 'skipped'
+    | 'timed_out'
+    | 'action_required'
+    | 'stale'
+    | 'startup_failure'
+    | null;
+  branch: string;
+  sha: string;
+  event: string;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  durationMs: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface WorkflowJobRecord {
+  id: string;
+  workflowRunId: string;
+  githubJobId: string;
+  name: string;
+  status:
+    | 'queued'
+    | 'in_progress'
+    | 'completed'
+    | 'pending'
+    | 'waiting'
+    | 'requested';
+  conclusion:
+    | 'success'
+    | 'failure'
+    | 'neutral'
+    | 'cancelled'
+    | 'skipped'
+    | 'timed_out'
+    | 'action_required'
+    | 'stale'
+    | 'startup_failure'
+    | null;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const buildRunRecord = (
+  overrides: Partial<WorkflowRunRecord> = {},
+): WorkflowRunRecord => {
+  const startedAt = new Date('2026-03-30T12:00:00.000Z');
+
+  return {
+    id: 'run_123',
+    workflowId: 'workflow_123',
+    githubRunId: '987654321',
+    status: 'completed',
+    conclusion: 'success',
+    branch: 'main',
+    sha: 'abc123def456',
+    event: 'push',
+    startedAt,
+    finishedAt: new Date('2026-03-30T12:05:00.000Z'),
+    durationMs: 300000,
+    createdAt: startedAt,
+    updatedAt: startedAt,
+    ...overrides,
+  };
+};
+
+const buildJobRecord = (
+  overrides: Partial<WorkflowJobRecord> = {},
+): WorkflowJobRecord => {
+  const startedAt = new Date('2026-03-30T12:01:00.000Z');
+
+  return {
+    id: 'job_123',
+    workflowRunId: 'run_123',
+    githubJobId: '123456789',
+    name: 'lint',
+    status: 'completed',
+    conclusion: 'success',
+    startedAt,
+    finishedAt: new Date('2026-03-30T12:02:00.000Z'),
+    createdAt: startedAt,
+    updatedAt: startedAt,
+    ...overrides,
+  };
+};
+
+describe('PrismaWorkflowRunRepository', () => {
+  it('should create and map a workflow run record', async () => {
+    const workflowRunCreate = vi.fn().mockResolvedValue(buildRunRecord());
+    const workflowRunUpsert = vi.fn();
+    const workflowRunFindMany = vi.fn();
+    const workflowJobCreate = vi.fn();
+    const workflowJobUpsert = vi.fn();
+    const workflowJobFindMany = vi.fn();
+    const repository = new PrismaWorkflowRunRepository({
+      workflowRun: {
+        create: workflowRunCreate,
+        upsert: workflowRunUpsert,
+        findMany: workflowRunFindMany,
+      },
+      workflowJob: {
+        create: workflowJobCreate,
+        upsert: workflowJobUpsert,
+        findMany: workflowJobFindMany,
+      },
+    });
+
+    await expect(
+      repository.createRun({
+        workflowId: 'workflow_123',
+        githubRunId: '987654321',
+        status: 'completed',
+        conclusion: 'success',
+        branch: 'main',
+        sha: 'abc123def456',
+        event: 'push',
+        startedAt: new Date('2026-03-30T12:00:00.000Z'),
+        finishedAt: new Date('2026-03-30T12:05:00.000Z'),
+        durationMs: 300000,
+      }),
+    ).resolves.toEqual(buildRunRecord());
+
+    expect(workflowRunCreate).toHaveBeenCalledWith({
+      data: {
+        workflowId: 'workflow_123',
+        githubRunId: '987654321',
+        status: 'completed',
+        conclusion: 'success',
+        branch: 'main',
+        sha: 'abc123def456',
+        event: 'push',
+        startedAt: new Date('2026-03-30T12:00:00.000Z'),
+        finishedAt: new Date('2026-03-30T12:05:00.000Z'),
+        durationMs: 300000,
+      },
+    });
+  });
+
+  it('should list workflow runs by workflow ordered by newest startedAt first', async () => {
+    const workflowRunCreate = vi.fn();
+    const workflowRunUpsert = vi.fn();
+    const workflowRunFindMany = vi.fn().mockResolvedValue([
+      buildRunRecord({
+        id: 'run_2',
+        githubRunId: '2',
+        startedAt: new Date('2026-03-30T12:10:00.000Z'),
+      }),
+      buildRunRecord({
+        id: 'run_1',
+        githubRunId: '1',
+        startedAt: new Date('2026-03-30T12:00:00.000Z'),
+      }),
+    ]);
+    const workflowJobCreate = vi.fn();
+    const workflowJobUpsert = vi.fn();
+    const workflowJobFindMany = vi.fn();
+    const repository = new PrismaWorkflowRunRepository({
+      workflowRun: {
+        create: workflowRunCreate,
+        upsert: workflowRunUpsert,
+        findMany: workflowRunFindMany,
+      },
+      workflowJob: {
+        create: workflowJobCreate,
+        upsert: workflowJobUpsert,
+        findMany: workflowJobFindMany,
+      },
+    });
+
+    await expect(repository.listRunsByWorkflowId('workflow_123')).resolves.toEqual([
+      buildRunRecord({
+        id: 'run_2',
+        githubRunId: '2',
+        startedAt: new Date('2026-03-30T12:10:00.000Z'),
+      }),
+      buildRunRecord({
+        id: 'run_1',
+        githubRunId: '1',
+        startedAt: new Date('2026-03-30T12:00:00.000Z'),
+      }),
+    ]);
+
+    expect(workflowRunFindMany).toHaveBeenCalledWith({
+      where: {
+        workflowId: 'workflow_123',
+      },
+      orderBy: [{ startedAt: 'desc' }, { createdAt: 'desc' }],
+    });
+  });
+
+  it('should translate unique constraint errors into a run domain conflict', async () => {
+    const workflowRunCreate = vi.fn().mockRejectedValue({ code: 'P2002' });
+    const workflowRunUpsert = vi.fn();
+    const workflowRunFindMany = vi.fn();
+    const workflowJobCreate = vi.fn();
+    const workflowJobUpsert = vi.fn();
+    const workflowJobFindMany = vi.fn();
+    const repository = new PrismaWorkflowRunRepository({
+      workflowRun: {
+        create: workflowRunCreate,
+        upsert: workflowRunUpsert,
+        findMany: workflowRunFindMany,
+      },
+      workflowJob: {
+        create: workflowJobCreate,
+        upsert: workflowJobUpsert,
+        findMany: workflowJobFindMany,
+      },
+    });
+
+    await expect(
+      repository.createRun({
+        workflowId: 'workflow_123',
+        githubRunId: '987654321',
+        status: 'completed',
+        conclusion: 'success',
+        branch: 'main',
+        sha: 'abc123def456',
+        event: 'push',
+        startedAt: new Date('2026-03-30T12:00:00.000Z'),
+        finishedAt: new Date('2026-03-30T12:05:00.000Z'),
+        durationMs: 300000,
+      }),
+    ).rejects.toBeInstanceOf(WorkflowRunAlreadyExistsError);
+  });
+
+  it('should upsert workflow runs by workflow and GitHub run id', async () => {
+    const workflowRunCreate = vi.fn();
+    const workflowRunUpsert = vi.fn().mockResolvedValue(
+      buildRunRecord({ status: 'in_progress', conclusion: null }),
+    );
+    const workflowRunFindMany = vi.fn();
+    const workflowJobCreate = vi.fn();
+    const workflowJobUpsert = vi.fn();
+    const workflowJobFindMany = vi.fn();
+    const repository = new PrismaWorkflowRunRepository({
+      workflowRun: {
+        create: workflowRunCreate,
+        upsert: workflowRunUpsert,
+        findMany: workflowRunFindMany,
+      },
+      workflowJob: {
+        create: workflowJobCreate,
+        upsert: workflowJobUpsert,
+        findMany: workflowJobFindMany,
+      },
+    });
+
+    await expect(
+      repository.upsertRun({
+        workflowId: 'workflow_123',
+        githubRunId: '987654321',
+        status: 'in_progress',
+        conclusion: null,
+        branch: 'main',
+        sha: 'abc123def456',
+        event: 'push',
+        startedAt: new Date('2026-03-30T12:00:00.000Z'),
+        finishedAt: null,
+        durationMs: null,
+      }),
+    ).resolves.toEqual(buildRunRecord({ status: 'in_progress', conclusion: null }));
+
+    expect(workflowRunUpsert).toHaveBeenCalledWith({
+      where: {
+        workflowId_githubRunId: {
+          workflowId: 'workflow_123',
+          githubRunId: '987654321',
+        },
+      },
+      create: {
+        workflowId: 'workflow_123',
+        githubRunId: '987654321',
+        status: 'in_progress',
+        conclusion: null,
+        branch: 'main',
+        sha: 'abc123def456',
+        event: 'push',
+        startedAt: new Date('2026-03-30T12:00:00.000Z'),
+        finishedAt: null,
+        durationMs: null,
+      },
+      update: {
+        status: 'in_progress',
+        conclusion: null,
+        branch: 'main',
+        sha: 'abc123def456',
+        event: 'push',
+        startedAt: new Date('2026-03-30T12:00:00.000Z'),
+        finishedAt: null,
+        durationMs: null,
+      },
+    });
+  });
+
+  it('should create and map a workflow job record', async () => {
+    const workflowRunCreate = vi.fn();
+    const workflowRunUpsert = vi.fn();
+    const workflowRunFindMany = vi.fn();
+    const workflowJobCreate = vi.fn().mockResolvedValue(buildJobRecord());
+    const workflowJobUpsert = vi.fn();
+    const workflowJobFindMany = vi.fn();
+    const repository = new PrismaWorkflowRunRepository({
+      workflowRun: {
+        create: workflowRunCreate,
+        upsert: workflowRunUpsert,
+        findMany: workflowRunFindMany,
+      },
+      workflowJob: {
+        create: workflowJobCreate,
+        upsert: workflowJobUpsert,
+        findMany: workflowJobFindMany,
+      },
+    });
+
+    await expect(
+      repository.createJob({
+        workflowRunId: 'run_123',
+        githubJobId: '123456789',
+        name: 'lint',
+        status: 'completed',
+        conclusion: 'success',
+        startedAt: new Date('2026-03-30T12:01:00.000Z'),
+        finishedAt: new Date('2026-03-30T12:02:00.000Z'),
+      }),
+    ).resolves.toEqual(buildJobRecord());
+
+    expect(workflowJobCreate).toHaveBeenCalledWith({
+      data: {
+        workflowRunId: 'run_123',
+        githubJobId: '123456789',
+        name: 'lint',
+        status: 'completed',
+        conclusion: 'success',
+        startedAt: new Date('2026-03-30T12:01:00.000Z'),
+        finishedAt: new Date('2026-03-30T12:02:00.000Z'),
+      },
+    });
+  });
+
+  it('should list workflow jobs by run ordered by newest startedAt first', async () => {
+    const workflowRunCreate = vi.fn();
+    const workflowRunUpsert = vi.fn();
+    const workflowRunFindMany = vi.fn();
+    const workflowJobCreate = vi.fn();
+    const workflowJobUpsert = vi.fn();
+    const workflowJobFindMany = vi.fn().mockResolvedValue([
+      buildJobRecord({
+        id: 'job_2',
+        githubJobId: '2',
+        name: 'test',
+        startedAt: new Date('2026-03-30T12:03:00.000Z'),
+      }),
+      buildJobRecord({
+        id: 'job_1',
+        githubJobId: '1',
+        name: 'lint',
+        startedAt: new Date('2026-03-30T12:01:00.000Z'),
+      }),
+    ]);
+    const repository = new PrismaWorkflowRunRepository({
+      workflowRun: {
+        create: workflowRunCreate,
+        upsert: workflowRunUpsert,
+        findMany: workflowRunFindMany,
+      },
+      workflowJob: {
+        create: workflowJobCreate,
+        upsert: workflowJobUpsert,
+        findMany: workflowJobFindMany,
+      },
+    });
+
+    await expect(repository.listJobsByWorkflowRunId('run_123')).resolves.toEqual([
+      buildJobRecord({
+        id: 'job_2',
+        githubJobId: '2',
+        name: 'test',
+        startedAt: new Date('2026-03-30T12:03:00.000Z'),
+      }),
+      buildJobRecord({
+        id: 'job_1',
+        githubJobId: '1',
+        name: 'lint',
+        startedAt: new Date('2026-03-30T12:01:00.000Z'),
+      }),
+    ]);
+
+    expect(workflowJobFindMany).toHaveBeenCalledWith({
+      where: {
+        workflowRunId: 'run_123',
+      },
+      orderBy: [{ startedAt: 'desc' }, { createdAt: 'desc' }],
+    });
+  });
+
+  it('should translate unique constraint errors into a job domain conflict', async () => {
+    const workflowRunCreate = vi.fn();
+    const workflowRunUpsert = vi.fn();
+    const workflowRunFindMany = vi.fn();
+    const workflowJobCreate = vi.fn().mockRejectedValue({ code: 'P2002' });
+    const workflowJobUpsert = vi.fn();
+    const workflowJobFindMany = vi.fn();
+    const repository = new PrismaWorkflowRunRepository({
+      workflowRun: {
+        create: workflowRunCreate,
+        upsert: workflowRunUpsert,
+        findMany: workflowRunFindMany,
+      },
+      workflowJob: {
+        create: workflowJobCreate,
+        upsert: workflowJobUpsert,
+        findMany: workflowJobFindMany,
+      },
+    });
+
+    await expect(
+      repository.createJob({
+        workflowRunId: 'run_123',
+        githubJobId: '123456789',
+        name: 'lint',
+        status: 'completed',
+        conclusion: 'success',
+        startedAt: new Date('2026-03-30T12:01:00.000Z'),
+        finishedAt: new Date('2026-03-30T12:02:00.000Z'),
+      }),
+    ).rejects.toBeInstanceOf(WorkflowJobAlreadyExistsError);
+  });
+
+  it('should upsert jobs by run and GitHub job id', async () => {
+    const workflowRunCreate = vi.fn();
+    const workflowRunUpsert = vi.fn();
+    const workflowRunFindMany = vi.fn();
+    const workflowJobCreate = vi.fn();
+    const workflowJobUpsert = vi.fn().mockResolvedValue(
+      buildJobRecord({ status: 'in_progress', conclusion: null }),
+    );
+    const workflowJobFindMany = vi.fn();
+    const repository = new PrismaWorkflowRunRepository({
+      workflowRun: {
+        create: workflowRunCreate,
+        upsert: workflowRunUpsert,
+        findMany: workflowRunFindMany,
+      },
+      workflowJob: {
+        create: workflowJobCreate,
+        upsert: workflowJobUpsert,
+        findMany: workflowJobFindMany,
+      },
+    });
+
+    await expect(
+      repository.upsertJob({
+        workflowRunId: 'run_123',
+        githubJobId: '123456789',
+        name: 'lint',
+        status: 'in_progress',
+        conclusion: null,
+        startedAt: new Date('2026-03-30T12:01:00.000Z'),
+        finishedAt: null,
+      }),
+    ).resolves.toEqual(buildJobRecord({ status: 'in_progress', conclusion: null }));
+
+    expect(workflowJobUpsert).toHaveBeenCalledWith({
+      where: {
+        workflowRunId_githubJobId: {
+          workflowRunId: 'run_123',
+          githubJobId: '123456789',
+        },
+      },
+      create: {
+        workflowRunId: 'run_123',
+        githubJobId: '123456789',
+        name: 'lint',
+        status: 'in_progress',
+        conclusion: null,
+        startedAt: new Date('2026-03-30T12:01:00.000Z'),
+        finishedAt: null,
+      },
+      update: {
+        name: 'lint',
+        status: 'in_progress',
+        conclusion: null,
+        startedAt: new Date('2026-03-30T12:01:00.000Z'),
+        finishedAt: null,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Prisma persistence baseline for workflow runs and workflow jobs
- model status and conclusion enums with idempotent uniqueness constraints for future sync
- cover the new repositories with tests for mapping, listing, upsert, and conflict handling

## Validation
- npm.cmd --prefix backend run prisma:generate
- npm.cmd --prefix backend run prisma:validate
- npm.cmd --prefix backend run lint
- npm.cmd --prefix backend run typecheck
- npm.cmd --prefix backend run test
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run test

## Issue
Closes #63