### PR TITLE
chore(ci): extract codex review workflow text into versioned prompts

### DIFF
--- a/.github/prompts/codex-comment-marker.txt
+++ b/.github/prompts/codex-comment-marker.txt
@@ -1,0 +1,1 @@
+<!-- forgeops-codex-review -->

--- a/.github/prompts/codex-fallback.md
+++ b/.github/prompts/codex-fallback.md
@@ -1,0 +1,5 @@
+Codex review automation tentou executar a revisão automática, mas não produziu um resultado utilizável.
+
+Nenhuma revisão automática foi publicada para o commit {{sha}}.
+
+Revisão humana continua obrigatória.

--- a/.github/prompts/codex-readiness.md
+++ b/.github/prompts/codex-readiness.md
@@ -1,0 +1,7 @@
+Codex review automation está configurada como advisory, mas ainda não está habilitada para este repositório.
+
+Nenhuma revisão automática do Codex foi solicitada para o commit {{sha}}.
+
+Revisão humana continua obrigatória.
+
+Habilite este workflow definindo a variável de repositório `CODEX_REVIEW_ENABLED=true` somente depois de confirmar que o fluxo de review do Codex está pronto para este repositório.

--- a/.github/prompts/codex-review.md
+++ b/.github/prompts/codex-review.md
@@ -1,26 +1,27 @@
-You are Codex reviewing a GitHub pull request for the ForgeOps repository.
+Você é o Codex revisando um pull request do repositório ForgeOps.
 
-Review only the PR metadata and unified diff provided in the request.
-Do not praise the change. Focus on actionable engineering review.
+Revise apenas os metadados do PR e o diff unificado fornecidos na requisição.
+Não elogie a mudança. Foque em revisão técnica acionável.
 
-Evaluate the pull request against these dimensions:
-- scope alignment with the linked issue and stated intent
-- bugs and behavioural regressions
-- security-sensitive changes or secret handling risks
-- architectural boundary violations or layering leaks
-- missing, weak, or incorrect tests
-- typing problems, unsafe assumptions, or overly weak validation
-- residual risks and follow-up work
+Avalie o pull request contra estas dimensões:
+- alinhamento de escopo com a issue vinculada e a intenção declarada
+- bugs e regressões comportamentais
+- mudanças sensíveis de segurança ou riscos no tratamento de segredos
+- violações de fronteira arquitetural ou vazamento de camadas
+- testes ausentes, fracos ou incorretos
+- problemas de tipagem, suposições inseguras ou validação fraca
+- riscos remanescentes e follow-ups relevantes
 
-Response rules:
-- Be concise and specific.
+Regras de resposta:
+- Responda em português do Brasil.
+- Seja conciso, direto e específico.
 - Use Markdown.
-- Start with `## Codex Review`.
-- If you find issues, list them as flat bullets ordered by severity.
-- For each finding, include:
-  - a short severity label in brackets such as `[high]`, `[medium]`, or `[low]`
-  - the concrete risk
-  - the relevant file or area when identifiable
-  - the suggested correction
-- If there are no material findings, say `No material findings.` and then add a short `Residual risk:` line.
-- End with a short `Residual risk:` line even when findings exist.
+- Comece com `## Revisão Codex`.
+- Se encontrar problemas, liste-os como bullets planos em ordem de severidade.
+- Para cada finding, inclua:
+  - um rótulo curto de severidade entre colchetes, como `[alto]`, `[médio]` ou `[baixo]`
+  - o risco concreto
+  - o arquivo ou área relevante, quando identificável
+  - a correção sugerida
+- Se não houver achados materiais, escreva `Sem achados materiais.` e depois uma linha curta de `Risco residual:`.
+- Termine com uma linha curta de `Risco residual:` mesmo quando houver findings.

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -210,51 +210,55 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const marker = '<!-- forgeops-codex-review -->';
+            const path = require('path');
             const codexReviewEnabled = process.env.CODEX_REVIEW_ENABLED === 'true';
             const openAiKeyPresent = process.env.OPENAI_API_KEY_PRESENT === 'true';
             const openAiReviewStatus = process.env.OPENAI_REVIEW_STATUS;
             const reviewPath = process.env.OPENAI_REVIEW_PATH;
+            const workspace = process.env.GITHUB_WORKSPACE;
+            const marker = fs
+              .readFileSync(path.join(workspace, '.github/prompts/codex-comment-marker.txt'), 'utf8')
+              .trim();
+            const readinessTemplate = fs.readFileSync(
+              path.join(workspace, '.github/prompts/codex-readiness.md'),
+              'utf8',
+            );
+            const fallbackTemplate = fs.readFileSync(
+              path.join(workspace, '.github/prompts/codex-fallback.md'),
+              'utf8',
+            );
+            const renderTemplate = (template) =>
+              template.replaceAll('{{sha}}', context.payload.pull_request.head.sha);
             let body;
 
             if (!codexReviewEnabled) {
               body = [
                 marker,
-                'Codex review automation is configured as advisory, but it is not enabled for this repository yet.',
-                '',
-                `No automatic Codex review was requested for commit ${context.payload.pull_request.head.sha}.`,
-                '',
-                'Human review remains required.',
-                '',
-                'Enable this workflow by setting repository variable `CODEX_REVIEW_ENABLED=true` after confirming that the Codex review path is ready for this repository.',
+                renderTemplate(readinessTemplate),
               ].join('\n');
             } else if (!openAiKeyPresent) {
               body = [
                 marker,
-                'Codex review automation is enabled, but `OPENAI_API_KEY` is not configured for this repository.',
+                'Codex review automation está habilitada, mas `OPENAI_API_KEY` não está configurada para este repositório.',
                 '',
-                `No automatic Codex review was requested for commit ${context.payload.pull_request.head.sha}.`,
+                `Nenhuma revisão automática do Codex foi solicitada para o commit ${context.payload.pull_request.head.sha}.`,
                 '',
-                'Human review remains required until the secret is configured.',
+                'Revisão humana continua obrigatória até que o secret seja configurado.',
               ].join('\n');
             } else if (openAiReviewStatus === 'completed' && reviewPath && fs.existsSync(reviewPath)) {
               const reviewText = fs.readFileSync(reviewPath, 'utf8').trim();
               body = [
                 marker,
-                `Codex review completed automatically via OpenAI API for commit ${context.payload.pull_request.head.sha}.`,
+                `Revisão Codex concluída automaticamente via OpenAI API para o commit ${context.payload.pull_request.head.sha}.`,
                 '',
                 reviewText,
                 '',
-                'This review is advisory and does not replace human review.',
+                'Esta revisão é advisory e não substitui a revisão humana.',
               ].join('\n');
             } else {
               body = [
                 marker,
-                'Codex review automation attempted an OpenAI API review, but no usable review result was produced.',
-                '',
-                `No automatic Codex review was published for commit ${context.payload.pull_request.head.sha}.`,
-                '',
-                'Human review remains required.',
+                renderTemplate(fallbackTemplate),
               ].join('\n');
             }
 

--- a/docs/architecture/repo-protection.md
+++ b/docs/architecture/repo-protection.md
@@ -29,6 +29,8 @@
 - Gate automatic `@codex review` requests behind repository variable `CODEX_REVIEW_ENABLED=true`.
 - Enable `CODEX_REVIEW_ENABLED` only after confirming that the maintainer account used for PR review is connected to GitHub in Codex and a manual `@codex review` produces an actual review.
 - If Codex is not enabled or not connected yet, the workflow must post a fallback comment that makes the lack of automatic review explicit and reminds reviewers that human review remains mandatory.
+- Keep the workflow text structure versioned under `.github/prompts/` so prompt, readiness, fallback, and marker changes are reviewable outside the YAML orchestration.
+- The automated Codex review prompt should require the response in Portuguese (Brazil).
 - The Codex review request should focus on:
   - security-sensitive changes and secret handling
   - scope alignment with the linked issue and acceptance criteria


### PR DESCRIPTION
## Summary
- extract Codex review readiness, fallback, and marker text into versioned prompt files
- require the automated review prompt to answer in português do Brasil
- keep the workflow advisory and reduce inline text coupling in `codex-review.yml`

## Testing
- `git diff --check`
- `npm.cmd run lint`
- `npm.cmd run test`
- `npm.cmd run typecheck`

Closes #89