### PR TITLE
feat(workflow-runs): expose workflow runs read api

### DIFF
--- a/backend/src/app/create-server.ts
+++ b/backend/src/app/create-server.ts
@@ -108,6 +108,7 @@ export const createServer = (options: CreateServerOptions) => {
     healthService,
     repositoryService,
     workflowService,
+    workflowRunService,
   });
 
   return app;

--- a/backend/src/app/register-routes.ts
+++ b/backend/src/app/register-routes.ts
@@ -12,11 +12,14 @@ import { registerRepositoryRegistryRoutes } from '../modules/repository-registry
 import type { RepositoryService } from '../modules/repository-registry/repository.service.js';
 import { registerWorkflowCatalogRoutes } from '../modules/workflow-catalog/workflow.controller.js';
 import type { WorkflowService } from '../modules/workflow-catalog/workflow.service.js';
+import { registerWorkflowRunRoutes } from '../modules/workflow-runs/workflow-run.controller.js';
+import type { WorkflowRunService } from '../modules/workflow-runs/workflow-run.service.js';
 
 interface RegisterRoutesOptions {
   healthService: HealthService;
   repositoryService: RepositoryService;
   workflowService: WorkflowService;
+  workflowRunService: WorkflowRunService;
 }
 
 export type ForgeOpsFastifyInstance = FastifyInstance<
@@ -34,4 +37,5 @@ export const registerRoutes = (
   registerAuthReferenceRoutes(app);
   registerRepositoryRegistryRoutes(app, options.repositoryService);
   registerWorkflowCatalogRoutes(app, options.workflowService);
+  registerWorkflowRunRoutes(app, options.workflowRunService);
 };

--- a/backend/src/modules/workflow-catalog/workflow.errors.ts
+++ b/backend/src/modules/workflow-catalog/workflow.errors.ts
@@ -5,3 +5,9 @@ export class WorkflowAlreadyExistsError extends ApplicationError {
     super(message, 409, 'workflow_already_exists');
   }
 }
+
+export class WorkflowNotFoundError extends ApplicationError {
+  constructor(message = 'Workflow was not found.') {
+    super(message, 404, 'workflow_not_found');
+  }
+}

--- a/backend/src/modules/workflow-catalog/workflow.prisma-repository.ts
+++ b/backend/src/modules/workflow-catalog/workflow.prisma-repository.ts
@@ -60,6 +60,11 @@ type WorkflowDelegate = {
       createdAt: 'asc' | 'desc';
     };
   }): Promise<WorkflowRecord[]>;
+  findUnique(args: {
+    where: {
+      id: string;
+    };
+  }): Promise<WorkflowRecord | null>;
 };
 
 const isUniqueConstraintError = (error: unknown): boolean => {
@@ -117,6 +122,16 @@ export class PrismaWorkflowRepository implements WorkflowRepository {
     });
 
     return records.map(toWorkflow);
+  }
+
+  async findById(id: string): Promise<Workflow | null> {
+    const record = await this.workflow.findUnique({
+      where: {
+        id,
+      },
+    });
+
+    return record ? toWorkflow(record) : null;
   }
 
   async upsert(input: CreateWorkflowInput): Promise<Workflow> {

--- a/backend/src/modules/workflow-catalog/workflow.repository.ts
+++ b/backend/src/modules/workflow-catalog/workflow.repository.ts
@@ -4,4 +4,5 @@ export interface WorkflowRepository {
   create(input: CreateWorkflowInput): Promise<Workflow>;
   upsert(input: CreateWorkflowInput): Promise<Workflow>;
   listByRepositoryId(repositoryId: string): Promise<Workflow[]>;
+  findById(id: string): Promise<Workflow | null>;
 }

--- a/backend/src/modules/workflow-runs/workflow-run.controller.ts
+++ b/backend/src/modules/workflow-runs/workflow-run.controller.ts
@@ -1,0 +1,86 @@
+import type { RouteGenericInterface } from 'fastify';
+import { z } from 'zod';
+import type { ForgeOpsFastifyInstance } from '../../app/register-routes.js';
+import type { WorkflowRunService } from './workflow-run.service.js';
+import type { WorkflowRun } from './workflow-run.entity.js';
+
+const workflowRunParamsSchema = z.object({
+  repositoryId: z.string().trim().min(1),
+  workflowId: z.string().trim().min(1),
+});
+
+interface WorkflowRunResponse {
+  id: string;
+  workflowId: string;
+  githubRunId: string;
+  status: 'queued' | 'in_progress' | 'completed' | 'pending' | 'waiting' | 'requested';
+  conclusion:
+    | 'success'
+    | 'failure'
+    | 'neutral'
+    | 'cancelled'
+    | 'skipped'
+    | 'timed_out'
+    | 'action_required'
+    | 'stale'
+    | 'startup_failure'
+    | null;
+  branch: string;
+  sha: string;
+  event: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  durationMs: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ListWorkflowRunsRoute extends RouteGenericInterface {
+  Params: {
+    repositoryId: string;
+    workflowId: string;
+  };
+  Reply: {
+    runs: WorkflowRunResponse[];
+  };
+}
+
+const toWorkflowRunResponse = (workflowRun: WorkflowRun): WorkflowRunResponse => {
+  return {
+    id: workflowRun.id,
+    workflowId: workflowRun.workflowId,
+    githubRunId: workflowRun.githubRunId,
+    status: workflowRun.status,
+    conclusion: workflowRun.conclusion,
+    branch: workflowRun.branch,
+    sha: workflowRun.sha,
+    event: workflowRun.event,
+    startedAt: workflowRun.startedAt?.toISOString() ?? null,
+    finishedAt: workflowRun.finishedAt?.toISOString() ?? null,
+    durationMs: workflowRun.durationMs,
+    createdAt: workflowRun.createdAt.toISOString(),
+    updatedAt: workflowRun.updatedAt.toISOString(),
+  };
+};
+
+export const registerWorkflowRunRoutes = (
+  app: ForgeOpsFastifyInstance,
+  workflowRunService: WorkflowRunService,
+): void => {
+  app.get<ListWorkflowRunsRoute>(
+    '/api/v1/repositories/:repositoryId/workflows/:workflowId/runs',
+    {
+      config: {
+        access: 'protected',
+      },
+    },
+    async (request) => {
+      const { repositoryId, workflowId } = workflowRunParamsSchema.parse(request.params);
+      const runs = await workflowRunService.listByWorkflowId(repositoryId, workflowId);
+
+      return {
+        runs: runs.map(toWorkflowRunResponse),
+      };
+    },
+  );
+};

--- a/backend/src/modules/workflow-runs/workflow-run.service.ts
+++ b/backend/src/modules/workflow-runs/workflow-run.service.ts
@@ -4,6 +4,7 @@ import type { GitHubAppBoundary } from '../github/github-app.boundary.js';
 import { RepositoryNotFoundError } from '../repository-registry/repository.errors.js';
 import type { RepositoryRepository } from '../repository-registry/repository.repository.js';
 import type { WorkflowRepository } from '../workflow-catalog/workflow.repository.js';
+import { WorkflowNotFoundError } from '../workflow-catalog/workflow.errors.js';
 import type { WorkflowRun } from './workflow-run.entity.js';
 import type { WorkflowRunRepository } from './workflow-run.repository.js';
 
@@ -24,6 +25,23 @@ export interface WorkflowRunServiceOptions {
 
 export class WorkflowRunService {
   constructor(private readonly options: WorkflowRunServiceOptions) {}
+
+  async listByWorkflowId(repositoryId: string, workflowId: string): Promise<WorkflowRun[]> {
+    const repository =
+      await this.options.repositoryRegistryRepository.findById(repositoryId);
+
+    if (!repository) {
+      throw new RepositoryNotFoundError();
+    }
+
+    const workflow = await this.options.workflowRepository.findById(workflowId);
+
+    if (!workflow || workflow.repositoryId !== repositoryId) {
+      throw new WorkflowNotFoundError();
+    }
+
+    return this.options.workflowRunRepository.listRunsByWorkflowId(workflowId);
+  }
 
   async syncByRepositoryId(repositoryId: string): Promise<WorkflowRun[]> {
     const repository =

--- a/backend/src/tests/app/create-server.test.ts
+++ b/backend/src/tests/app/create-server.test.ts
@@ -122,6 +122,7 @@ const buildWorkflowJob = (overrides: Partial<WorkflowJob> = {}): WorkflowJob => 
 const createProtectedServer = (overrides?: {
   repositories?: Repository[];
   workflows?: Workflow[];
+  workflowRuns?: WorkflowRun[];
   createRepository?: (input: CreateRepositoryInput) => Promise<Repository>;
   deleteRepositoryById?: (id: string) => Promise<void>;
   installationRepositories?: GitHubInstallationRepository[];
@@ -138,7 +139,7 @@ const createProtectedServer = (overrides?: {
 }) => {
   const repositoryStore = [...(overrides?.repositories ?? [])];
   const workflowStore = [...(overrides?.workflows ?? [])];
-  const workflowRunStore: WorkflowRun[] = [];
+  const workflowRunStore: WorkflowRun[] = [...(overrides?.workflowRuns ?? [])];
   const workflowJobStore: WorkflowJob[] = [];
 
   return createServer({
@@ -266,6 +267,8 @@ const createProtectedServer = (overrides?: {
       },
       listByRepositoryId: async (repositoryId) =>
         workflowStore.filter((workflow) => workflow.repositoryId === repositoryId),
+      findById: async (id) =>
+        workflowStore.find((workflow) => workflow.id === id) ?? null,
     },
     workflowRunRepository: {
       createRun: async (input) =>
@@ -313,7 +316,9 @@ const createProtectedServer = (overrides?: {
         return workflowRun;
       },
       listRunsByWorkflowId: async (workflowId) =>
-        workflowRunStore.filter((workflowRun) => workflowRun.workflowId === workflowId),
+        workflowRunStore
+          .filter((workflowRun) => workflowRun.workflowId === workflowId)
+          .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime()),
       createJob: async (input) =>
         buildWorkflowJob({
           workflowRunId: input.workflowRunId,
@@ -1100,6 +1105,194 @@ describe('createServer', () => {
           sourceType: 'reusable',
           createdAt: '2026-03-30T15:10:00.000Z',
           updatedAt: '2026-03-30T15:10:00.000Z',
+        },
+      ],
+    });
+
+    await server.close();
+  });
+
+  it('should keep workflow run routes protected', async () => {
+    const server = createProtectedServer({
+      repositories: [buildRepository()],
+      workflows: [buildWorkflow()],
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories/repo_123/workflows/workflow_123/runs',
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'authentication_required',
+        message: 'Authentication is required.',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should reject invalid workflow run route params before service execution', async () => {
+    const server = createProtectedServer({
+      repositories: [buildRepository()],
+      workflows: [buildWorkflow()],
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories/%20/workflows/workflow_123/runs',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'validation_error',
+        message: 'String must contain at least 1 character(s)',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should return not found when the workflow runs repository does not exist', async () => {
+    const server = createProtectedServer();
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories/repo_missing/workflows/workflow_123/runs',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'repository_not_found',
+        message: 'Repository was not found.',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should return not found when the workflow does not belong to the repository', async () => {
+    const server = createProtectedServer({
+      repositories: [buildRepository()],
+      workflows: [
+        buildWorkflow({
+          id: 'workflow_other',
+          repositoryId: 'repo_other',
+        }),
+      ],
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories/repo_123/workflows/workflow_other/runs',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'workflow_not_found',
+        message: 'Workflow was not found.',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should return an empty workflow runs list when the workflow has no persisted runs', async () => {
+    const server = createProtectedServer({
+      repositories: [buildRepository()],
+      workflows: [buildWorkflow()],
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories/repo_123/workflows/workflow_123/runs',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      runs: [],
+    });
+
+    await server.close();
+  });
+
+  it('should list workflow runs for an authenticated operator', async () => {
+    const server = createProtectedServer({
+      repositories: [buildRepository()],
+      workflows: [buildWorkflow()],
+      workflowRuns: [
+        buildWorkflowRun({
+          id: 'run_older',
+          githubRunId: 'run-gh-older',
+          status: 'completed',
+          conclusion: 'failure',
+          startedAt: new Date('2026-03-30T15:00:00.000Z'),
+          finishedAt: new Date('2026-03-30T15:04:00.000Z'),
+          durationMs: 240000,
+          createdAt: new Date('2026-03-30T15:00:00.000Z'),
+          updatedAt: new Date('2026-03-30T15:04:00.000Z'),
+        }),
+        buildWorkflowRun(),
+      ],
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories/repo_123/workflows/workflow_123/runs',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      runs: [
+        {
+          id: 'run_123',
+          workflowId: 'workflow_123',
+          githubRunId: 'run-gh-123',
+          status: 'completed',
+          conclusion: 'success',
+          branch: 'main',
+          sha: 'abc123def456',
+          event: 'push',
+          startedAt: '2026-03-30T16:00:00.000Z',
+          finishedAt: '2026-03-30T16:05:00.000Z',
+          durationMs: 300000,
+          createdAt: '2026-03-30T16:00:00.000Z',
+          updatedAt: '2026-03-30T16:00:00.000Z',
+        },
+        {
+          id: 'run_older',
+          workflowId: 'workflow_123',
+          githubRunId: 'run-gh-older',
+          status: 'completed',
+          conclusion: 'failure',
+          branch: 'main',
+          sha: 'abc123def456',
+          event: 'push',
+          startedAt: '2026-03-30T15:00:00.000Z',
+          finishedAt: '2026-03-30T15:04:00.000Z',
+          durationMs: 240000,
+          createdAt: '2026-03-30T15:00:00.000Z',
+          updatedAt: '2026-03-30T15:04:00.000Z',
         },
       ],
     });

--- a/backend/src/tests/modules/workflow-catalog/workflow.prisma-repository.test.ts
+++ b/backend/src/tests/modules/workflow-catalog/workflow.prisma-repository.test.ts
@@ -45,6 +45,7 @@ describe('PrismaWorkflowRepository', () => {
       create,
       upsert,
       findMany,
+      findUnique: vi.fn(),
     });
 
     await expect(
@@ -90,6 +91,7 @@ describe('PrismaWorkflowRepository', () => {
       create,
       upsert,
       findMany,
+      findUnique: vi.fn(),
     });
 
     await expect(repository.listByRepositoryId('repo_123')).resolves.toEqual([
@@ -116,6 +118,27 @@ describe('PrismaWorkflowRepository', () => {
     });
   });
 
+  it('should find a workflow by id', async () => {
+    const create = vi.fn();
+    const upsert = vi.fn();
+    const findMany = vi.fn();
+    const findUnique = vi.fn().mockResolvedValue(buildRecord());
+    const repository = new PrismaWorkflowRepository({
+      create,
+      upsert,
+      findMany,
+      findUnique,
+    });
+
+    await expect(repository.findById('workflow_123')).resolves.toEqual(buildRecord());
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: {
+        id: 'workflow_123',
+      },
+    });
+  });
+
   it('should translate unique constraint errors into a domain conflict', async () => {
     const create = vi.fn().mockRejectedValue({ code: 'P2002' });
     const findMany = vi.fn();
@@ -124,6 +147,7 @@ describe('PrismaWorkflowRepository', () => {
       create,
       upsert,
       findMany,
+      findUnique: vi.fn(),
     });
 
     await expect(
@@ -146,6 +170,7 @@ describe('PrismaWorkflowRepository', () => {
       create,
       upsert,
       findMany,
+      findUnique: vi.fn(),
     });
 
     await expect(

--- a/backend/src/tests/modules/workflow-catalog/workflow.service.test.ts
+++ b/backend/src/tests/modules/workflow-catalog/workflow.service.test.ts
@@ -83,6 +83,7 @@ describe('WorkflowService', () => {
         create: vi.fn(),
         upsert,
         listByRepositoryId,
+        findById: vi.fn(),
       },
       githubBoundary: {
         mode: 'github-app',
@@ -163,6 +164,7 @@ describe('WorkflowService', () => {
         create: vi.fn(),
         upsert: vi.fn(),
         listByRepositoryId: vi.fn(),
+        findById: vi.fn(),
       },
       githubBoundary: {
         mode: 'github-app',
@@ -214,6 +216,7 @@ describe('WorkflowService', () => {
         create: vi.fn(),
         upsert: vi.fn(),
         listByRepositoryId: vi.fn(),
+        findById: vi.fn(),
       },
       githubBoundary: {
         mode: 'github-app',

--- a/backend/src/tests/modules/workflow-runs/workflow-run.service.test.ts
+++ b/backend/src/tests/modules/workflow-runs/workflow-run.service.test.ts
@@ -3,6 +3,7 @@ import { GitHubWorkflowRunsSyncError } from '../../../modules/github/github-app.
 import type { Repository } from '../../../modules/repository-registry/repository.entity.js';
 import { RepositoryNotFoundError } from '../../../modules/repository-registry/repository.errors.js';
 import type { Workflow } from '../../../modules/workflow-catalog/workflow.entity.js';
+import { WorkflowNotFoundError } from '../../../modules/workflow-catalog/workflow.errors.js';
 import type { WorkflowJob, WorkflowRun } from '../../../modules/workflow-runs/workflow-run.entity.js';
 import { WorkflowRunService } from '../../../modules/workflow-runs/workflow-run.service.js';
 
@@ -80,6 +81,215 @@ const buildWorkflowJob = (overrides: Partial<WorkflowJob> = {}): WorkflowJob => 
 };
 
 describe('WorkflowRunService', () => {
+  it('should list workflow runs for a workflow that belongs to the repository', async () => {
+    const findRepositoryById = vi.fn().mockResolvedValue(buildRepository());
+    const findWorkflowById = vi.fn().mockResolvedValue(buildWorkflow());
+    const listRunsByWorkflowId = vi.fn().mockResolvedValue([
+      buildWorkflowRun(),
+      buildWorkflowRun({
+        id: 'run_456',
+        githubRunId: '778',
+        status: 'in_progress',
+        conclusion: null,
+        finishedAt: null,
+        durationMs: null,
+      }),
+    ]);
+    const service = new WorkflowRunService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: findRepositoryById,
+        deleteById: vi.fn(),
+      },
+      workflowRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId: vi.fn(),
+        findById: findWorkflowById,
+      },
+      workflowRunRepository: {
+        createRun: vi.fn(),
+        upsertRun: vi.fn(),
+        listRunsByWorkflowId,
+        createJob: vi.fn(),
+        upsertJob: vi.fn(),
+        listJobsByWorkflowRunId: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+      },
+    });
+
+    await expect(service.listByWorkflowId('repo_123', 'workflow_123')).resolves.toEqual([
+      buildWorkflowRun(),
+      buildWorkflowRun({
+        id: 'run_456',
+        githubRunId: '778',
+        status: 'in_progress',
+        conclusion: null,
+        finishedAt: null,
+        durationMs: null,
+      }),
+    ]);
+
+    expect(findRepositoryById).toHaveBeenCalledWith('repo_123');
+    expect(findWorkflowById).toHaveBeenCalledWith('workflow_123');
+    expect(listRunsByWorkflowId).toHaveBeenCalledWith('workflow_123');
+  });
+
+  it('should return an empty list when the workflow has no persisted runs', async () => {
+    const listRunsByWorkflowId = vi.fn().mockResolvedValue([]);
+    const service = new WorkflowRunService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildRepository()),
+        deleteById: vi.fn(),
+      },
+      workflowRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildWorkflow()),
+      },
+      workflowRunRepository: {
+        createRun: vi.fn(),
+        upsertRun: vi.fn(),
+        listRunsByWorkflowId,
+        createJob: vi.fn(),
+        upsertJob: vi.fn(),
+        listJobsByWorkflowRunId: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+      },
+    });
+
+    await expect(service.listByWorkflowId('repo_123', 'workflow_123')).resolves.toEqual([]);
+    expect(listRunsByWorkflowId).toHaveBeenCalledWith('workflow_123');
+  });
+
+  it('should fail with workflow not found when the workflow does not exist', async () => {
+    const service = new WorkflowRunService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildRepository()),
+        deleteById: vi.fn(),
+      },
+      workflowRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId: vi.fn(),
+        findById: vi.fn().mockResolvedValue(null),
+      },
+      workflowRunRepository: {
+        createRun: vi.fn(),
+        upsertRun: vi.fn(),
+        listRunsByWorkflowId: vi.fn(),
+        createJob: vi.fn(),
+        upsertJob: vi.fn(),
+        listJobsByWorkflowRunId: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+      },
+    });
+
+    await expect(service.listByWorkflowId('repo_123', 'workflow_missing')).rejects.toBeInstanceOf(
+      WorkflowNotFoundError,
+    );
+  });
+
+  it('should fail with workflow not found when the workflow belongs to another repository', async () => {
+    const service = new WorkflowRunService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildRepository()),
+        deleteById: vi.fn(),
+      },
+      workflowRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId: vi.fn(),
+        findById: vi.fn().mockResolvedValue(
+          buildWorkflow({
+            repositoryId: 'repo_other',
+          }),
+        ),
+      },
+      workflowRunRepository: {
+        createRun: vi.fn(),
+        upsertRun: vi.fn(),
+        listRunsByWorkflowId: vi.fn(),
+        createJob: vi.fn(),
+        upsertJob: vi.fn(),
+        listJobsByWorkflowRunId: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+      },
+    });
+
+    await expect(service.listByWorkflowId('repo_123', 'workflow_123')).rejects.toBeInstanceOf(
+      WorkflowNotFoundError,
+    );
+  });
+
   it('should sync workflow runs and jobs for cataloged workflows', async () => {
     const findById = vi.fn().mockResolvedValue(buildRepository());
     const listByRepositoryId = vi.fn().mockResolvedValue([buildWorkflow()]);
@@ -171,6 +381,7 @@ describe('WorkflowRunService', () => {
         create: vi.fn(),
         upsert: vi.fn(),
         listByRepositoryId,
+        findById: vi.fn(),
       },
       workflowRunRepository: {
         createRun: vi.fn(),
@@ -309,6 +520,7 @@ describe('WorkflowRunService', () => {
         create: vi.fn(),
         upsert: vi.fn(),
         listByRepositoryId: vi.fn().mockResolvedValue([buildWorkflow()]),
+        findById: vi.fn(),
       },
       workflowRunRepository: {
         createRun: vi.fn(),
@@ -368,6 +580,7 @@ describe('WorkflowRunService', () => {
         create: vi.fn(),
         upsert: vi.fn(),
         listByRepositoryId: vi.fn(),
+        findById: vi.fn(),
       },
       workflowRunRepository: {
         createRun: vi.fn(),
@@ -426,6 +639,7 @@ describe('WorkflowRunService', () => {
         create: vi.fn(),
         upsert: vi.fn(),
         listByRepositoryId: vi.fn().mockResolvedValue([buildWorkflow()]),
+        findById: vi.fn(),
       },
       workflowRunRepository: {
         createRun: vi.fn(),


### PR DESCRIPTION
## Summary
- add a protected read API for persisted workflow runs
- validate repository and workflow ownership before listing runs
- cover the new workflow runs read path with service, repository, and HTTP tests

## Issue
Closes #65