### PR TITLE
feat(backend): add pull request persistence baseline

### DIFF
--- a/backend/prisma/migrations/20260331171000_add_pull_request/migration.sql
+++ b/backend/prisma/migrations/20260331171000_add_pull_request/migration.sql
@@ -1,0 +1,38 @@
+﻿-- CreateEnum
+CREATE TYPE "PullRequestState" AS ENUM ('open', 'closed', 'merged');
+
+-- CreateTable
+CREATE TABLE "PullRequest" (
+  "id" TEXT NOT NULL,
+  "repositoryId" TEXT NOT NULL,
+  "githubPrId" TEXT NOT NULL,
+  "number" INTEGER NOT NULL,
+  "title" TEXT NOT NULL,
+  "state" "PullRequestState" NOT NULL,
+  "author" TEXT NOT NULL,
+  "baseBranch" TEXT NOT NULL,
+  "headBranch" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "PullRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PullRequest_repositoryId_githubPrId_key"
+ON "PullRequest"("repositoryId", "githubPrId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PullRequest_repositoryId_number_key"
+ON "PullRequest"("repositoryId", "number");
+
+-- CreateIndex
+CREATE INDEX "PullRequest_repositoryId_createdAt_idx"
+ON "PullRequest"("repositoryId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "PullRequest"
+ADD CONSTRAINT "PullRequest_repositoryId_fkey"
+FOREIGN KEY ("repositoryId") REFERENCES "Repository"("id")
+ON DELETE CASCADE
+ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -18,6 +18,7 @@ model Repository {
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
   workflows     Workflow[]
+  pullRequests  PullRequest[]
 
   @@index([owner, name])
 }
@@ -77,6 +78,25 @@ model WorkflowJob {
   @@index([workflowRunId, startedAt])
 }
 
+model PullRequest {
+  id           String           @id @default(cuid())
+  repositoryId String
+  githubPrId   String
+  number       Int
+  title        String
+  state        PullRequestState
+  author       String
+  baseBranch   String
+  headBranch   String
+  createdAt    DateTime         @default(now())
+  updatedAt    DateTime         @updatedAt
+  repository   Repository       @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
+
+  @@unique([repositoryId, githubPrId])
+  @@unique([repositoryId, number])
+  @@index([repositoryId, createdAt])
+}
+
 enum WorkflowState {
   active
   deleted
@@ -109,5 +129,11 @@ enum WorkflowExecutionConclusion {
   action_required
   stale
   startup_failure
+}
+
+enum PullRequestState {
+  open
+  closed
+  merged
 }
 

--- a/backend/src/modules/pull-request-insights/pull-request.entity.ts
+++ b/backend/src/modules/pull-request-insights/pull-request.entity.ts
@@ -1,0 +1,26 @@
+export type PullRequestState = 'open' | 'closed' | 'merged';
+
+export interface PullRequest {
+  id: string;
+  repositoryId: string;
+  githubPrId: string;
+  number: number;
+  title: string;
+  state: PullRequestState;
+  author: string;
+  baseBranch: string;
+  headBranch: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreatePullRequestInput {
+  repositoryId: string;
+  githubPrId: string;
+  number: number;
+  title: string;
+  state: PullRequestState;
+  author: string;
+  baseBranch: string;
+  headBranch: string;
+}

--- a/backend/src/modules/pull-request-insights/pull-request.errors.ts
+++ b/backend/src/modules/pull-request-insights/pull-request.errors.ts
@@ -1,0 +1,13 @@
+import { ApplicationError } from '../../shared/errors/application-error.js';
+
+export class PullRequestAlreadyExistsError extends ApplicationError {
+  constructor(message = 'Pull request is already synchronized.') {
+    super(message, 409, 'pull_request_already_exists');
+  }
+}
+
+export class PullRequestNotFoundError extends ApplicationError {
+  constructor(message = 'Pull request was not found.') {
+    super(message, 404, 'pull_request_not_found');
+  }
+}

--- a/backend/src/modules/pull-request-insights/pull-request.prisma-repository.ts
+++ b/backend/src/modules/pull-request-insights/pull-request.prisma-repository.ts
@@ -1,0 +1,179 @@
+import { PullRequestAlreadyExistsError } from './pull-request.errors.js';
+import type {
+  CreatePullRequestInput,
+  PullRequest,
+  PullRequestState,
+} from './pull-request.entity.js';
+import type { PullRequestRepository } from './pull-request.repository.js';
+
+interface PullRequestRecord {
+  id: string;
+  repositoryId: string;
+  githubPrId: string;
+  number: number;
+  title: string;
+  state: PullRequestState;
+  author: string;
+  baseBranch: string;
+  headBranch: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+type PullRequestDelegate = {
+  create(args: {
+    data: {
+      repositoryId: string;
+      githubPrId: string;
+      number: number;
+      title: string;
+      state: PullRequestState;
+      author: string;
+      baseBranch: string;
+      headBranch: string;
+    };
+  }): Promise<PullRequestRecord>;
+  upsert(args: {
+    where: {
+      repositoryId_githubPrId: {
+        repositoryId: string;
+        githubPrId: string;
+      };
+    };
+    create: {
+      repositoryId: string;
+      githubPrId: string;
+      number: number;
+      title: string;
+      state: PullRequestState;
+      author: string;
+      baseBranch: string;
+      headBranch: string;
+    };
+    update: {
+      number: number;
+      title: string;
+      state: PullRequestState;
+      author: string;
+      baseBranch: string;
+      headBranch: string;
+    };
+  }): Promise<PullRequestRecord>;
+  findMany(args: {
+    where: {
+      repositoryId: string;
+    };
+    orderBy: [{ number: 'asc' | 'desc' }, { createdAt: 'asc' | 'desc' }];
+  }): Promise<PullRequestRecord[]>;
+  findUnique(args: {
+    where: {
+      id: string;
+    };
+  }): Promise<PullRequestRecord | null>;
+};
+
+const isUniqueConstraintError = (error: unknown): boolean => {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'P2002'
+  );
+};
+
+const toPullRequest = (record: PullRequestRecord): PullRequest => {
+  return {
+    id: record.id,
+    repositoryId: record.repositoryId,
+    githubPrId: record.githubPrId,
+    number: record.number,
+    title: record.title,
+    state: record.state,
+    author: record.author,
+    baseBranch: record.baseBranch,
+    headBranch: record.headBranch,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+};
+
+export class PrismaPullRequestRepository implements PullRequestRepository {
+  constructor(private readonly pullRequest: PullRequestDelegate) {}
+
+  async create(input: CreatePullRequestInput): Promise<PullRequest> {
+    try {
+      const record = await this.pullRequest.create({
+        data: {
+          repositoryId: input.repositoryId,
+          githubPrId: input.githubPrId,
+          number: input.number,
+          title: input.title,
+          state: input.state,
+          author: input.author,
+          baseBranch: input.baseBranch,
+          headBranch: input.headBranch,
+        },
+      });
+
+      return toPullRequest(record);
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw new PullRequestAlreadyExistsError();
+      }
+
+      throw error;
+    }
+  }
+
+  async upsert(input: CreatePullRequestInput): Promise<PullRequest> {
+    const record = await this.pullRequest.upsert({
+      where: {
+        repositoryId_githubPrId: {
+          repositoryId: input.repositoryId,
+          githubPrId: input.githubPrId,
+        },
+      },
+      create: {
+        repositoryId: input.repositoryId,
+        githubPrId: input.githubPrId,
+        number: input.number,
+        title: input.title,
+        state: input.state,
+        author: input.author,
+        baseBranch: input.baseBranch,
+        headBranch: input.headBranch,
+      },
+      update: {
+        number: input.number,
+        title: input.title,
+        state: input.state,
+        author: input.author,
+        baseBranch: input.baseBranch,
+        headBranch: input.headBranch,
+      },
+    });
+
+    return toPullRequest(record);
+  }
+
+  async listByRepositoryId(repositoryId: string): Promise<PullRequest[]> {
+    const records = await this.pullRequest.findMany({
+      where: {
+        repositoryId,
+      },
+      orderBy: [{ number: 'desc' }, { createdAt: 'desc' }],
+    });
+
+    return records.map(toPullRequest);
+  }
+
+  async findById(id: string): Promise<PullRequest | null> {
+    const record = await this.pullRequest.findUnique({
+      where: {
+        id,
+      },
+    });
+
+    return record ? toPullRequest(record) : null;
+  }
+}

--- a/backend/src/modules/pull-request-insights/pull-request.repository.ts
+++ b/backend/src/modules/pull-request-insights/pull-request.repository.ts
@@ -1,0 +1,11 @@
+import type {
+  CreatePullRequestInput,
+  PullRequest,
+} from './pull-request.entity.js';
+
+export interface PullRequestRepository {
+  create(input: CreatePullRequestInput): Promise<PullRequest>;
+  upsert(input: CreatePullRequestInput): Promise<PullRequest>;
+  listByRepositoryId(repositoryId: string): Promise<PullRequest[]>;
+  findById(id: string): Promise<PullRequest | null>;
+}

--- a/backend/src/tests/modules/pull-request-insights/pull-request.prisma-repository.test.ts
+++ b/backend/src/tests/modules/pull-request-insights/pull-request.prisma-repository.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PullRequestAlreadyExistsError } from '../../../modules/pull-request-insights/pull-request.errors.js';
+import { PrismaPullRequestRepository } from '../../../modules/pull-request-insights/pull-request.prisma-repository.js';
+
+interface PullRequestRecord {
+  id: string;
+  repositoryId: string;
+  githubPrId: string;
+  number: number;
+  title: string;
+  state: 'open' | 'closed' | 'merged';
+  author: string;
+  baseBranch: string;
+  headBranch: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const buildRecord = (
+  overrides: Partial<PullRequestRecord> = {},
+): PullRequestRecord => {
+  const createdAt = new Date('2026-03-31T16:00:00.000Z');
+
+  return {
+    id: 'pr_123',
+    repositoryId: 'repo_123',
+    githubPrId: '987654321',
+    number: 42,
+    title: 'Add workflow dashboard',
+    state: 'open',
+    author: 'alessandrolsdev',
+    baseBranch: 'main',
+    headBranch: 'feature/workflow-dashboard',
+    createdAt,
+    updatedAt: createdAt,
+    ...overrides,
+  };
+};
+
+describe('PrismaPullRequestRepository', () => {
+  it('should create and map a pull request record', async () => {
+    const create = vi.fn().mockResolvedValue(buildRecord());
+    const upsert = vi.fn();
+    const findMany = vi.fn();
+    const findUnique = vi.fn();
+    const repository = new PrismaPullRequestRepository({
+      create,
+      upsert,
+      findMany,
+      findUnique,
+    });
+
+    await expect(
+      repository.create({
+        repositoryId: 'repo_123',
+        githubPrId: '987654321',
+        number: 42,
+        title: 'Add workflow dashboard',
+        state: 'open',
+        author: 'alessandrolsdev',
+        baseBranch: 'main',
+        headBranch: 'feature/workflow-dashboard',
+      }),
+    ).resolves.toEqual(buildRecord());
+
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        repositoryId: 'repo_123',
+        githubPrId: '987654321',
+        number: 42,
+        title: 'Add workflow dashboard',
+        state: 'open',
+        author: 'alessandrolsdev',
+        baseBranch: 'main',
+        headBranch: 'feature/workflow-dashboard',
+      },
+    });
+  });
+
+  it('should list pull requests by repository ordered by newest first', async () => {
+    const create = vi.fn();
+    const upsert = vi.fn();
+    const findUnique = vi.fn();
+    const findMany = vi.fn().mockResolvedValue([
+      buildRecord({
+        id: 'pr_2',
+        githubPrId: '2',
+        number: 43,
+        title: 'Fix flaky tests',
+      }),
+      buildRecord({
+        id: 'pr_1',
+        githubPrId: '1',
+      }),
+    ]);
+    const repository = new PrismaPullRequestRepository({
+      create,
+      upsert,
+      findMany,
+      findUnique,
+    });
+
+    await expect(repository.listByRepositoryId('repo_123')).resolves.toEqual([
+      buildRecord({
+        id: 'pr_2',
+        githubPrId: '2',
+        number: 43,
+        title: 'Fix flaky tests',
+      }),
+      buildRecord({
+        id: 'pr_1',
+        githubPrId: '1',
+      }),
+    ]);
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        repositoryId: 'repo_123',
+      },
+      orderBy: [{ number: 'desc' }, { createdAt: 'desc' }],
+    });
+  });
+
+  it('should find a pull request by id', async () => {
+    const create = vi.fn();
+    const upsert = vi.fn();
+    const findMany = vi.fn();
+    const findUnique = vi.fn().mockResolvedValue(buildRecord());
+    const repository = new PrismaPullRequestRepository({
+      create,
+      upsert,
+      findMany,
+      findUnique,
+    });
+
+    await expect(repository.findById('pr_123')).resolves.toEqual(buildRecord());
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: {
+        id: 'pr_123',
+      },
+    });
+  });
+
+  it('should translate unique constraint errors into a domain conflict', async () => {
+    const create = vi.fn().mockRejectedValue({ code: 'P2002' });
+    const upsert = vi.fn();
+    const findMany = vi.fn();
+    const findUnique = vi.fn();
+    const repository = new PrismaPullRequestRepository({
+      create,
+      upsert,
+      findMany,
+      findUnique,
+    });
+
+    await expect(
+      repository.create({
+        repositoryId: 'repo_123',
+        githubPrId: '987654321',
+        number: 42,
+        title: 'Add workflow dashboard',
+        state: 'open',
+        author: 'alessandrolsdev',
+        baseBranch: 'main',
+        headBranch: 'feature/workflow-dashboard',
+      }),
+    ).rejects.toBeInstanceOf(PullRequestAlreadyExistsError);
+  });
+
+  it('should upsert pull requests by repository and GitHub pull request id', async () => {
+    const create = vi.fn();
+    const upsert = vi.fn().mockResolvedValue(
+      buildRecord({
+        state: 'merged',
+      }),
+    );
+    const findMany = vi.fn();
+    const findUnique = vi.fn();
+    const repository = new PrismaPullRequestRepository({
+      create,
+      upsert,
+      findMany,
+      findUnique,
+    });
+
+    await expect(
+      repository.upsert({
+        repositoryId: 'repo_123',
+        githubPrId: '987654321',
+        number: 42,
+        title: 'Add workflow dashboard',
+        state: 'merged',
+        author: 'alessandrolsdev',
+        baseBranch: 'main',
+        headBranch: 'feature/workflow-dashboard',
+      }),
+    ).resolves.toEqual(
+      buildRecord({
+        state: 'merged',
+      }),
+    );
+
+    expect(upsert).toHaveBeenCalledWith({
+      where: {
+        repositoryId_githubPrId: {
+          repositoryId: 'repo_123',
+          githubPrId: '987654321',
+        },
+      },
+      create: {
+        repositoryId: 'repo_123',
+        githubPrId: '987654321',
+        number: 42,
+        title: 'Add workflow dashboard',
+        state: 'merged',
+        author: 'alessandrolsdev',
+        baseBranch: 'main',
+        headBranch: 'feature/workflow-dashboard',
+      },
+      update: {
+        number: 42,
+        title: 'Add workflow dashboard',
+        state: 'merged',
+        author: 'alessandrolsdev',
+        baseBranch: 'main',
+        headBranch: 'feature/workflow-dashboard',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Prisma baseline persistence for `PullRequest` with explicit domain fields and repository relation
- add pull request insights persistence module (`entity`, `errors`, `repository`, `prisma-repository`)
- add repository-level persistence tests covering create, list, find, upsert and unique constraint behavior

## Validation
- npm.cmd --prefix backend run prisma:generate
- $env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/forgeops'; npm.cmd --prefix backend run prisma:validate
- npm.cmd --prefix backend run test
- npm.cmd --prefix backend run typecheck
- npm.cmd --prefix backend run lint
- npm.cmd run test
- npm.cmd run typecheck
- npm.cmd run lint

Closes #75