### PR TITLE
chore(ci): harden codex review readiness flow

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -32,20 +32,51 @@ jobs:
         run: |
           echo "Codex review is skipped for fork pull requests to avoid exposing review automation to untrusted contexts."
 
-      - name: Request Codex review
+      - name: Publish Codex review status
         if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          CODEX_REVIEW_ENABLED: ${{ vars.CODEX_REVIEW_ENABLED }}
         with:
           script: |
             const marker = '<!-- forgeops-codex-review -->';
-            const body = [
-              marker,
-              '@codex review',
-              '',
-              `Requested automatically for commit ${context.payload.pull_request.head.sha}.`,
-              '',
-              'If this PR is not connected to Codex review yet, keep this workflow green and finish with human review.'
+            const codexReviewEnabled = process.env.CODEX_REVIEW_ENABLED === 'true';
+            const reviewFocus = [
+              '- security-sensitive changes and secret handling',
+              '- scope alignment with the linked issue and stated acceptance criteria',
+              '- tests added or updated, plus missing coverage',
+              '- behavioural regressions or edge cases',
+              '- architectural boundaries and layering',
+              '- TypeScript typing safety and unsafe relaxations',
+              '- residual risks and follow-up items',
             ].join('\n');
+            const body = codexReviewEnabled
+              ? [
+                  marker,
+                  '@codex review',
+                  '',
+                  `Requested automatically for commit ${context.payload.pull_request.head.sha}.`,
+                  '',
+                  'Review focus:',
+                  reviewFocus,
+                  '',
+                  'If Codex does not respond with an actual review, keep this check advisory and finish with human review.',
+                ].join('\n')
+              : [
+                  marker,
+                  'Codex review automation is configured as advisory, but it is not enabled for this repository yet.',
+                  '',
+                  `No automatic Codex review was requested for commit ${context.payload.pull_request.head.sha}.`,
+                  '',
+                  'Human review remains required.',
+                  '',
+                  'Enable this workflow only after confirming that the maintainer account used for PR review is connected to GitHub in Codex and a manual `@codex review` works.',
+                  '',
+                  'Then set repository variable `CODEX_REVIEW_ENABLED=true`.',
+                  '',
+                  'Expected Codex review focus:',
+                  reviewFocus,
+                ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/docs/architecture/repo-protection.md
+++ b/docs/architecture/repo-protection.md
@@ -25,8 +25,18 @@
 ## Codex Review Policy
 - Trigger Codex review only for non-draft PRs targeting `main`.
 - Skip fork PRs by default.
-- Request review by posting `@codex review` from automation, which assumes the repository is connected to Codex on GitHub.
-- If Codex is not enabled for the repository yet, the workflow should remain non-blocking and human review remains mandatory.
+- Treat Codex review as advisory until the repository owner validates the signal quality and GitHub connector readiness.
+- Gate automatic `@codex review` requests behind repository variable `CODEX_REVIEW_ENABLED=true`.
+- Enable `CODEX_REVIEW_ENABLED` only after confirming that the maintainer account used for PR review is connected to GitHub in Codex and a manual `@codex review` produces an actual review.
+- If Codex is not enabled or not connected yet, the workflow must post a fallback comment that makes the lack of automatic review explicit and reminds reviewers that human review remains mandatory.
+- The Codex review request should focus on:
+  - security-sensitive changes and secret handling
+  - scope alignment with the linked issue and acceptance criteria
+  - tests added or updated, plus missing coverage
+  - behavioural regressions and edge cases
+  - architectural boundaries and layering
+  - TypeScript typing safety and unsafe relaxations
+  - residual risks and follow-up items
 
 ## Merge Strategy
 - Prefer squash merges during the foundation milestone.


### PR DESCRIPTION
## Summary
- gate automatic `@codex review` requests behind explicit repository readiness via `CODEX_REVIEW_ENABLED`
- publish a clear fallback PR comment when Codex review is not actually enabled, keeping human review mandatory
- document the advisory Codex review policy and expected review focus in repository protection guidance

## Validation
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run test
- local `actionlint` binary was not available in this environment; rely on the `Workflow Validation` PR check for workflow-specific validation

Closes #84