### PR TITLE
feat(frontend): implement workflow runs list for repository workflows

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -408,6 +408,39 @@ pre {
   font-size: 0.95rem;
 }
 
+.workflow-runs-list {
+  display: grid;
+  gap: 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.workflow-runs-list__item {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.workflow-runs-list__summary {
+  display: grid;
+  gap: 6px;
+}
+
+.workflow-runs-list__summary span {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.workflow-runs-list__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
 @media (max-width: 980px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -446,7 +479,8 @@ pre {
 
   .repository-list__actions,
   .workflow-list__item,
-  .workflow-list__meta {
+  .workflow-list__meta,
+  .workflow-runs-list__meta {
     width: 100%;
   }
 

--- a/frontend/src/features/repositories/repositories-view.tsx
+++ b/frontend/src/features/repositories/repositories-view.tsx
@@ -11,11 +11,15 @@ import {
   type ForgeOpsApiClient,
   type MonitoredRepository,
   type RepositoryDiscoveryItem,
+  type WorkflowCatalogItem,
+  type WorkflowRunItem,
 } from '@/lib/api/client';
 
 const STORAGE_KEY = 'forgeops.operator-access-token';
 const EMPTY_MONITORED_REPOSITORIES: MonitoredRepository[] = [];
 const EMPTY_DISCOVERED_REPOSITORIES: RepositoryDiscoveryItem[] = [];
+const EMPTY_WORKFLOWS: WorkflowCatalogItem[] = [];
+const EMPTY_WORKFLOW_RUNS: WorkflowRunItem[] = [];
 
 const getErrorMessage = (error: unknown, fallback: string): string => {
   if (error instanceof ApiClientError) {
@@ -29,6 +33,26 @@ const getErrorMessage = (error: unknown, fallback: string): string => {
   return fallback;
 };
 
+const formatTimestamp = (value: string | null): string => {
+  if (!value) {
+    return 'n/a';
+  }
+
+  return new Date(value).toLocaleString();
+};
+
+const formatDuration = (durationMs: number | null): string => {
+  if (durationMs === null) {
+    return 'n/a';
+  }
+
+  const totalSeconds = Math.round(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${minutes}m ${seconds}s`;
+};
+
 interface RepositoriesViewProps {
   client?: ForgeOpsApiClient;
 }
@@ -38,6 +62,7 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
   const [draftAccessToken, setDraftAccessToken] = useState('');
   const [accessToken, setAccessToken] = useState('');
   const [selectedRepositoryId, setSelectedRepositoryId] = useState<string | null>(null);
+  const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [tokenError, setTokenError] = useState<string | null>(null);
   const hasAccessToken = accessToken.trim().length > 0;
@@ -95,6 +120,33 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
     retry: false,
   });
 
+  const repositoryWorkflows = workflowsQuery.data ?? EMPTY_WORKFLOWS;
+
+  useEffect(() => {
+    if (repositoryWorkflows.length === 0) {
+      setSelectedWorkflowId(null);
+      return;
+    }
+
+    const selectedExists = repositoryWorkflows.some(
+      (workflow) => workflow.id === selectedWorkflowId,
+    );
+    const firstWorkflow = repositoryWorkflows[0];
+
+    if (!selectedWorkflowId || !selectedExists) {
+      setSelectedWorkflowId(firstWorkflow?.id ?? null);
+    }
+  }, [repositoryWorkflows, selectedWorkflowId]);
+
+  const workflowRunsQuery = useQuery({
+    queryKey: ['workflow-runs', accessToken, selectedRepositoryId, selectedWorkflowId],
+    queryFn: () =>
+      client.getWorkflowRuns(accessToken, selectedRepositoryId!, selectedWorkflowId!),
+    enabled:
+      hasAccessToken && selectedRepositoryId !== null && selectedWorkflowId !== null,
+    retry: false,
+  });
+
   const createRepositoryMutation = useMutation({
     mutationFn: (repository: RepositoryDiscoveryItem) =>
       client.createRepository(accessToken, {
@@ -114,6 +166,9 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
         queryClient.invalidateQueries({
           queryKey: ['repository-workflows', accessToken, repository.id],
         }),
+        queryClient.invalidateQueries({
+          queryKey: ['workflow-runs', accessToken, repository.id],
+        }),
       ]);
     },
     onError: (error) => {
@@ -132,7 +187,9 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
   );
   const selectedRepository =
     monitoredRepositories.find((repository) => repository.id === selectedRepositoryId) ?? null;
-  const repositoryWorkflows = workflowsQuery.data ?? [];
+  const selectedWorkflow =
+    repositoryWorkflows.find((workflow) => workflow.id === selectedWorkflowId) ?? null;
+  const workflowRuns = workflowRunsQuery.data ?? EMPTY_WORKFLOW_RUNS;
 
   const submitAccessToken = () => {
     const normalizedToken = draftAccessToken.trim();
@@ -153,6 +210,7 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
     setDraftAccessToken('');
     setAccessToken('');
     setSelectedRepositoryId(null);
+    setSelectedWorkflowId(null);
     setTokenError(null);
     setStatusMessage(null);
     void queryClient.removeQueries({
@@ -163,6 +221,9 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
     });
     void queryClient.removeQueries({
       queryKey: ['repository-workflows'],
+    });
+    void queryClient.removeQueries({
+      queryKey: ['workflow-runs'],
     });
   };
 
@@ -351,6 +412,83 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
                   </span>
                   <span className="repository-list__badge repository-list__badge--neutral">
                     {workflow.state}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      <Card
+        eyebrow="Workflow runs"
+        title={
+          selectedWorkflow
+            ? `Workflow runs for ${selectedWorkflow.name}`
+            : 'Workflow runs'
+        }
+      >
+        {!hasAccessToken ? (
+          <p className="empty-state">
+            Add an operator token to inspect workflow runs for cataloged workflows.
+          </p>
+        ) : monitoredRepositoriesQuery.isLoading ? (
+          <p className="empty-state">Loading repositories before fetching workflow runs...</p>
+        ) : monitoredRepositories.length === 0 ? (
+          <p className="empty-state">
+            Connect a repository first so ForgeOps can show workflow runs.
+          </p>
+        ) : !selectedRepository ? (
+          <p className="empty-state">
+            Select a monitored repository to inspect workflow runs.
+          </p>
+        ) : workflowsQuery.isLoading ? (
+          <p className="empty-state">Loading workflows before fetching workflow runs...</p>
+        ) : repositoryWorkflows.length === 0 ? (
+          <p className="empty-state">
+            Catalog workflows first before inspecting workflow runs.
+          </p>
+        ) : !selectedWorkflow ? (
+          <p className="empty-state">Select a workflow to inspect workflow runs.</p>
+        ) : workflowRunsQuery.isLoading ? (
+          <p className="empty-state">Loading workflow runs...</p>
+        ) : workflowRunsQuery.isError ? (
+          <p className="empty-state">
+            {getErrorMessage(workflowRunsQuery.error, 'Unable to load workflow runs.')}
+          </p>
+        ) : workflowRuns.length === 0 ? (
+          <p className="empty-state">
+            ForgeOps has not synchronized workflow runs for this workflow yet.
+          </p>
+        ) : (
+          <ul className="workflow-runs-list">
+            {workflowRuns.map((run) => (
+              <li key={run.id} className="workflow-runs-list__item">
+                <div className="workflow-runs-list__summary">
+                  <strong>Run #{run.githubRunId}</strong>
+                  <span>sha {run.sha.slice(0, 12)}</span>
+                </div>
+                <div className="workflow-runs-list__meta">
+                  <span className="repository-list__badge repository-list__badge--neutral">
+                    status: {run.status}
+                  </span>
+                  <span className="repository-list__badge repository-list__badge--neutral">
+                    conclusion: {run.conclusion ?? 'n/a'}
+                  </span>
+                  <span className="repository-list__badge repository-list__badge--neutral">
+                    branch: {run.branch}
+                  </span>
+                  <span className="repository-list__badge repository-list__badge--neutral">
+                    event: {run.event}
+                  </span>
+                  <span className="repository-list__badge repository-list__badge--neutral">
+                    started: {formatTimestamp(run.startedAt)}
+                  </span>
+                  <span className="repository-list__badge repository-list__badge--neutral">
+                    finished: {formatTimestamp(run.finishedAt)}
+                  </span>
+                  <span className="repository-list__badge repository-list__badge--neutral">
+                    duration: {formatDuration(run.durationMs)}
                   </span>
                 </div>
               </li>

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -90,10 +90,43 @@ const workflowCatalogResponseSchema = z.object({
   workflows: z.array(workflowCatalogItemSchema),
 });
 
+const workflowRunItemSchema = z.object({
+  id: z.string().min(1),
+  workflowId: z.string().min(1),
+  githubRunId: z.string().min(1),
+  status: z.enum(['queued', 'in_progress', 'completed', 'pending', 'waiting', 'requested']),
+  conclusion: z
+    .enum([
+      'success',
+      'failure',
+      'neutral',
+      'cancelled',
+      'skipped',
+      'timed_out',
+      'action_required',
+      'stale',
+      'startup_failure',
+    ])
+    .nullable(),
+  branch: z.string().min(1),
+  sha: z.string().min(1),
+  event: z.string().min(1),
+  startedAt: z.string().datetime().nullable(),
+  finishedAt: z.string().datetime().nullable(),
+  durationMs: z.number().int().nonnegative().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+const workflowRunsResponseSchema = z.object({
+  runs: z.array(workflowRunItemSchema),
+});
+
 export type MonitoredRepository = z.infer<typeof monitoredRepositorySchema>;
 export type RepositoryDiscoveryItem = z.infer<typeof repositoryDiscoveryItemSchema>;
 export type CreateRepositoryInput = z.infer<typeof createRepositoryInputSchema>;
 export type WorkflowCatalogItem = z.infer<typeof workflowCatalogItemSchema>;
+export type WorkflowRunItem = z.infer<typeof workflowRunItemSchema>;
 
 interface CreateApiClientOptions {
   baseUrl?: string;
@@ -121,6 +154,11 @@ export interface ForgeOpsApiClient {
     accessToken: string,
     repositoryId: string,
   ): Promise<WorkflowCatalogItem[]>;
+  getWorkflowRuns(
+    accessToken: string,
+    repositoryId: string,
+    workflowId: string,
+  ): Promise<WorkflowRunItem[]>;
   createRepository(
     accessToken: string,
     input: CreateRepositoryInput,
@@ -206,6 +244,25 @@ export const createApiClient = (options: CreateApiClientOptions = {}): ForgeOpsA
       }
 
       return workflowCatalogResponseSchema.parse(await response.json()).workflows;
+    },
+
+    async getWorkflowRuns(
+      accessToken: string,
+      repositoryId: string,
+      workflowId: string,
+    ): Promise<WorkflowRunItem[]> {
+      const response = await fetcher(
+        `${baseUrl}/api/v1/repositories/${repositoryId}/workflows/${workflowId}/runs`,
+        {
+          headers: buildHeaders(accessToken),
+        },
+      );
+
+      if (!response.ok) {
+        throw await createApiError(response, `Failed to fetch workflow runs (${response.status})`);
+      }
+
+      return workflowRunsResponseSchema.parse(await response.json()).runs;
     },
 
     async createRepository(

--- a/frontend/src/tests/api-client.test.ts
+++ b/frontend/src/tests/api-client.test.ts
@@ -216,6 +216,71 @@ describe('createApiClient', () => {
     );
   });
 
+  it('should fetch workflow runs with operator authorization', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          runs: [
+            {
+              id: 'run_123',
+              workflowId: 'workflow_123',
+              githubRunId: '1001',
+              status: 'completed',
+              conclusion: 'success',
+              branch: 'main',
+              sha: 'abcdef123456',
+              event: 'push',
+              startedAt: '2026-03-31T11:00:00.000Z',
+              finishedAt: '2026-03-31T11:03:00.000Z',
+              durationMs: 180000,
+              createdAt: '2026-03-31T11:00:00.000Z',
+              updatedAt: '2026-03-31T11:03:00.000Z',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+      ),
+    );
+    const client = createApiClient({
+      baseUrl: 'http://localhost:3333',
+      fetcher,
+    });
+
+    await expect(client.getWorkflowRuns('trusted-token', 'repo_123', 'workflow_123')).resolves.toEqual(
+      [
+        {
+          id: 'run_123',
+          workflowId: 'workflow_123',
+          githubRunId: '1001',
+          status: 'completed',
+          conclusion: 'success',
+          branch: 'main',
+          sha: 'abcdef123456',
+          event: 'push',
+          startedAt: '2026-03-31T11:00:00.000Z',
+          finishedAt: '2026-03-31T11:03:00.000Z',
+          durationMs: 180000,
+          createdAt: '2026-03-31T11:00:00.000Z',
+          updatedAt: '2026-03-31T11:03:00.000Z',
+        },
+      ],
+    );
+    expect(fetcher).toHaveBeenCalledWith(
+      'http://localhost:3333/api/v1/repositories/repo_123/workflows/workflow_123/runs',
+      {
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer trusted-token',
+        },
+      },
+    );
+  });
+
   it('should create repositories and surface structured API errors', async () => {
     const fetcher = vi
       .fn<typeof fetch>()

--- a/frontend/src/tests/repositories-view.test.tsx
+++ b/frontend/src/tests/repositories-view.test.tsx
@@ -26,6 +26,7 @@ describe('RepositoriesView', () => {
       getRepositories: vi.fn(),
       getRepositoryDiscovery: vi.fn(),
       getRepositoryWorkflows: vi.fn(),
+      getWorkflowRuns: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -49,6 +50,7 @@ describe('RepositoriesView', () => {
     expect(client.getRepositories).not.toHaveBeenCalled();
     expect(client.getRepositoryDiscovery).not.toHaveBeenCalled();
     expect(client.getRepositoryWorkflows).not.toHaveBeenCalled();
+    expect(client.getWorkflowRuns).not.toHaveBeenCalled();
   });
 
   it('should load repository workflows for the selected monitored repository', async () => {
@@ -95,11 +97,31 @@ describe('RepositoriesView', () => {
         },
       ]);
     const createRepository = vi.fn<ForgeOpsApiClient['createRepository']>();
+    const getWorkflowRuns = vi
+      .fn<ForgeOpsApiClient['getWorkflowRuns']>()
+      .mockResolvedValue([
+        {
+          id: 'run_123',
+          workflowId: 'workflow_123',
+          githubRunId: '1001',
+          status: 'completed',
+          conclusion: 'success',
+          branch: 'main',
+          sha: 'abcdef123456',
+          event: 'push',
+          startedAt: '2026-03-31T11:00:00.000Z',
+          finishedAt: '2026-03-31T11:03:00.000Z',
+          durationMs: 180000,
+          createdAt: '2026-03-31T11:00:00.000Z',
+          updatedAt: '2026-03-31T11:03:00.000Z',
+        },
+      ]);
     const client: ForgeOpsApiClient = {
       getHealth: vi.fn(),
       getRepositories,
       getRepositoryDiscovery,
       getRepositoryWorkflows,
+      getWorkflowRuns,
       createRepository,
     };
 
@@ -119,6 +141,155 @@ describe('RepositoriesView', () => {
     });
 
     expect(getRepositoryWorkflows).toHaveBeenCalledWith('trusted-token', 'repo_123');
+    await waitFor(() => {
+      expect(getWorkflowRuns).toHaveBeenCalledWith(
+        'trusted-token',
+        'repo_123',
+        'workflow_123',
+      );
+    });
+  });
+
+  it('should render workflow runs loading state while querying runs', async () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([
+        {
+          id: 'workflow_123',
+          repositoryId: 'repo_123',
+          githubWorkflowId: 'workflow-gh-123',
+          name: 'CI',
+          path: '.github/workflows/ci.yml',
+          state: 'active',
+          sourceType: 'local',
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getWorkflowRuns: vi.fn().mockImplementation(() => new Promise(() => undefined)),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Loading workflow runs...')).toBeInTheDocument();
+    });
+  });
+
+  it('should render workflow runs empty state', async () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([
+        {
+          id: 'workflow_123',
+          repositoryId: 'repo_123',
+          githubWorkflowId: 'workflow-gh-123',
+          name: 'CI',
+          path: '.github/workflows/ci.yml',
+          state: 'active',
+          sourceType: 'local',
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('ForgeOps has not synchronized workflow runs for this workflow yet.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should render workflow runs errors clearly', async () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([
+        {
+          id: 'workflow_123',
+          repositoryId: 'repo_123',
+          githubWorkflowId: 'workflow-gh-123',
+          name: 'CI',
+          path: '.github/workflows/ci.yml',
+          state: 'active',
+          sourceType: 'local',
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getWorkflowRuns: vi
+        .fn()
+        .mockRejectedValue(new ApiClientError('Workflow runs are currently unavailable.', 503)),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Workflow runs are currently unavailable.')).toBeInTheDocument();
+    });
   });
 
   it('should load discovery and connect a repository through the backend client', async () => {
@@ -183,6 +354,7 @@ describe('RepositoriesView', () => {
       getRepositories,
       getRepositoryDiscovery,
       getRepositoryWorkflows,
+      getWorkflowRuns: vi.fn().mockResolvedValue([]),
       createRepository,
     };
 
@@ -225,6 +397,7 @@ describe('RepositoriesView', () => {
           new ApiClientError('GitHub repository discovery is currently unavailable.', 503),
         ),
       getRepositoryWorkflows: vi.fn(),
+      getWorkflowRuns: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -273,6 +446,7 @@ describe('RepositoriesView', () => {
         },
       ]),
       getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
+      getWorkflowRuns: vi.fn().mockResolvedValue([]),
       createRepository: vi
         .fn()
         .mockRejectedValue(
@@ -322,6 +496,7 @@ describe('RepositoriesView', () => {
         .mockRejectedValue(
           new ApiClientError('Repository was not found.', 404, 'repository_not_found'),
         ),
+      getWorkflowRuns: vi.fn().mockResolvedValue([]),
       createRepository: vi.fn(),
     };
 


### PR DESCRIPTION
## Summary
- add protected workflow runs API client contract in frontend with zod-validated response typing
- extend repositories view to fetch and render workflow runs for the selected workflow
- cover workflow runs loading, empty, error, and success states in frontend tests

## Validation
- npm.cmd --prefix frontend run test
- npm.cmd --prefix frontend run typecheck
- npm.cmd --prefix frontend run lint
- npm.cmd run test
- npm.cmd run typecheck
- npm.cmd run lint

Closes #67