### PR TITLE
feat(frontend): add workflow run detail view with jobs

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -441,6 +441,43 @@ pre {
   gap: 12px;
 }
 
+.workflow-runs-list__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.workflow-run-detail {
+  display: grid;
+  gap: 16px;
+}
+
+.workflow-jobs-list {
+  display: grid;
+  gap: 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.workflow-jobs-list__item {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.workflow-jobs-list__summary {
+  display: grid;
+  gap: 4px;
+}
+
+.workflow-jobs-list__summary span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
 @media (max-width: 980px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -482,6 +519,11 @@ pre {
   .workflow-list__meta,
   .workflow-runs-list__meta {
     width: 100%;
+  }
+
+  .workflow-runs-list__actions {
+    width: 100%;
+    justify-content: flex-start;
   }
 
   .workflow-list__item {

--- a/frontend/src/features/repositories/repositories-view.tsx
+++ b/frontend/src/features/repositories/repositories-view.tsx
@@ -12,6 +12,7 @@ import {
   type MonitoredRepository,
   type RepositoryDiscoveryItem,
   type WorkflowCatalogItem,
+  type WorkflowRunDetailResponse,
   type WorkflowRunItem,
 } from '@/lib/api/client';
 
@@ -20,6 +21,7 @@ const EMPTY_MONITORED_REPOSITORIES: MonitoredRepository[] = [];
 const EMPTY_DISCOVERED_REPOSITORIES: RepositoryDiscoveryItem[] = [];
 const EMPTY_WORKFLOWS: WorkflowCatalogItem[] = [];
 const EMPTY_WORKFLOW_RUNS: WorkflowRunItem[] = [];
+const EMPTY_WORKFLOW_RUN_DETAIL_JOBS: WorkflowRunDetailResponse['jobs'] = [];
 
 const getErrorMessage = (error: unknown, fallback: string): string => {
   if (error instanceof ApiClientError) {
@@ -63,6 +65,7 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
   const [accessToken, setAccessToken] = useState('');
   const [selectedRepositoryId, setSelectedRepositoryId] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
+  const [selectedWorkflowRunId, setSelectedWorkflowRunId] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [tokenError, setTokenError] = useState<string | null>(null);
   const hasAccessToken = accessToken.trim().length > 0;
@@ -147,6 +150,48 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
     retry: false,
   });
 
+  const workflowRuns = workflowRunsQuery.data ?? EMPTY_WORKFLOW_RUNS;
+
+  useEffect(() => {
+    if (workflowRuns.length === 0) {
+      setSelectedWorkflowRunId(null);
+      return;
+    }
+
+    if (!selectedWorkflowRunId) {
+      return;
+    }
+
+    const selectedExists = workflowRuns.some((workflowRun) => workflowRun.id === selectedWorkflowRunId);
+
+    if (!selectedExists) {
+      setSelectedWorkflowRunId(null);
+    }
+  }, [workflowRuns, selectedWorkflowRunId]);
+
+  const workflowRunDetailQuery = useQuery({
+    queryKey: [
+      'workflow-run-detail',
+      accessToken,
+      selectedRepositoryId,
+      selectedWorkflowId,
+      selectedWorkflowRunId,
+    ],
+    queryFn: () =>
+      client.getWorkflowRunDetail(
+        accessToken,
+        selectedRepositoryId!,
+        selectedWorkflowId!,
+        selectedWorkflowRunId!,
+      ),
+    enabled:
+      hasAccessToken &&
+      selectedRepositoryId !== null &&
+      selectedWorkflowId !== null &&
+      selectedWorkflowRunId !== null,
+    retry: false,
+  });
+
   const createRepositoryMutation = useMutation({
     mutationFn: (repository: RepositoryDiscoveryItem) =>
       client.createRepository(accessToken, {
@@ -169,6 +214,9 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
         queryClient.invalidateQueries({
           queryKey: ['workflow-runs', accessToken, repository.id],
         }),
+        queryClient.invalidateQueries({
+          queryKey: ['workflow-run-detail', accessToken, repository.id],
+        }),
       ]);
     },
     onError: (error) => {
@@ -189,7 +237,9 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
     monitoredRepositories.find((repository) => repository.id === selectedRepositoryId) ?? null;
   const selectedWorkflow =
     repositoryWorkflows.find((workflow) => workflow.id === selectedWorkflowId) ?? null;
-  const workflowRuns = workflowRunsQuery.data ?? EMPTY_WORKFLOW_RUNS;
+  const selectedWorkflowRun =
+    workflowRuns.find((workflowRun) => workflowRun.id === selectedWorkflowRunId) ?? null;
+  const workflowRunDetail = workflowRunDetailQuery.data;
 
   const submitAccessToken = () => {
     const normalizedToken = draftAccessToken.trim();
@@ -211,6 +261,7 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
     setAccessToken('');
     setSelectedRepositoryId(null);
     setSelectedWorkflowId(null);
+    setSelectedWorkflowRunId(null);
     setTokenError(null);
     setStatusMessage(null);
     void queryClient.removeQueries({
@@ -224,6 +275,9 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
     });
     void queryClient.removeQueries({
       queryKey: ['workflow-runs'],
+    });
+    void queryClient.removeQueries({
+      queryKey: ['workflow-run-detail'],
     });
   };
 
@@ -491,9 +545,106 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
                     duration: {formatDuration(run.durationMs)}
                   </span>
                 </div>
+                <div className="workflow-runs-list__actions">
+                  <Button
+                    variant={run.id === selectedWorkflowRunId ? 'secondary' : 'primary'}
+                    onClick={() => setSelectedWorkflowRunId(run.id)}
+                  >
+                    {run.id === selectedWorkflowRunId ? 'Viewing run detail' : 'View run detail'}
+                  </Button>
+                </div>
               </li>
             ))}
           </ul>
+        )}
+      </Card>
+
+      <Card
+        eyebrow="Workflow run detail"
+        title={selectedWorkflowRun ? `Run #${selectedWorkflowRun.githubRunId}` : 'Workflow run detail'}
+      >
+        {!hasAccessToken ? (
+          <p className="empty-state">
+            Add an operator token to inspect workflow run details.
+          </p>
+        ) : !selectedRepository ? (
+          <p className="empty-state">Select a repository to inspect run details.</p>
+        ) : !selectedWorkflow ? (
+          <p className="empty-state">Select a workflow to inspect run details.</p>
+        ) : workflowRunsQuery.isLoading ? (
+          <p className="empty-state">Loading workflow runs before showing run detail...</p>
+        ) : workflowRuns.length === 0 ? (
+          <p className="empty-state">
+            No workflow runs are available yet for this workflow.
+          </p>
+        ) : !selectedWorkflowRun ? (
+          <p className="empty-state">Select a workflow run to load detail.</p>
+        ) : workflowRunDetailQuery.isLoading ? (
+          <p className="empty-state">Loading workflow run detail...</p>
+        ) : workflowRunDetailQuery.isError ? (
+          <p className="empty-state">
+            {getErrorMessage(workflowRunDetailQuery.error, 'Unable to load workflow run detail.')}
+          </p>
+        ) : !workflowRunDetail ? (
+          <p className="empty-state">Workflow run detail is unavailable.</p>
+        ) : (
+          <div className="workflow-run-detail">
+            <div className="workflow-runs-list__meta">
+              <span className="repository-list__badge repository-list__badge--neutral">
+                status: {workflowRunDetail.run.status}
+              </span>
+              <span className="repository-list__badge repository-list__badge--neutral">
+                conclusion: {workflowRunDetail.run.conclusion ?? 'n/a'}
+              </span>
+              <span className="repository-list__badge repository-list__badge--neutral">
+                branch: {workflowRunDetail.run.branch}
+              </span>
+              <span className="repository-list__badge repository-list__badge--neutral">
+                event: {workflowRunDetail.run.event}
+              </span>
+              <span className="repository-list__badge repository-list__badge--neutral">
+                started: {formatTimestamp(workflowRunDetail.run.startedAt)}
+              </span>
+              <span className="repository-list__badge repository-list__badge--neutral">
+                finished: {formatTimestamp(workflowRunDetail.run.finishedAt)}
+              </span>
+              <span className="repository-list__badge repository-list__badge--neutral">
+                duration: {formatDuration(workflowRunDetail.run.durationMs)}
+              </span>
+              <span className="repository-list__badge repository-list__badge--neutral">
+                jobs: {workflowRunDetail.jobs.length}
+              </span>
+            </div>
+
+            {workflowRunDetail.jobs.length === 0 ? (
+              <p className="empty-state">No jobs were synchronized for this workflow run.</p>
+            ) : (
+              <ul className="workflow-jobs-list">
+                {(workflowRunDetail.jobs ?? EMPTY_WORKFLOW_RUN_DETAIL_JOBS).map((job) => (
+                  <li key={job.id} className="workflow-jobs-list__item">
+                    <div className="workflow-jobs-list__summary">
+                      <strong>{job.name}</strong>
+                      <span>job id: {job.githubJobId}</span>
+                    </div>
+                    <div className="workflow-runs-list__meta">
+                      <span className="repository-list__badge repository-list__badge--neutral">
+                        status: {job.status}
+                      </span>
+                      <span className="repository-list__badge repository-list__badge--neutral">
+                        conclusion: {job.conclusion ?? 'n/a'}
+                      </span>
+                      <span className="repository-list__badge repository-list__badge--neutral">
+                        started: {formatTimestamp(job.startedAt)}
+                      </span>
+                      <span className="repository-list__badge repository-list__badge--neutral">
+                        finished: {formatTimestamp(job.finishedAt)}
+                      </span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         )}
       </Card>
     </div>

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -122,11 +122,43 @@ const workflowRunsResponseSchema = z.object({
   runs: z.array(workflowRunItemSchema),
 });
 
+const workflowRunJobItemSchema = z.object({
+  id: z.string().min(1),
+  workflowRunId: z.string().min(1),
+  githubJobId: z.string().min(1),
+  name: z.string().min(1),
+  status: z.enum(['queued', 'in_progress', 'completed', 'pending', 'waiting', 'requested']),
+  conclusion: z
+    .enum([
+      'success',
+      'failure',
+      'neutral',
+      'cancelled',
+      'skipped',
+      'timed_out',
+      'action_required',
+      'stale',
+      'startup_failure',
+    ])
+    .nullable(),
+  startedAt: z.string().datetime().nullable(),
+  finishedAt: z.string().datetime().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+const workflowRunDetailResponseSchema = z.object({
+  run: workflowRunItemSchema,
+  jobs: z.array(workflowRunJobItemSchema),
+});
+
 export type MonitoredRepository = z.infer<typeof monitoredRepositorySchema>;
 export type RepositoryDiscoveryItem = z.infer<typeof repositoryDiscoveryItemSchema>;
 export type CreateRepositoryInput = z.infer<typeof createRepositoryInputSchema>;
 export type WorkflowCatalogItem = z.infer<typeof workflowCatalogItemSchema>;
 export type WorkflowRunItem = z.infer<typeof workflowRunItemSchema>;
+export type WorkflowRunJobItem = z.infer<typeof workflowRunJobItemSchema>;
+export type WorkflowRunDetailResponse = z.infer<typeof workflowRunDetailResponseSchema>;
 
 interface CreateApiClientOptions {
   baseUrl?: string;
@@ -159,6 +191,12 @@ export interface ForgeOpsApiClient {
     repositoryId: string,
     workflowId: string,
   ): Promise<WorkflowRunItem[]>;
+  getWorkflowRunDetail(
+    accessToken: string,
+    repositoryId: string,
+    workflowId: string,
+    workflowRunId: string,
+  ): Promise<WorkflowRunDetailResponse>;
   createRepository(
     accessToken: string,
     input: CreateRepositoryInput,
@@ -263,6 +301,29 @@ export const createApiClient = (options: CreateApiClientOptions = {}): ForgeOpsA
       }
 
       return workflowRunsResponseSchema.parse(await response.json()).runs;
+    },
+
+    async getWorkflowRunDetail(
+      accessToken: string,
+      repositoryId: string,
+      workflowId: string,
+      workflowRunId: string,
+    ): Promise<WorkflowRunDetailResponse> {
+      const response = await fetcher(
+        `${baseUrl}/api/v1/repositories/${repositoryId}/workflows/${workflowId}/runs/${workflowRunId}`,
+        {
+          headers: buildHeaders(accessToken),
+        },
+      );
+
+      if (!response.ok) {
+        throw await createApiError(
+          response,
+          `Failed to fetch workflow run detail (${response.status})`,
+        );
+      }
+
+      return workflowRunDetailResponseSchema.parse(await response.json());
     },
 
     async createRepository(

--- a/frontend/src/tests/api-client.test.ts
+++ b/frontend/src/tests/api-client.test.ts
@@ -281,6 +281,97 @@ describe('createApiClient', () => {
     );
   });
 
+  it('should fetch workflow run detail with jobs', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          run: {
+            id: 'run_123',
+            workflowId: 'workflow_123',
+            githubRunId: '1001',
+            status: 'completed',
+            conclusion: 'success',
+            branch: 'main',
+            sha: 'abcdef123456',
+            event: 'push',
+            startedAt: '2026-03-31T11:00:00.000Z',
+            finishedAt: '2026-03-31T11:03:00.000Z',
+            durationMs: 180000,
+            createdAt: '2026-03-31T11:00:00.000Z',
+            updatedAt: '2026-03-31T11:03:00.000Z',
+          },
+          jobs: [
+            {
+              id: 'job_123',
+              workflowRunId: 'run_123',
+              githubJobId: 'job-gh-1',
+              name: 'lint',
+              status: 'completed',
+              conclusion: 'success',
+              startedAt: '2026-03-31T11:00:30.000Z',
+              finishedAt: '2026-03-31T11:01:00.000Z',
+              createdAt: '2026-03-31T11:00:30.000Z',
+              updatedAt: '2026-03-31T11:01:00.000Z',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+      ),
+    );
+    const client = createApiClient({
+      baseUrl: 'http://localhost:3333',
+      fetcher,
+    });
+
+    await expect(
+      client.getWorkflowRunDetail('trusted-token', 'repo_123', 'workflow_123', 'run_123'),
+    ).resolves.toEqual({
+      run: {
+        id: 'run_123',
+        workflowId: 'workflow_123',
+        githubRunId: '1001',
+        status: 'completed',
+        conclusion: 'success',
+        branch: 'main',
+        sha: 'abcdef123456',
+        event: 'push',
+        startedAt: '2026-03-31T11:00:00.000Z',
+        finishedAt: '2026-03-31T11:03:00.000Z',
+        durationMs: 180000,
+        createdAt: '2026-03-31T11:00:00.000Z',
+        updatedAt: '2026-03-31T11:03:00.000Z',
+      },
+      jobs: [
+        {
+          id: 'job_123',
+          workflowRunId: 'run_123',
+          githubJobId: 'job-gh-1',
+          name: 'lint',
+          status: 'completed',
+          conclusion: 'success',
+          startedAt: '2026-03-31T11:00:30.000Z',
+          finishedAt: '2026-03-31T11:01:00.000Z',
+          createdAt: '2026-03-31T11:00:30.000Z',
+          updatedAt: '2026-03-31T11:01:00.000Z',
+        },
+      ],
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      'http://localhost:3333/api/v1/repositories/repo_123/workflows/workflow_123/runs/run_123',
+      {
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer trusted-token',
+        },
+      },
+    );
+  });
+
   it('should create repositories and surface structured API errors', async () => {
     const fetcher = vi
       .fn<typeof fetch>()

--- a/frontend/src/tests/repositories-view.test.tsx
+++ b/frontend/src/tests/repositories-view.test.tsx
@@ -27,6 +27,7 @@ describe('RepositoriesView', () => {
       getRepositoryDiscovery: vi.fn(),
       getRepositoryWorkflows: vi.fn(),
       getWorkflowRuns: vi.fn(),
+      getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -122,6 +123,24 @@ describe('RepositoriesView', () => {
       getRepositoryDiscovery,
       getRepositoryWorkflows,
       getWorkflowRuns,
+      getWorkflowRunDetail: vi.fn().mockResolvedValue({
+        run: {
+          id: 'run_123',
+          workflowId: 'workflow_123',
+          githubRunId: '1001',
+          status: 'completed',
+          conclusion: 'success',
+          branch: 'main',
+          sha: 'abcdef123456',
+          event: 'push',
+          startedAt: '2026-03-31T11:00:00.000Z',
+          finishedAt: '2026-03-31T11:03:00.000Z',
+          durationMs: 180000,
+          createdAt: '2026-03-31T11:00:00.000Z',
+          updatedAt: '2026-03-31T11:03:00.000Z',
+        },
+        jobs: [],
+      }),
       createRepository,
     };
 
@@ -181,6 +200,7 @@ describe('RepositoriesView', () => {
         },
       ]),
       getWorkflowRuns: vi.fn().mockImplementation(() => new Promise(() => undefined)),
+      getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -227,6 +247,7 @@ describe('RepositoriesView', () => {
         },
       ]),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -277,6 +298,7 @@ describe('RepositoriesView', () => {
       getWorkflowRuns: vi
         .fn()
         .mockRejectedValue(new ApiClientError('Workflow runs are currently unavailable.', 503)),
+      getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -289,6 +311,343 @@ describe('RepositoriesView', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Workflow runs are currently unavailable.')).toBeInTheDocument();
+    });
+  });
+
+  it('should load workflow run detail with jobs after selecting a run', async () => {
+    const getWorkflowRunDetail = vi
+      .fn<ForgeOpsApiClient['getWorkflowRunDetail']>()
+      .mockResolvedValue({
+        run: {
+          id: 'run_123',
+          workflowId: 'workflow_123',
+          githubRunId: '1001',
+          status: 'completed',
+          conclusion: 'success',
+          branch: 'main',
+          sha: 'abcdef123456',
+          event: 'push',
+          startedAt: '2026-03-31T11:00:00.000Z',
+          finishedAt: '2026-03-31T11:03:00.000Z',
+          durationMs: 180000,
+          createdAt: '2026-03-31T11:00:00.000Z',
+          updatedAt: '2026-03-31T11:03:00.000Z',
+        },
+        jobs: [
+          {
+            id: 'job_123',
+            workflowRunId: 'run_123',
+            githubJobId: 'job-gh-1',
+            name: 'lint',
+            status: 'completed',
+            conclusion: 'success',
+            startedAt: '2026-03-31T11:00:20.000Z',
+            finishedAt: '2026-03-31T11:00:50.000Z',
+            createdAt: '2026-03-31T11:00:20.000Z',
+            updatedAt: '2026-03-31T11:00:50.000Z',
+          },
+        ],
+      });
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([
+        {
+          id: 'workflow_123',
+          repositoryId: 'repo_123',
+          githubWorkflowId: 'workflow-gh-123',
+          name: 'CI',
+          path: '.github/workflows/ci.yml',
+          state: 'active',
+          sourceType: 'local',
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getWorkflowRuns: vi.fn().mockResolvedValue([
+        {
+          id: 'run_123',
+          workflowId: 'workflow_123',
+          githubRunId: '1001',
+          status: 'completed',
+          conclusion: 'success',
+          branch: 'main',
+          sha: 'abcdef123456',
+          event: 'push',
+          startedAt: '2026-03-31T11:00:00.000Z',
+          finishedAt: '2026-03-31T11:03:00.000Z',
+          durationMs: 180000,
+          createdAt: '2026-03-31T11:00:00.000Z',
+          updatedAt: '2026-03-31T11:03:00.000Z',
+        },
+      ]),
+      getWorkflowRunDetail,
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'View run detail' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'View run detail' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Workflow run detail')).toBeInTheDocument();
+      expect(screen.getByText('jobs: 1')).toBeInTheDocument();
+      expect(screen.getByText('lint')).toBeInTheDocument();
+    });
+
+    expect(getWorkflowRunDetail).toHaveBeenCalledWith(
+      'trusted-token',
+      'repo_123',
+      'workflow_123',
+      'run_123',
+    );
+  });
+
+  it('should render workflow run detail loading state', async () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([
+        {
+          id: 'workflow_123',
+          repositoryId: 'repo_123',
+          githubWorkflowId: 'workflow-gh-123',
+          name: 'CI',
+          path: '.github/workflows/ci.yml',
+          state: 'active',
+          sourceType: 'local',
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getWorkflowRuns: vi.fn().mockResolvedValue([
+        {
+          id: 'run_123',
+          workflowId: 'workflow_123',
+          githubRunId: '1001',
+          status: 'completed',
+          conclusion: 'success',
+          branch: 'main',
+          sha: 'abcdef123456',
+          event: 'push',
+          startedAt: '2026-03-31T11:00:00.000Z',
+          finishedAt: '2026-03-31T11:03:00.000Z',
+          durationMs: 180000,
+          createdAt: '2026-03-31T11:00:00.000Z',
+          updatedAt: '2026-03-31T11:03:00.000Z',
+        },
+      ]),
+      getWorkflowRunDetail: vi.fn().mockImplementation(() => new Promise(() => undefined)),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'View run detail' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'View run detail' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Loading workflow run detail...')).toBeInTheDocument();
+    });
+  });
+
+  it('should render workflow run detail empty jobs state', async () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([
+        {
+          id: 'workflow_123',
+          repositoryId: 'repo_123',
+          githubWorkflowId: 'workflow-gh-123',
+          name: 'CI',
+          path: '.github/workflows/ci.yml',
+          state: 'active',
+          sourceType: 'local',
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getWorkflowRuns: vi.fn().mockResolvedValue([
+        {
+          id: 'run_123',
+          workflowId: 'workflow_123',
+          githubRunId: '1001',
+          status: 'completed',
+          conclusion: 'success',
+          branch: 'main',
+          sha: 'abcdef123456',
+          event: 'push',
+          startedAt: '2026-03-31T11:00:00.000Z',
+          finishedAt: '2026-03-31T11:03:00.000Z',
+          durationMs: 180000,
+          createdAt: '2026-03-31T11:00:00.000Z',
+          updatedAt: '2026-03-31T11:03:00.000Z',
+        },
+      ]),
+      getWorkflowRunDetail: vi.fn().mockResolvedValue({
+        run: {
+          id: 'run_123',
+          workflowId: 'workflow_123',
+          githubRunId: '1001',
+          status: 'completed',
+          conclusion: 'success',
+          branch: 'main',
+          sha: 'abcdef123456',
+          event: 'push',
+          startedAt: '2026-03-31T11:00:00.000Z',
+          finishedAt: '2026-03-31T11:03:00.000Z',
+          durationMs: 180000,
+          createdAt: '2026-03-31T11:00:00.000Z',
+          updatedAt: '2026-03-31T11:03:00.000Z',
+        },
+        jobs: [],
+      }),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'View run detail' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'View run detail' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No jobs were synchronized for this workflow run.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should render workflow run detail errors clearly', async () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([
+        {
+          id: 'workflow_123',
+          repositoryId: 'repo_123',
+          githubWorkflowId: 'workflow-gh-123',
+          name: 'CI',
+          path: '.github/workflows/ci.yml',
+          state: 'active',
+          sourceType: 'local',
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getWorkflowRuns: vi.fn().mockResolvedValue([
+        {
+          id: 'run_123',
+          workflowId: 'workflow_123',
+          githubRunId: '1001',
+          status: 'completed',
+          conclusion: 'success',
+          branch: 'main',
+          sha: 'abcdef123456',
+          event: 'push',
+          startedAt: '2026-03-31T11:00:00.000Z',
+          finishedAt: '2026-03-31T11:03:00.000Z',
+          durationMs: 180000,
+          createdAt: '2026-03-31T11:00:00.000Z',
+          updatedAt: '2026-03-31T11:03:00.000Z',
+        },
+      ]),
+      getWorkflowRunDetail: vi
+        .fn()
+        .mockRejectedValue(new ApiClientError('Workflow run detail is unavailable.', 503)),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'View run detail' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'View run detail' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Workflow run detail is unavailable.')).toBeInTheDocument();
     });
   });
 
@@ -355,6 +714,7 @@ describe('RepositoriesView', () => {
       getRepositoryDiscovery,
       getRepositoryWorkflows,
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      getWorkflowRunDetail: vi.fn(),
       createRepository,
     };
 
@@ -398,6 +758,7 @@ describe('RepositoriesView', () => {
         ),
       getRepositoryWorkflows: vi.fn(),
       getWorkflowRuns: vi.fn(),
+      getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -447,6 +808,7 @@ describe('RepositoriesView', () => {
       ]),
       getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      getWorkflowRunDetail: vi.fn(),
       createRepository: vi
         .fn()
         .mockRejectedValue(
@@ -497,6 +859,7 @@ describe('RepositoriesView', () => {
           new ApiClientError('Repository was not found.', 404, 'repository_not_found'),
         ),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
     };
 


### PR DESCRIPTION
## Summary
- add frontend support to load workflow run detail from the protected backend API
- allow selecting a workflow run from the repository workflow context and render its jobs
- cover loading, error, empty-job and success states in frontend tests

## Validation
- npm.cmd --prefix frontend run test
- npm.cmd --prefix frontend run typecheck
- npm.cmd --prefix frontend run lint
- npm.cmd run test
- npm.cmd run typecheck
- npm.cmd run lint

Closes #68