### PR TITLE
feat(api): expõe listagem protegida de pull requests

### DIFF
--- a/backend/src/app/create-server.ts
+++ b/backend/src/app/create-server.ts
@@ -124,6 +124,7 @@ export const createServer = (options: CreateServerOptions) => {
     repositoryService,
     workflowService,
     workflowRunService,
+    pullRequestService,
   });
 
   return app;

--- a/backend/src/app/register-routes.ts
+++ b/backend/src/app/register-routes.ts
@@ -14,12 +14,15 @@ import { registerWorkflowCatalogRoutes } from '../modules/workflow-catalog/workf
 import type { WorkflowService } from '../modules/workflow-catalog/workflow.service.js';
 import { registerWorkflowRunRoutes } from '../modules/workflow-runs/workflow-run.controller.js';
 import type { WorkflowRunService } from '../modules/workflow-runs/workflow-run.service.js';
+import { registerPullRequestRoutes } from '../modules/pull-request-insights/pull-request.controller.js';
+import type { PullRequestService } from '../modules/pull-request-insights/pull-request.service.js';
 
 interface RegisterRoutesOptions {
   healthService: HealthService;
   repositoryService: RepositoryService;
   workflowService: WorkflowService;
   workflowRunService: WorkflowRunService;
+  pullRequestService: PullRequestService;
 }
 
 export type ForgeOpsFastifyInstance = FastifyInstance<
@@ -38,4 +41,5 @@ export const registerRoutes = (
   registerRepositoryRegistryRoutes(app, options.repositoryService);
   registerWorkflowCatalogRoutes(app, options.workflowService);
   registerWorkflowRunRoutes(app, options.workflowRunService);
+  registerPullRequestRoutes(app, options.pullRequestService);
 };

--- a/backend/src/modules/pull-request-insights/pull-request.controller.ts
+++ b/backend/src/modules/pull-request-insights/pull-request.controller.ts
@@ -1,0 +1,68 @@
+import type { RouteGenericInterface } from 'fastify';
+import { z } from 'zod';
+import type { ForgeOpsFastifyInstance } from '../../app/register-routes.js';
+import type { PullRequest } from './pull-request.entity.js';
+import type { PullRequestService } from './pull-request.service.js';
+
+const pullRequestParamsSchema = z.object({
+  repositoryId: z.string().trim().min(1),
+});
+
+interface PullRequestResponse {
+  id: string;
+  githubPrId: string;
+  number: number;
+  title: string;
+  state: 'open' | 'closed' | 'merged';
+  author: string;
+  baseBranch: string;
+  headBranch: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ListPullRequestsRoute extends RouteGenericInterface {
+  Params: {
+    repositoryId: string;
+  };
+  Reply: {
+    pullRequests: PullRequestResponse[];
+  };
+}
+
+const toPullRequestResponse = (pullRequest: PullRequest): PullRequestResponse => {
+  return {
+    id: pullRequest.id,
+    githubPrId: pullRequest.githubPrId,
+    number: pullRequest.number,
+    title: pullRequest.title,
+    state: pullRequest.state,
+    author: pullRequest.author,
+    baseBranch: pullRequest.baseBranch,
+    headBranch: pullRequest.headBranch,
+    createdAt: pullRequest.createdAt.toISOString(),
+    updatedAt: pullRequest.updatedAt.toISOString(),
+  };
+};
+
+export const registerPullRequestRoutes = (
+  app: ForgeOpsFastifyInstance,
+  pullRequestService: PullRequestService,
+): void => {
+  app.get<ListPullRequestsRoute>(
+    '/api/v1/repositories/:repositoryId/pull-requests',
+    {
+      config: {
+        access: 'protected',
+      },
+    },
+    async (request) => {
+      const { repositoryId } = pullRequestParamsSchema.parse(request.params);
+      const pullRequests = await pullRequestService.listByRepositoryId(repositoryId);
+
+      return {
+        pullRequests: pullRequests.map(toPullRequestResponse),
+      };
+    },
+  );
+};

--- a/backend/src/modules/pull-request-insights/pull-request.service.ts
+++ b/backend/src/modules/pull-request-insights/pull-request.service.ts
@@ -23,6 +23,17 @@ export interface PullRequestServiceOptions {
 export class PullRequestService {
   constructor(private readonly options: PullRequestServiceOptions) {}
 
+  async listByRepositoryId(repositoryId: string): Promise<PullRequest[]> {
+    const repository =
+      await this.options.repositoryRegistryRepository.findById(repositoryId);
+
+    if (!repository) {
+      throw new RepositoryNotFoundError();
+    }
+
+    return this.options.pullRequestRepository.listByRepositoryId(repositoryId);
+  }
+
   async syncByRepositoryId(repositoryId: string): Promise<PullRequest[]> {
     const repository =
       await this.options.repositoryRegistryRepository.findById(repositoryId);

--- a/backend/src/tests/app/create-server.test.ts
+++ b/backend/src/tests/app/create-server.test.ts
@@ -16,6 +16,7 @@ import type {
   WorkflowJob,
   WorkflowRun,
 } from '../../modules/workflow-runs/workflow-run.entity.js';
+import type { PullRequest } from '../../modules/pull-request-insights/pull-request.entity.js';
 
 const buildRepository = (
   overrides: Partial<Repository> = {},
@@ -119,11 +120,31 @@ const buildWorkflowJob = (overrides: Partial<WorkflowJob> = {}): WorkflowJob => 
   };
 };
 
+const buildPullRequest = (overrides: Partial<PullRequest> = {}): PullRequest => {
+  const createdAt = new Date('2026-03-31T18:20:00.000Z');
+
+  return {
+    id: 'pr_123',
+    repositoryId: 'repo_123',
+    githubPrId: '987654321',
+    number: 42,
+    title: 'Add pull request insights',
+    state: 'open',
+    author: 'alessandrolsdev',
+    baseBranch: 'main',
+    headBranch: 'feature/pull-request-insights',
+    createdAt,
+    updatedAt: createdAt,
+    ...overrides,
+  };
+};
+
 const createProtectedServer = (overrides?: {
   repositories?: Repository[];
   workflows?: Workflow[];
   workflowRuns?: WorkflowRun[];
   workflowJobs?: WorkflowJob[];
+  pullRequests?: PullRequest[];
   createRepository?: (input: CreateRepositoryInput) => Promise<Repository>;
   deleteRepositoryById?: (id: string) => Promise<void>;
   installationRepositories?: GitHubInstallationRepository[];
@@ -142,6 +163,7 @@ const createProtectedServer = (overrides?: {
   const workflowStore = [...(overrides?.workflows ?? [])];
   const workflowRunStore: WorkflowRun[] = [...(overrides?.workflowRuns ?? [])];
   const workflowJobStore: WorkflowJob[] = [...(overrides?.workflowJobs ?? [])];
+  const pullRequestStore: PullRequest[] = [...(overrides?.pullRequests ?? [])];
 
   return createServer({
     env: {
@@ -365,6 +387,54 @@ const createProtectedServer = (overrides?: {
         workflowJobStore
           .filter((workflowJob) => workflowJob.workflowRunId === workflowRunId)
           .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime()),
+    },
+    pullRequestRepository: {
+      create: async (input) =>
+        buildPullRequest({
+          repositoryId: input.repositoryId,
+          githubPrId: input.githubPrId,
+          number: input.number,
+          title: input.title,
+          state: input.state,
+          author: input.author,
+          baseBranch: input.baseBranch,
+          headBranch: input.headBranch,
+        }),
+      upsert: async (input) => {
+        const existingPullRequestIndex = pullRequestStore.findIndex(
+          (pullRequest) =>
+            pullRequest.repositoryId === input.repositoryId &&
+            pullRequest.githubPrId === input.githubPrId,
+        );
+        const pullRequest = buildPullRequest({
+          id:
+            existingPullRequestIndex >= 0
+              ? pullRequestStore[existingPullRequestIndex]!.id
+              : `pr_${pullRequestStore.length + 1}`,
+          repositoryId: input.repositoryId,
+          githubPrId: input.githubPrId,
+          number: input.number,
+          title: input.title,
+          state: input.state,
+          author: input.author,
+          baseBranch: input.baseBranch,
+          headBranch: input.headBranch,
+        });
+
+        if (existingPullRequestIndex >= 0) {
+          pullRequestStore[existingPullRequestIndex] = pullRequest;
+        } else {
+          pullRequestStore.push(pullRequest);
+        }
+
+        return pullRequest;
+      },
+      listByRepositoryId: async (repositoryId) =>
+        pullRequestStore
+          .filter((pullRequest) => pullRequest.repositoryId === repositoryId)
+          .sort((left, right) => right.number - left.number),
+      findById: async (id) =>
+        pullRequestStore.find((pullRequest) => pullRequest.id === id) ?? null,
     },
   });
 };
@@ -1349,6 +1419,164 @@ describe('createServer', () => {
         code: 'validation_error',
         message: 'String must contain at least 1 character(s)',
       },
+    });
+
+    await server.close();
+  });
+
+  it('should require authentication for pull request listing', async () => {
+    const server = createProtectedServer({
+      repositories: [buildRepository()],
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories/repo_123/pull-requests',
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'authentication_required',
+        message: 'Authentication is required.',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should reject invalid pull request list route params before service execution', async () => {
+    const server = createProtectedServer({
+      repositories: [buildRepository()],
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories/%20/pull-requests',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'validation_error',
+        message: 'String must contain at least 1 character(s)',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should return not found when the repository does not exist for pull request listing', async () => {
+    const server = createProtectedServer();
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories/repo_missing/pull-requests',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'repository_not_found',
+        message: 'Repository was not found.',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should return an empty pull request list for a monitored repository', async () => {
+    const server = createProtectedServer({
+      repositories: [buildRepository()],
+      pullRequests: [],
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories/repo_123/pull-requests',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      pullRequests: [],
+    });
+
+    await server.close();
+  });
+
+  it('should return pull requests for an authenticated operator', async () => {
+    const server = createProtectedServer({
+      repositories: [buildRepository()],
+      pullRequests: [
+        buildPullRequest({
+          id: 'pr_123',
+          githubPrId: '987654321',
+          number: 42,
+          title: 'Add pull request insights',
+          state: 'open',
+          createdAt: new Date('2026-03-31T18:20:00.000Z'),
+          updatedAt: new Date('2026-03-31T18:20:00.000Z'),
+        }),
+        buildPullRequest({
+          id: 'pr_456',
+          githubPrId: '987654322',
+          number: 43,
+          title: 'Close flaky workflow gap',
+          state: 'merged',
+          author: 'codex-bot',
+          baseBranch: 'release',
+          headBranch: 'feature/flaky-workflow-gap',
+          createdAt: new Date('2026-03-31T18:30:00.000Z'),
+          updatedAt: new Date('2026-03-31T18:31:00.000Z'),
+        }),
+      ],
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories/repo_123/pull-requests',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      pullRequests: [
+        {
+          id: 'pr_456',
+          githubPrId: '987654322',
+          number: 43,
+          title: 'Close flaky workflow gap',
+          state: 'merged',
+          author: 'codex-bot',
+          baseBranch: 'release',
+          headBranch: 'feature/flaky-workflow-gap',
+          createdAt: '2026-03-31T18:30:00.000Z',
+          updatedAt: '2026-03-31T18:31:00.000Z',
+        },
+        {
+          id: 'pr_123',
+          githubPrId: '987654321',
+          number: 42,
+          title: 'Add pull request insights',
+          state: 'open',
+          author: 'alessandrolsdev',
+          baseBranch: 'main',
+          headBranch: 'feature/pull-request-insights',
+          createdAt: '2026-03-31T18:20:00.000Z',
+          updatedAt: '2026-03-31T18:20:00.000Z',
+        },
+      ],
     });
 
     await server.close();

--- a/backend/src/tests/modules/pull-request-insights/pull-request.service.test.ts
+++ b/backend/src/tests/modules/pull-request-insights/pull-request.service.test.ts
@@ -70,6 +70,103 @@ const buildRemotePullRequest = (
 };
 
 describe('PullRequestService', () => {
+  it('should list pull requests for a monitored repository', async () => {
+    const findById = vi.fn().mockResolvedValue(buildRepository());
+    const listByRepositoryId = vi.fn().mockResolvedValue([
+      buildPullRequest({
+        id: 'pr_456',
+        githubPrId: '987654322',
+        number: 43,
+        title: 'Close flaky workflow gap',
+        state: 'merged',
+      }),
+      buildPullRequest(),
+    ]);
+    const service = new PullRequestService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById,
+        deleteById: vi.fn(),
+      },
+      pullRequestRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId,
+        findById: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+        listPullRequests: async () => [],
+      },
+    });
+
+    await expect(service.listByRepositoryId('repo_123')).resolves.toEqual([
+      buildPullRequest({
+        id: 'pr_456',
+        githubPrId: '987654322',
+        number: 43,
+        title: 'Close flaky workflow gap',
+        state: 'merged',
+      }),
+      buildPullRequest(),
+    ]);
+
+    expect(findById).toHaveBeenCalledWith('repo_123');
+    expect(listByRepositoryId).toHaveBeenCalledWith('repo_123');
+  });
+
+  it('should return an empty list when the repository has no persisted pull requests', async () => {
+    const listByRepositoryId = vi.fn().mockResolvedValue([]);
+    const service = new PullRequestService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildRepository()),
+        deleteById: vi.fn(),
+      },
+      pullRequestRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId,
+        findById: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+        listPullRequests: async () => [],
+      },
+    });
+
+    await expect(service.listByRepositoryId('repo_123')).resolves.toEqual([]);
+    expect(listByRepositoryId).toHaveBeenCalledWith('repo_123');
+  });
+
   it('should sync pull requests for a monitored repository', async () => {
     const findById = vi.fn().mockResolvedValue(buildRepository());
     const listPullRequests = vi.fn().mockResolvedValue([
@@ -237,7 +334,7 @@ describe('PullRequestService', () => {
       },
     });
 
-    await expect(service.syncByRepositoryId('repo_missing')).rejects.toBeInstanceOf(
+    await expect(service.listByRepositoryId('repo_missing')).rejects.toBeInstanceOf(
       RepositoryNotFoundError,
     );
   });


### PR DESCRIPTION
## Resumo
Expõe uma API protegida para listar pull requests persistidas de um repositório monitorado, com validação explícita de entrada e resposta estável para consumo futuro. A mudança fecha a lacuna entre a sincronização backend já existente e a primeira leitura HTTP do domínio de Pull Request Insights.

## O que foi alterado
- Adiciona a rota protegida `GET /api/v1/repositories/:repositoryId/pull-requests` no backend.
- Cria o controller de pull requests com validação de parâmetros e serialização da resposta.
- Amplia o `PullRequestService` com o caso de uso de listagem por repositório, incluindo `repository_not_found`.
- Atualiza os testes de service e HTTP para cobrir autenticação, parâmetros inválidos, vazio, not found e sucesso.

## Motivação
A baseline persistente e o sync de pull requests já existem, mas ainda não havia uma borda HTTP protegida para expor esses dados ao frontend e aos próximos incrementos do produto. Esta PR entrega a leitura mínima necessária sem avançar para detalhe, reviews ou vínculos com workflow runs.

## Como validar
- Executar `npm.cmd --prefix backend run typecheck`.
- Executar `npm.cmd --prefix backend run lint`.
- Executar `npm.cmd --prefix backend run test`.
- Executar `npm.cmd run typecheck`.
- Executar `npm.cmd run lint`.
- Executar `npm.cmd run test`.

## Riscos e impactos
- Baixo risco funcional no backend, limitado ao módulo de pull request insights e ao registro de rotas.
- O teste raiz `npm.cmd run test` pode continuar falhando por instabilidade de memória do `esbuild` no frontend, sem relação com esta mudança.
- Não há alteração de contrato além da nova rota protegida de listagem.

## Evidências
- Não há evidências anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #77