### PR TITLE
feat(workflow-runs): sync cataloged workflow runs

### DIFF
--- a/backend/src/app/create-server.ts
+++ b/backend/src/app/create-server.ts
@@ -19,6 +19,9 @@ import { RepositoryService } from '../modules/repository-registry/repository.ser
 import { PrismaWorkflowRepository } from '../modules/workflow-catalog/workflow.prisma-repository.js';
 import type { WorkflowRepository } from '../modules/workflow-catalog/workflow.repository.js';
 import { WorkflowService } from '../modules/workflow-catalog/workflow.service.js';
+import { PrismaWorkflowRunRepository } from '../modules/workflow-runs/workflow-run.prisma-repository.js';
+import type { WorkflowRunRepository } from '../modules/workflow-runs/workflow-run.repository.js';
+import { WorkflowRunService } from '../modules/workflow-runs/workflow-run.service.js';
 import type { OperatorAuthVerifier } from '../shared/auth/operator-auth-verifier.js';
 
 export interface CreateServerOptions {
@@ -29,6 +32,7 @@ export interface CreateServerOptions {
   githubBoundary?: GitHubAppBoundary;
   repositoryRegistryRepository?: RepositoryRepository;
   workflowCatalogRepository?: WorkflowRepository;
+  workflowRunRepository?: WorkflowRunRepository;
 }
 
 export const createServer = (options: CreateServerOptions) => {
@@ -46,7 +50,9 @@ export const createServer = (options: CreateServerOptions) => {
   );
 
   const prismaClient =
-    options.repositoryRegistryRepository && options.workflowCatalogRepository
+    options.repositoryRegistryRepository &&
+    options.workflowCatalogRepository &&
+    options.workflowRunRepository
       ? null
       : createPrismaClient();
   const githubBoundary =
@@ -60,6 +66,12 @@ export const createServer = (options: CreateServerOptions) => {
   const workflowCatalogRepository =
     options.workflowCatalogRepository ??
     new PrismaWorkflowRepository(prismaClient!.workflow);
+  const workflowRunRepository =
+    options.workflowRunRepository ??
+    new PrismaWorkflowRunRepository({
+      workflowRun: prismaClient!.workflowRun,
+      workflowJob: prismaClient!.workflowJob,
+    });
   const healthService = new HealthService({
     githubBoundary,
     repository: healthRepository,
@@ -70,10 +82,18 @@ export const createServer = (options: CreateServerOptions) => {
     githubBoundary,
     logger: app.log,
   });
+  const workflowRunService = new WorkflowRunService({
+    repositoryRegistryRepository,
+    workflowRepository: workflowCatalogRepository,
+    workflowRunRepository,
+    githubBoundary,
+    logger: app.log,
+  });
   const repositoryService = new RepositoryService({
     repository: repositoryRegistryRepository,
     githubBoundary,
     workflowCatalogSync: workflowService,
+    workflowRunSync: workflowRunService,
     logger: app.log,
   });
 

--- a/backend/src/modules/github/github-app.boundary.ts
+++ b/backend/src/modules/github/github-app.boundary.ts
@@ -3,6 +3,10 @@ import {
   GitHubAppProvider,
   type GitHubAppProviderOptions,
 } from './providers/github-app.provider.js';
+import type {
+  WorkflowExecutionConclusion,
+  WorkflowExecutionStatus,
+} from '../workflow-runs/workflow-run.entity.js';
 
 export interface GitHubRepositoryDescriptor {
   owner: string;
@@ -31,6 +35,27 @@ export interface GitHubWorkflowDescriptor {
   sourceType: 'local' | 'reusable';
 }
 
+export interface GitHubWorkflowRunDescriptor {
+  githubRunId: string;
+  status: WorkflowExecutionStatus;
+  conclusion: WorkflowExecutionConclusion | null;
+  branch: string;
+  sha: string;
+  event: string;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  durationMs: number | null;
+}
+
+export interface GitHubWorkflowJobDescriptor {
+  githubJobId: string;
+  name: string;
+  status: WorkflowExecutionStatus;
+  conclusion: WorkflowExecutionConclusion | null;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+}
+
 export interface GitHubAppBoundary {
   readonly mode: 'github-app';
   readonly configured: boolean;
@@ -40,6 +65,14 @@ export interface GitHubAppBoundary {
   listRepositoryWorkflows(
     repository: GitHubRepositoryDescriptor,
   ): Promise<GitHubWorkflowDescriptor[]>;
+  listWorkflowRuns(
+    repository: GitHubRepositoryDescriptor,
+    workflowId: string,
+  ): Promise<GitHubWorkflowRunDescriptor[]>;
+  listWorkflowRunJobs(
+    repository: GitHubRepositoryDescriptor,
+    workflowRunId: string,
+  ): Promise<GitHubWorkflowJobDescriptor[]>;
 }
 
 export interface GitHubAppStatus {

--- a/backend/src/modules/github/github-app.errors.ts
+++ b/backend/src/modules/github/github-app.errors.ts
@@ -20,6 +20,16 @@ export class GitHubWorkflowCatalogSyncError extends ApplicationError {
   }
 }
 
+export class GitHubWorkflowRunsSyncError extends ApplicationError {
+  constructor() {
+    super(
+      'GitHub workflow runs are currently unavailable.',
+      503,
+      'github_workflow_runs_unavailable',
+    );
+  }
+}
+
 export class GitHubWebhookVerificationError extends ApplicationError {
   constructor() {
     super(

--- a/backend/src/modules/github/providers/github-app.provider.ts
+++ b/backend/src/modules/github/providers/github-app.provider.ts
@@ -6,13 +6,20 @@ import type {
   GitHubAppStatus,
   GitHubRepositoryDescriptor,
   GitHubWorkflowDescriptor,
+  GitHubWorkflowJobDescriptor,
+  GitHubWorkflowRunDescriptor,
 } from '../github-app.boundary.js';
 import type { GitHubAppEnv } from '../../../infra/config/github-app-env.js';
 import { ConfigurationError } from '../../../shared/errors/configuration-error.js';
 import {
   GitHubRepositoryDiscoveryError,
   GitHubWorkflowCatalogSyncError,
+  GitHubWorkflowRunsSyncError,
 } from '../github-app.errors.js';
+import type {
+  WorkflowExecutionConclusion,
+  WorkflowExecutionStatus,
+} from '../../workflow-runs/workflow-run.entity.js';
 
 const githubInstallationAccessTokenSchema = z.object({
   token: z.string().trim().min(1),
@@ -46,6 +53,34 @@ const githubRepositoryWorkflowsSchema = z.object({
         'disabled_inactivity',
         'disabled_manually',
       ]),
+    }),
+  ),
+});
+
+const githubWorkflowRunsSchema = z.object({
+  workflow_runs: z.array(
+    z.object({
+      id: z.number().int().nonnegative(),
+      status: z.string().trim().min(1),
+      conclusion: z.string().trim().min(1).nullable(),
+      head_branch: z.string().trim().min(1),
+      head_sha: z.string().trim().min(1),
+      event: z.string().trim().min(1),
+      run_started_at: z.string().trim().min(1).nullable(),
+      updated_at: z.string().trim().min(1),
+    }),
+  ),
+});
+
+const githubWorkflowRunJobsSchema = z.object({
+  jobs: z.array(
+    z.object({
+      id: z.number().int().nonnegative(),
+      name: z.string().trim().min(1),
+      status: z.string().trim().min(1),
+      conclusion: z.string().trim().min(1).nullable(),
+      started_at: z.string().trim().min(1).nullable(),
+      completed_at: z.string().trim().min(1).nullable(),
     }),
   ),
 });
@@ -181,6 +216,68 @@ export class GitHubAppProvider implements GitHubAppBoundary {
     }
   }
 
+  public async listWorkflowRuns(
+    repository: GitHubRepositoryDescriptor,
+    workflowId: string,
+  ): Promise<GitHubWorkflowRunDescriptor[]> {
+    this.assertConfigured();
+
+    try {
+      const installationToken = await this.createInstallationAccessToken();
+      const payload = await this.requestJson(
+        `${this.apiBaseUrl}/repos/${repository.owner}/${repository.name}/actions/workflows/${workflowId}/runs?per_page=20`,
+        {
+          method: 'GET',
+          headers: this.createJsonHeaders(`Bearer ${installationToken}`),
+        },
+        githubWorkflowRunsSchema,
+      );
+
+      return payload.workflow_runs.map((workflowRun) =>
+        mapGitHubWorkflowRunDescriptor(workflowRun),
+      );
+    } catch (error) {
+      if (
+        error instanceof ConfigurationError ||
+        error instanceof GitHubWorkflowRunsSyncError
+      ) {
+        throw error;
+      }
+
+      throw new GitHubWorkflowRunsSyncError();
+    }
+  }
+
+  public async listWorkflowRunJobs(
+    repository: GitHubRepositoryDescriptor,
+    workflowRunId: string,
+  ): Promise<GitHubWorkflowJobDescriptor[]> {
+    this.assertConfigured();
+
+    try {
+      const installationToken = await this.createInstallationAccessToken();
+      const payload = await this.requestJson(
+        `${this.apiBaseUrl}/repos/${repository.owner}/${repository.name}/actions/runs/${workflowRunId}/jobs?per_page=100`,
+        {
+          method: 'GET',
+          headers: this.createJsonHeaders(`Bearer ${installationToken}`),
+        },
+        githubWorkflowRunJobsSchema,
+      );
+
+      return payload.jobs.map((job) => mapGitHubWorkflowJobDescriptor(job));
+    } catch (error) {
+      if (
+        error instanceof ConfigurationError ||
+        error instanceof GitHubWorkflowRunsSyncError
+      ) {
+        throw error;
+      }
+
+      throw new GitHubWorkflowRunsSyncError();
+    }
+  }
+
   private async createInstallationAccessToken(): Promise<string> {
     const config = this.config;
 
@@ -224,7 +321,7 @@ export class GitHubAppProvider implements GitHubAppBoundary {
     });
 
     if (!response.ok) {
-      throw new GitHubRepositoryDiscoveryError();
+      throw new Error(`GitHub request failed with status ${response.status}.`);
     }
 
     const payload: unknown = await response.json();
@@ -262,4 +359,97 @@ const createGitHubAppJwt = (config: GitHubAppEnv, now: Date): string => {
   ).toString('base64url');
 
   return `${signingInput}.${signature}`;
+};
+
+const mapGitHubWorkflowRunDescriptor = (
+  workflowRun: z.infer<typeof githubWorkflowRunsSchema>['workflow_runs'][number],
+): GitHubWorkflowRunDescriptor => {
+  const status = mapWorkflowExecutionStatus(workflowRun.status);
+  const startedAt = parseGitHubDate(workflowRun.run_started_at);
+  const finishedAt =
+    status === 'completed' ? parseGitHubDate(workflowRun.updated_at) : null;
+
+  return {
+    githubRunId: String(workflowRun.id),
+    status,
+    conclusion: mapWorkflowExecutionConclusion(workflowRun.conclusion),
+    branch: workflowRun.head_branch,
+    sha: workflowRun.head_sha,
+    event: workflowRun.event,
+    startedAt,
+    finishedAt,
+    durationMs: calculateDurationMs(startedAt, finishedAt),
+  };
+};
+
+const mapGitHubWorkflowJobDescriptor = (
+  workflowJob: z.infer<typeof githubWorkflowRunJobsSchema>['jobs'][number],
+): GitHubWorkflowJobDescriptor => {
+  return {
+    githubJobId: String(workflowJob.id),
+    name: workflowJob.name,
+    status: mapWorkflowExecutionStatus(workflowJob.status),
+    conclusion: mapWorkflowExecutionConclusion(workflowJob.conclusion),
+    startedAt: parseGitHubDate(workflowJob.started_at),
+    finishedAt: parseGitHubDate(workflowJob.completed_at),
+  };
+};
+
+const mapWorkflowExecutionStatus = (
+  value: string,
+): WorkflowExecutionStatus => {
+  switch (value) {
+    case 'queued':
+    case 'in_progress':
+    case 'completed':
+    case 'pending':
+    case 'waiting':
+    case 'requested':
+      return value;
+    default:
+      throw new GitHubWorkflowRunsSyncError();
+  }
+};
+
+const mapWorkflowExecutionConclusion = (
+  value: string | null,
+): WorkflowExecutionConclusion | null => {
+  if (value === null) {
+    return null;
+  }
+
+  switch (value) {
+    case 'success':
+    case 'failure':
+    case 'neutral':
+    case 'cancelled':
+    case 'skipped':
+    case 'timed_out':
+    case 'action_required':
+    case 'stale':
+    case 'startup_failure':
+      return value;
+    default:
+      throw new GitHubWorkflowRunsSyncError();
+  }
+};
+
+const parseGitHubDate = (value: string | null): Date | null => {
+  if (value === null) {
+    return null;
+  }
+
+  return new Date(value);
+};
+
+const calculateDurationMs = (
+  startedAt: Date | null,
+  finishedAt: Date | null,
+): number | null => {
+  if (!startedAt || !finishedAt) {
+    return null;
+  }
+
+  const durationMs = finishedAt.getTime() - startedAt.getTime();
+  return durationMs >= 0 ? durationMs : null;
 };

--- a/backend/src/modules/repository-registry/repository.service.ts
+++ b/backend/src/modules/repository-registry/repository.service.ts
@@ -14,6 +14,9 @@ type ServiceLogger = Pick<Logger, 'info' | 'error'>;
 type WorkflowCatalogSync = {
   syncByRepositoryId(repositoryId: string): Promise<unknown[]>;
 };
+type WorkflowRunSync = {
+  syncByRepositoryId(repositoryId: string): Promise<unknown[]>;
+};
 
 const noopLogger: ServiceLogger = {
   info: () => undefined,
@@ -24,6 +27,7 @@ export interface RepositoryServiceOptions {
   repository: RepositoryRepository;
   githubBoundary: GitHubAppBoundary;
   workflowCatalogSync?: WorkflowCatalogSync;
+  workflowRunSync?: WorkflowRunSync;
   logger?: ServiceLogger;
 }
 
@@ -38,9 +42,13 @@ export class RepositoryService {
     try {
       const repository = await this.options.repository.create(input);
       let syncedWorkflows: unknown[] | undefined;
+      let syncedWorkflowRuns: unknown[] | undefined;
 
       try {
         syncedWorkflows = await this.options.workflowCatalogSync?.syncByRepositoryId(
+          repository.id,
+        );
+        syncedWorkflowRuns = await this.options.workflowRunSync?.syncByRepositoryId(
           repository.id,
         );
       } catch (error) {
@@ -57,6 +65,7 @@ export class RepositoryService {
           githubRepoId: repository.githubRepoId,
           fullName: repository.fullName,
           syncedWorkflowCount: syncedWorkflows?.length ?? 0,
+          syncedWorkflowRunCount: syncedWorkflowRuns?.length ?? 0,
         },
         'Repository ingestion completed.',
       );

--- a/backend/src/modules/workflow-runs/workflow-run.service.ts
+++ b/backend/src/modules/workflow-runs/workflow-run.service.ts
@@ -1,0 +1,154 @@
+import type { Logger } from 'pino';
+import { ApplicationError } from '../../shared/errors/application-error.js';
+import type { GitHubAppBoundary } from '../github/github-app.boundary.js';
+import { RepositoryNotFoundError } from '../repository-registry/repository.errors.js';
+import type { RepositoryRepository } from '../repository-registry/repository.repository.js';
+import type { WorkflowRepository } from '../workflow-catalog/workflow.repository.js';
+import type { WorkflowRun } from './workflow-run.entity.js';
+import type { WorkflowRunRepository } from './workflow-run.repository.js';
+
+type ServiceLogger = Pick<Logger, 'info' | 'error'>;
+
+const noopLogger: ServiceLogger = {
+  info: () => undefined,
+  error: () => undefined,
+};
+
+export interface WorkflowRunServiceOptions {
+  repositoryRegistryRepository: RepositoryRepository;
+  workflowRepository: WorkflowRepository;
+  workflowRunRepository: WorkflowRunRepository;
+  githubBoundary: GitHubAppBoundary;
+  logger?: ServiceLogger;
+}
+
+export class WorkflowRunService {
+  constructor(private readonly options: WorkflowRunServiceOptions) {}
+
+  async syncByRepositoryId(repositoryId: string): Promise<WorkflowRun[]> {
+    const repository =
+      await this.options.repositoryRegistryRepository.findById(repositoryId);
+
+    if (!repository) {
+      const error = new RepositoryNotFoundError();
+
+      this.logger.error(
+        {
+          event: 'workflow_runs_sync_failed',
+          repositoryId,
+          errorCode: error.code,
+          errorStatusCode: error.statusCode,
+        },
+        'Workflow runs sync failed.',
+      );
+
+      throw error;
+    }
+
+    try {
+      const workflows = await this.options.workflowRepository.listByRepositoryId(
+        repositoryId,
+      );
+      const syncedRuns: WorkflowRun[] = [];
+      let syncedJobCount = 0;
+
+      for (const workflow of workflows) {
+        const remoteRuns = await this.options.githubBoundary.listWorkflowRuns(
+          {
+            owner: repository.owner,
+            name: repository.name,
+          },
+          workflow.githubWorkflowId,
+        );
+
+        for (const remoteRun of remoteRuns) {
+          const persistedRun = await this.options.workflowRunRepository.upsertRun({
+            workflowId: workflow.id,
+            githubRunId: remoteRun.githubRunId,
+            status: remoteRun.status,
+            conclusion: remoteRun.conclusion,
+            branch: remoteRun.branch,
+            sha: remoteRun.sha,
+            event: remoteRun.event,
+            startedAt: remoteRun.startedAt,
+            finishedAt: remoteRun.finishedAt,
+            durationMs: remoteRun.durationMs,
+          });
+
+          syncedRuns.push(persistedRun);
+
+          const remoteJobs = await this.options.githubBoundary.listWorkflowRunJobs(
+            {
+              owner: repository.owner,
+              name: repository.name,
+            },
+            remoteRun.githubRunId,
+          );
+
+          for (const remoteJob of remoteJobs) {
+            await this.options.workflowRunRepository.upsertJob({
+              workflowRunId: persistedRun.id,
+              githubJobId: remoteJob.githubJobId,
+              name: remoteJob.name,
+              status: remoteJob.status,
+              conclusion: remoteJob.conclusion,
+              startedAt: remoteJob.startedAt,
+              finishedAt: remoteJob.finishedAt,
+            });
+
+            syncedJobCount += 1;
+          }
+        }
+      }
+
+      this.logger.info(
+        {
+          event: 'workflow_runs_sync_succeeded',
+          repositoryId: repository.id,
+          fullName: repository.fullName,
+          catalogedWorkflowCount: workflows.length,
+          syncedRunCount: syncedRuns.length,
+          syncedJobCount,
+        },
+        'Workflow runs sync completed.',
+      );
+
+      return syncedRuns;
+    } catch (error) {
+      this.logger.error(
+        {
+          event: 'workflow_runs_sync_failed',
+          repositoryId: repository.id,
+          fullName: repository.fullName,
+          ...serializeApplicationError(error),
+        },
+        'Workflow runs sync failed.',
+      );
+
+      throw error;
+    }
+  }
+
+  private get logger(): ServiceLogger {
+    return this.options.logger ?? noopLogger;
+  }
+}
+
+const serializeApplicationError = (error: unknown): Record<string, string | number> => {
+  if (error instanceof ApplicationError) {
+    return {
+      errorCode: error.code,
+      errorStatusCode: error.statusCode,
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      errorName: error.name,
+    };
+  }
+
+  return {
+    errorName: 'UnknownError',
+  };
+};

--- a/backend/src/tests/app/create-server.test.ts
+++ b/backend/src/tests/app/create-server.test.ts
@@ -12,6 +12,10 @@ import type {
 } from '../../modules/repository-registry/repository.entity.js';
 import type { GitHubInstallationRepository } from '../../modules/github/github-app.boundary.js';
 import type { Workflow } from '../../modules/workflow-catalog/workflow.entity.js';
+import type {
+  WorkflowJob,
+  WorkflowRun,
+} from '../../modules/workflow-runs/workflow-run.entity.js';
 
 const buildRepository = (
   overrides: Partial<Repository> = {},
@@ -76,6 +80,45 @@ const buildWorkflow = (overrides: Partial<Workflow> = {}): Workflow => {
   };
 };
 
+const buildWorkflowRun = (overrides: Partial<WorkflowRun> = {}): WorkflowRun => {
+  const startedAt = new Date('2026-03-30T16:00:00.000Z');
+
+  return {
+    id: 'run_123',
+    workflowId: 'workflow_123',
+    githubRunId: 'run-gh-123',
+    status: 'completed',
+    conclusion: 'success',
+    branch: 'main',
+    sha: 'abc123def456',
+    event: 'push',
+    startedAt,
+    finishedAt: new Date('2026-03-30T16:05:00.000Z'),
+    durationMs: 300000,
+    createdAt: startedAt,
+    updatedAt: startedAt,
+    ...overrides,
+  };
+};
+
+const buildWorkflowJob = (overrides: Partial<WorkflowJob> = {}): WorkflowJob => {
+  const startedAt = new Date('2026-03-30T16:01:00.000Z');
+
+  return {
+    id: 'job_123',
+    workflowRunId: 'run_123',
+    githubJobId: 'job-gh-123',
+    name: 'lint',
+    status: 'completed',
+    conclusion: 'success',
+    startedAt,
+    finishedAt: new Date('2026-03-30T16:02:00.000Z'),
+    createdAt: startedAt,
+    updatedAt: startedAt,
+    ...overrides,
+  };
+};
+
 const createProtectedServer = (overrides?: {
   repositories?: Repository[];
   workflows?: Workflow[];
@@ -95,6 +138,8 @@ const createProtectedServer = (overrides?: {
 }) => {
   const repositoryStore = [...(overrides?.repositories ?? [])];
   const workflowStore = [...(overrides?.workflows ?? [])];
+  const workflowRunStore: WorkflowRun[] = [];
+  const workflowJobStore: WorkflowJob[] = [];
 
   return createServer({
     env: {
@@ -155,6 +200,8 @@ const createProtectedServer = (overrides?: {
           ]
         );
       },
+      listWorkflowRuns: async () => [],
+      listWorkflowRunJobs: async () => [],
     },
     repositoryRegistryRepository: {
       list: async () => [...repositoryStore],
@@ -219,6 +266,94 @@ const createProtectedServer = (overrides?: {
       },
       listByRepositoryId: async (repositoryId) =>
         workflowStore.filter((workflow) => workflow.repositoryId === repositoryId),
+    },
+    workflowRunRepository: {
+      createRun: async (input) =>
+        buildWorkflowRun({
+          workflowId: input.workflowId,
+          githubRunId: input.githubRunId,
+          status: input.status,
+          conclusion: input.conclusion,
+          branch: input.branch,
+          sha: input.sha,
+          event: input.event,
+          startedAt: input.startedAt,
+          finishedAt: input.finishedAt,
+          durationMs: input.durationMs,
+        }),
+      upsertRun: async (input) => {
+        const existingRunIndex = workflowRunStore.findIndex(
+          (workflowRun) =>
+            workflowRun.workflowId === input.workflowId &&
+            workflowRun.githubRunId === input.githubRunId,
+        );
+        const workflowRun = buildWorkflowRun({
+          id:
+            existingRunIndex >= 0
+              ? workflowRunStore[existingRunIndex]!.id
+              : `run_${workflowRunStore.length + 1}`,
+          workflowId: input.workflowId,
+          githubRunId: input.githubRunId,
+          status: input.status,
+          conclusion: input.conclusion,
+          branch: input.branch,
+          sha: input.sha,
+          event: input.event,
+          startedAt: input.startedAt,
+          finishedAt: input.finishedAt,
+          durationMs: input.durationMs,
+        });
+
+        if (existingRunIndex >= 0) {
+          workflowRunStore[existingRunIndex] = workflowRun;
+        } else {
+          workflowRunStore.push(workflowRun);
+        }
+
+        return workflowRun;
+      },
+      listRunsByWorkflowId: async (workflowId) =>
+        workflowRunStore.filter((workflowRun) => workflowRun.workflowId === workflowId),
+      createJob: async (input) =>
+        buildWorkflowJob({
+          workflowRunId: input.workflowRunId,
+          githubJobId: input.githubJobId,
+          name: input.name,
+          status: input.status,
+          conclusion: input.conclusion,
+          startedAt: input.startedAt,
+          finishedAt: input.finishedAt,
+        }),
+      upsertJob: async (input) => {
+        const existingJobIndex = workflowJobStore.findIndex(
+          (workflowJob) =>
+            workflowJob.workflowRunId === input.workflowRunId &&
+            workflowJob.githubJobId === input.githubJobId,
+        );
+        const workflowJob = buildWorkflowJob({
+          id:
+            existingJobIndex >= 0
+              ? workflowJobStore[existingJobIndex]!.id
+              : `job_${workflowJobStore.length + 1}`,
+          workflowRunId: input.workflowRunId,
+          githubJobId: input.githubJobId,
+          name: input.name,
+          status: input.status,
+          conclusion: input.conclusion,
+          startedAt: input.startedAt,
+          finishedAt: input.finishedAt,
+        });
+
+        if (existingJobIndex >= 0) {
+          workflowJobStore[existingJobIndex] = workflowJob;
+        } else {
+          workflowJobStore.push(workflowJob);
+        }
+
+        return workflowJob;
+      },
+      listJobsByWorkflowRunId: async (workflowRunId) =>
+        workflowJobStore.filter((workflowJob) => workflowJob.workflowRunId === workflowRunId),
     },
   });
 };

--- a/backend/src/tests/modules/github/github-app.provider.test.ts
+++ b/backend/src/tests/modules/github/github-app.provider.test.ts
@@ -3,6 +3,7 @@ import { createGitHubAppBoundary } from '../../../modules/github/github-app.boun
 import {
   GitHubRepositoryDiscoveryError,
   GitHubWorkflowCatalogSyncError,
+  GitHubWorkflowRunsSyncError,
 } from '../../../modules/github/github-app.errors.js';
 
 const buildConfig = () => ({
@@ -215,5 +216,234 @@ describe('GitHubAppProvider', () => {
       message: 'GitHub workflow catalog is currently unavailable.',
       statusCode: 503,
     });
+  });
+
+  it('should exchange credentials and normalize workflow runs', async () => {
+    const fetchImplementation = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: 'installation-token' }), {
+          status: 201,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            workflow_runs: [
+              {
+                id: 777,
+                status: 'completed',
+                conclusion: 'success',
+                head_branch: 'main',
+                head_sha: 'abc123def456',
+                event: 'push',
+                run_started_at: '2026-03-30T12:00:00.000Z',
+                updated_at: '2026-03-30T12:05:00.000Z',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+    const boundary = createGitHubAppBoundary(buildConfig(), {
+      apiBaseUrl: 'https://api.github.test',
+      fetchImplementation,
+      appJwtFactory: () => 'app-jwt',
+      now: () => new Date('2026-03-30T12:10:00.000Z'),
+    });
+
+    await expect(
+      boundary.listWorkflowRuns(
+        {
+          owner: 'forgeops',
+          name: 'backend',
+        },
+        '555',
+      ),
+    ).resolves.toEqual([
+      {
+        githubRunId: '777',
+        status: 'completed',
+        conclusion: 'success',
+        branch: 'main',
+        sha: 'abc123def456',
+        event: 'push',
+        startedAt: new Date('2026-03-30T12:00:00.000Z'),
+        finishedAt: new Date('2026-03-30T12:05:00.000Z'),
+        durationMs: 300000,
+      },
+    ]);
+
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.test/repos/forgeops/backend/actions/workflows/555/runs?per_page=20',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Accept: 'application/vnd.github+json',
+          Authorization: 'Bearer installation-token',
+        }),
+      }),
+    );
+  });
+
+  it('should exchange credentials and normalize workflow run jobs', async () => {
+    const fetchImplementation = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: 'installation-token' }), {
+          status: 201,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jobs: [
+              {
+                id: 888,
+                name: 'lint',
+                status: 'completed',
+                conclusion: 'success',
+                started_at: '2026-03-30T12:01:00.000Z',
+                completed_at: '2026-03-30T12:02:00.000Z',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+    const boundary = createGitHubAppBoundary(buildConfig(), {
+      apiBaseUrl: 'https://api.github.test',
+      fetchImplementation,
+      appJwtFactory: () => 'app-jwt',
+      now: () => new Date('2026-03-30T12:10:00.000Z'),
+    });
+
+    await expect(
+      boundary.listWorkflowRunJobs(
+        {
+          owner: 'forgeops',
+          name: 'backend',
+        },
+        '777',
+      ),
+    ).resolves.toEqual([
+      {
+        githubJobId: '888',
+        name: 'lint',
+        status: 'completed',
+        conclusion: 'success',
+        startedAt: new Date('2026-03-30T12:01:00.000Z'),
+        finishedAt: new Date('2026-03-30T12:02:00.000Z'),
+      },
+    ]);
+
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.test/repos/forgeops/backend/actions/runs/777/jobs?per_page=100',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Accept: 'application/vnd.github+json',
+          Authorization: 'Bearer installation-token',
+        }),
+      }),
+    );
+  });
+
+  it('should raise a safe workflow runs sync error when run sync fails', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'rate limited' }), {
+        status: 403,
+        headers: {
+          'content-type': 'application/json',
+        },
+      }),
+    );
+    const boundary = createGitHubAppBoundary(buildConfig(), {
+      apiBaseUrl: 'https://api.github.test',
+      fetchImplementation,
+      appJwtFactory: () => 'app-jwt',
+      now: () => new Date('2026-03-30T12:00:00.000Z'),
+    });
+
+    await expect(
+      boundary.listWorkflowRuns(
+        {
+          owner: 'forgeops',
+          name: 'backend',
+        },
+        '555',
+      ),
+    ).rejects.toBeInstanceOf(GitHubWorkflowRunsSyncError);
+  });
+
+  it('should fail safely when GitHub returns an unsupported workflow run status', async () => {
+    const fetchImplementation = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: 'installation-token' }), {
+          status: 201,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            workflow_runs: [
+              {
+                id: 777,
+                status: 'mystery_status',
+                conclusion: null,
+                head_branch: 'main',
+                head_sha: 'abc123def456',
+                event: 'push',
+                run_started_at: null,
+                updated_at: '2026-03-30T12:05:00.000Z',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+    const boundary = createGitHubAppBoundary(buildConfig(), {
+      apiBaseUrl: 'https://api.github.test',
+      fetchImplementation,
+      appJwtFactory: () => 'app-jwt',
+      now: () => new Date('2026-03-30T12:00:00.000Z'),
+    });
+
+    await expect(
+      boundary.listWorkflowRuns(
+        {
+          owner: 'forgeops',
+          name: 'backend',
+        },
+        '555',
+      ),
+    ).rejects.toBeInstanceOf(GitHubWorkflowRunsSyncError);
   });
 });

--- a/backend/src/tests/modules/repository-registry/repository.service.test.ts
+++ b/backend/src/tests/modules/repository-registry/repository.service.test.ts
@@ -4,7 +4,10 @@ import type {
   Repository,
 } from '../../../modules/repository-registry/repository.entity.js';
 import type { GitHubInstallationRepository } from '../../../modules/github/github-app.boundary.js';
-import { GitHubWorkflowCatalogSyncError } from '../../../modules/github/github-app.errors.js';
+import {
+  GitHubWorkflowCatalogSyncError,
+  GitHubWorkflowRunsSyncError,
+} from '../../../modules/github/github-app.errors.js';
 import { RepositoryAlreadyExistsError } from '../../../modules/repository-registry/repository.errors.js';
 import { RepositoryService } from '../../../modules/repository-registry/repository.service.js';
 
@@ -86,6 +89,8 @@ describe('RepositoryService', () => {
         assertConfigured: () => undefined,
         listInstallationRepositories: async () => [],
         listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
       },
     });
 
@@ -104,6 +109,9 @@ describe('RepositoryService', () => {
   it('should delegate repository creation to the repository layer', async () => {
     const create = vi.fn().mockResolvedValue(buildRepository());
     const list = vi.fn();
+    const workflowRunSync = {
+      syncByRepositoryId: vi.fn().mockResolvedValue([]),
+    };
     const logger = {
       info: vi.fn(),
       error: vi.fn(),
@@ -128,15 +136,19 @@ describe('RepositoryService', () => {
         assertConfigured: () => undefined,
         listInstallationRepositories: async () => [],
         listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
       },
       workflowCatalogSync: {
         syncByRepositoryId: vi.fn().mockResolvedValue([]),
       },
+      workflowRunSync,
       logger,
     });
 
     await expect(service.create(buildCreateInput())).resolves.toEqual(buildRepository());
     expect(create).toHaveBeenCalledWith(buildCreateInput());
+    expect(workflowRunSync.syncByRepositoryId).toHaveBeenCalledWith('repo_123');
     expect(logger.info).toHaveBeenCalledWith(
       {
         event: 'repository_ingestion_succeeded',
@@ -144,10 +156,67 @@ describe('RepositoryService', () => {
         githubRepoId: '123456789',
         fullName: 'forgeops/backend',
         syncedWorkflowCount: 0,
+        syncedWorkflowRunCount: 0,
       },
       'Repository ingestion completed.',
     );
     expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('should roll back the repository when workflow run sync fails after catalog sync', async () => {
+    const deleteById = vi.fn().mockResolvedValue(undefined);
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    const service = new RepositoryService({
+      repository: {
+        list: vi.fn(),
+        create: vi.fn().mockResolvedValue(buildRepository()),
+        findById: vi.fn(),
+        deleteById,
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+      },
+      workflowCatalogSync: {
+        syncByRepositoryId: vi.fn().mockResolvedValue([]),
+      },
+      workflowRunSync: {
+        syncByRepositoryId: vi.fn().mockRejectedValue(new GitHubWorkflowRunsSyncError()),
+      },
+      logger,
+    });
+
+    await expect(service.create(buildCreateInput())).rejects.toBeInstanceOf(
+      GitHubWorkflowRunsSyncError,
+    );
+
+    expect(deleteById).toHaveBeenCalledWith('repo_123');
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        event: 'repository_ingestion_failed',
+        repositoryId: 'repo_123',
+        githubRepoId: '123456789',
+        fullName: 'forgeops/backend',
+        errorCode: 'github_workflow_runs_unavailable',
+        errorStatusCode: 503,
+      },
+      'Repository ingestion failed.',
+    );
   });
 
   it('should log repository ingestion failures with safe operational context', async () => {
@@ -175,6 +244,8 @@ describe('RepositoryService', () => {
         assertConfigured: () => undefined,
         listInstallationRepositories: async () => [],
         listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
       },
       workflowCatalogSync: {
         syncByRepositoryId: vi.fn(),
@@ -226,6 +297,8 @@ describe('RepositoryService', () => {
         assertConfigured: () => undefined,
         listInstallationRepositories: async () => [],
         listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
       },
       workflowCatalogSync: {
         syncByRepositoryId: vi
@@ -287,6 +360,8 @@ describe('RepositoryService', () => {
         assertConfigured: () => undefined,
         listInstallationRepositories,
         listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
       },
     });
 

--- a/backend/src/tests/modules/workflow-catalog/workflow.service.test.ts
+++ b/backend/src/tests/modules/workflow-catalog/workflow.service.test.ts
@@ -97,6 +97,8 @@ describe('WorkflowService', () => {
         assertConfigured: () => undefined,
         listInstallationRepositories: async () => [],
         listRepositoryWorkflows,
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
       },
       logger,
     });
@@ -175,6 +177,8 @@ describe('WorkflowService', () => {
         assertConfigured: () => undefined,
         listInstallationRepositories: async () => [],
         listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
       },
       logger,
     });
@@ -226,6 +230,8 @@ describe('WorkflowService', () => {
         listRepositoryWorkflows: async () => {
           throw new GitHubWorkflowCatalogSyncError();
         },
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
       },
       logger,
     });

--- a/backend/src/tests/modules/workflow-runs/workflow-run.service.test.ts
+++ b/backend/src/tests/modules/workflow-runs/workflow-run.service.test.ts
@@ -1,0 +1,473 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GitHubWorkflowRunsSyncError } from '../../../modules/github/github-app.errors.js';
+import type { Repository } from '../../../modules/repository-registry/repository.entity.js';
+import { RepositoryNotFoundError } from '../../../modules/repository-registry/repository.errors.js';
+import type { Workflow } from '../../../modules/workflow-catalog/workflow.entity.js';
+import type { WorkflowJob, WorkflowRun } from '../../../modules/workflow-runs/workflow-run.entity.js';
+import { WorkflowRunService } from '../../../modules/workflow-runs/workflow-run.service.js';
+
+const buildRepository = (overrides: Partial<Repository> = {}): Repository => {
+  const createdAt = new Date('2026-03-30T10:00:00.000Z');
+
+  return {
+    id: 'repo_123',
+    githubRepoId: '123456789',
+    owner: 'forgeops',
+    name: 'backend',
+    fullName: 'forgeops/backend',
+    defaultBranch: 'main',
+    isActive: true,
+    createdAt,
+    updatedAt: createdAt,
+    ...overrides,
+  };
+};
+
+const buildWorkflow = (overrides: Partial<Workflow> = {}): Workflow => {
+  const createdAt = new Date('2026-03-30T10:05:00.000Z');
+
+  return {
+    id: 'workflow_123',
+    repositoryId: 'repo_123',
+    githubWorkflowId: 'workflow-gh-123',
+    name: 'CI',
+    path: '.github/workflows/ci.yml',
+    state: 'active',
+    sourceType: 'local',
+    createdAt,
+    updatedAt: createdAt,
+    ...overrides,
+  };
+};
+
+const buildWorkflowRun = (overrides: Partial<WorkflowRun> = {}): WorkflowRun => {
+  const startedAt = new Date('2026-03-30T12:00:00.000Z');
+
+  return {
+    id: 'run_123',
+    workflowId: 'workflow_123',
+    githubRunId: '777',
+    status: 'completed',
+    conclusion: 'success',
+    branch: 'main',
+    sha: 'abc123def456',
+    event: 'push',
+    startedAt,
+    finishedAt: new Date('2026-03-30T12:05:00.000Z'),
+    durationMs: 300000,
+    createdAt: startedAt,
+    updatedAt: startedAt,
+    ...overrides,
+  };
+};
+
+const buildWorkflowJob = (overrides: Partial<WorkflowJob> = {}): WorkflowJob => {
+  const startedAt = new Date('2026-03-30T12:01:00.000Z');
+
+  return {
+    id: 'job_123',
+    workflowRunId: 'run_123',
+    githubJobId: '888',
+    name: 'lint',
+    status: 'completed',
+    conclusion: 'success',
+    startedAt,
+    finishedAt: new Date('2026-03-30T12:02:00.000Z'),
+    createdAt: startedAt,
+    updatedAt: startedAt,
+    ...overrides,
+  };
+};
+
+describe('WorkflowRunService', () => {
+  it('should sync workflow runs and jobs for cataloged workflows', async () => {
+    const findById = vi.fn().mockResolvedValue(buildRepository());
+    const listByRepositoryId = vi.fn().mockResolvedValue([buildWorkflow()]);
+    const upsertRun = vi
+      .fn()
+      .mockResolvedValueOnce(buildWorkflowRun())
+      .mockResolvedValueOnce(
+        buildWorkflowRun({
+          id: 'run_456',
+          githubRunId: '778',
+          status: 'in_progress',
+          conclusion: null,
+          finishedAt: null,
+          durationMs: null,
+        }),
+      );
+    const upsertJob = vi
+      .fn()
+      .mockResolvedValueOnce(buildWorkflowJob())
+      .mockResolvedValueOnce(
+        buildWorkflowJob({
+          id: 'job_456',
+          workflowRunId: 'run_456',
+          githubJobId: '889',
+          name: 'test',
+          status: 'in_progress',
+          conclusion: null,
+          finishedAt: null,
+        }),
+      );
+    const listWorkflowRuns = vi.fn().mockResolvedValue([
+      {
+        githubRunId: '777',
+        status: 'completed',
+        conclusion: 'success',
+        branch: 'main',
+        sha: 'abc123def456',
+        event: 'push',
+        startedAt: new Date('2026-03-30T12:00:00.000Z'),
+        finishedAt: new Date('2026-03-30T12:05:00.000Z'),
+        durationMs: 300000,
+      },
+      {
+        githubRunId: '778',
+        status: 'in_progress',
+        conclusion: null,
+        branch: 'main',
+        sha: 'fed654cba321',
+        event: 'pull_request',
+        startedAt: new Date('2026-03-30T12:10:00.000Z'),
+        finishedAt: null,
+        durationMs: null,
+      },
+    ]);
+    const listWorkflowRunJobs = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          githubJobId: '888',
+          name: 'lint',
+          status: 'completed',
+          conclusion: 'success',
+          startedAt: new Date('2026-03-30T12:01:00.000Z'),
+          finishedAt: new Date('2026-03-30T12:02:00.000Z'),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          githubJobId: '889',
+          name: 'test',
+          status: 'in_progress',
+          conclusion: null,
+          startedAt: new Date('2026-03-30T12:11:00.000Z'),
+          finishedAt: null,
+        },
+      ]);
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    const service = new WorkflowRunService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById,
+        deleteById: vi.fn(),
+      },
+      workflowRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId,
+      },
+      workflowRunRepository: {
+        createRun: vi.fn(),
+        upsertRun,
+        listRunsByWorkflowId: vi.fn(),
+        createJob: vi.fn(),
+        upsertJob,
+        listJobsByWorkflowRunId: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns,
+        listWorkflowRunJobs,
+      },
+      logger,
+    });
+
+    await expect(service.syncByRepositoryId('repo_123')).resolves.toEqual([
+      buildWorkflowRun(),
+      buildWorkflowRun({
+        id: 'run_456',
+        githubRunId: '778',
+        status: 'in_progress',
+        conclusion: null,
+        finishedAt: null,
+        durationMs: null,
+      }),
+    ]);
+
+    expect(findById).toHaveBeenCalledWith('repo_123');
+    expect(listByRepositoryId).toHaveBeenCalledWith('repo_123');
+    expect(listWorkflowRuns).toHaveBeenCalledWith(
+      {
+        owner: 'forgeops',
+        name: 'backend',
+      },
+      'workflow-gh-123',
+    );
+    expect(upsertRun).toHaveBeenNthCalledWith(1, {
+      workflowId: 'workflow_123',
+      githubRunId: '777',
+      status: 'completed',
+      conclusion: 'success',
+      branch: 'main',
+      sha: 'abc123def456',
+      event: 'push',
+      startedAt: new Date('2026-03-30T12:00:00.000Z'),
+      finishedAt: new Date('2026-03-30T12:05:00.000Z'),
+      durationMs: 300000,
+    });
+    expect(upsertRun).toHaveBeenNthCalledWith(2, {
+      workflowId: 'workflow_123',
+      githubRunId: '778',
+      status: 'in_progress',
+      conclusion: null,
+      branch: 'main',
+      sha: 'fed654cba321',
+      event: 'pull_request',
+      startedAt: new Date('2026-03-30T12:10:00.000Z'),
+      finishedAt: null,
+      durationMs: null,
+    });
+    expect(listWorkflowRunJobs).toHaveBeenNthCalledWith(
+      1,
+      {
+        owner: 'forgeops',
+        name: 'backend',
+      },
+      '777',
+    );
+    expect(listWorkflowRunJobs).toHaveBeenNthCalledWith(
+      2,
+      {
+        owner: 'forgeops',
+        name: 'backend',
+      },
+      '778',
+    );
+    expect(upsertJob).toHaveBeenNthCalledWith(1, {
+      workflowRunId: 'run_123',
+      githubJobId: '888',
+      name: 'lint',
+      status: 'completed',
+      conclusion: 'success',
+      startedAt: new Date('2026-03-30T12:01:00.000Z'),
+      finishedAt: new Date('2026-03-30T12:02:00.000Z'),
+    });
+    expect(upsertJob).toHaveBeenNthCalledWith(2, {
+      workflowRunId: 'run_456',
+      githubJobId: '889',
+      name: 'test',
+      status: 'in_progress',
+      conclusion: null,
+      startedAt: new Date('2026-03-30T12:11:00.000Z'),
+      finishedAt: null,
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      {
+        event: 'workflow_runs_sync_succeeded',
+        repositoryId: 'repo_123',
+        fullName: 'forgeops/backend',
+        catalogedWorkflowCount: 1,
+        syncedRunCount: 2,
+        syncedJobCount: 2,
+      },
+      'Workflow runs sync completed.',
+    );
+  });
+
+  it('should succeed with no runs when cataloged workflows return an empty result', async () => {
+    const listWorkflowRuns = vi.fn().mockResolvedValue([]);
+    const listWorkflowRunJobs = vi.fn();
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    const service = new WorkflowRunService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildRepository()),
+        deleteById: vi.fn(),
+      },
+      workflowRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId: vi.fn().mockResolvedValue([buildWorkflow()]),
+      },
+      workflowRunRepository: {
+        createRun: vi.fn(),
+        upsertRun: vi.fn(),
+        listRunsByWorkflowId: vi.fn(),
+        createJob: vi.fn(),
+        upsertJob: vi.fn(),
+        listJobsByWorkflowRunId: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns,
+        listWorkflowRunJobs,
+      },
+      logger,
+    });
+
+    await expect(service.syncByRepositoryId('repo_123')).resolves.toEqual([]);
+    expect(listWorkflowRunJobs).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      {
+        event: 'workflow_runs_sync_succeeded',
+        repositoryId: 'repo_123',
+        fullName: 'forgeops/backend',
+        catalogedWorkflowCount: 1,
+        syncedRunCount: 0,
+        syncedJobCount: 0,
+      },
+      'Workflow runs sync completed.',
+    );
+  });
+
+  it('should fail with repository not found when sync receives an unknown repository id', async () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    const service = new WorkflowRunService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: vi.fn().mockResolvedValue(null),
+        deleteById: vi.fn(),
+      },
+      workflowRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId: vi.fn(),
+      },
+      workflowRunRepository: {
+        createRun: vi.fn(),
+        upsertRun: vi.fn(),
+        listRunsByWorkflowId: vi.fn(),
+        createJob: vi.fn(),
+        upsertJob: vi.fn(),
+        listJobsByWorkflowRunId: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+      },
+      logger,
+    });
+
+    await expect(service.syncByRepositoryId('missing_repo')).rejects.toBeInstanceOf(
+      RepositoryNotFoundError,
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        event: 'workflow_runs_sync_failed',
+        repositoryId: 'missing_repo',
+        errorCode: 'repository_not_found',
+        errorStatusCode: 404,
+      },
+      'Workflow runs sync failed.',
+    );
+  });
+
+  it('should propagate a safe GitHub workflow runs error during sync', async () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    const service = new WorkflowRunService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildRepository()),
+        deleteById: vi.fn(),
+      },
+      workflowRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId: vi.fn().mockResolvedValue([buildWorkflow()]),
+      },
+      workflowRunRepository: {
+        createRun: vi.fn(),
+        upsertRun: vi.fn(),
+        listRunsByWorkflowId: vi.fn(),
+        createJob: vi.fn(),
+        upsertJob: vi.fn(),
+        listJobsByWorkflowRunId: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => {
+          throw new GitHubWorkflowRunsSyncError();
+        },
+        listWorkflowRunJobs: async () => [],
+      },
+      logger,
+    });
+
+    await expect(service.syncByRepositoryId('repo_123')).rejects.toBeInstanceOf(
+      GitHubWorkflowRunsSyncError,
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        event: 'workflow_runs_sync_failed',
+        repositoryId: 'repo_123',
+        fullName: 'forgeops/backend',
+        errorCode: 'github_workflow_runs_unavailable',
+        errorStatusCode: 503,
+      },
+      'Workflow runs sync failed.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add workflow run sync service for cataloged workflows and jobs
- extend the GitHub App boundary/provider with explicit workflow runs and jobs mapping
- trigger workflow runs sync after workflow catalog sync during repository onboarding
- cover provider, service, repository onboarding, and server wiring with tests

## Validation
- npm.cmd --prefix backend run lint
- npm.cmd --prefix backend run typecheck
- npm.cmd --prefix backend run test
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run test

## Issue
Closes #64