### PR TITLE
test(ci): adiciona cobertura smoke para o workflow codex-review

### DIFF
--- a/.github/scripts/codex-review-smoke.sh
+++ b/.github/scripts/codex-review-smoke.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+scenario="${SCENARIO:?SCENARIO is required}"
+fork_pr="${FORK_PR:-false}"
+review_enabled="${CODEX_REVIEW_ENABLED:-true}"
+pat_available="${PAT_AVAILABLE:-false}"
+openai_present="${OPENAI_PRESENT:-false}"
+openai_result="${OPENAI_RESULT:-failed}"
+openrouter_present="${OPENROUTER_PRESENT:-false}"
+openrouter_result="${OPENROUTER_RESULT:-failed}"
+
+comment_publisher="none"
+final_comment="false"
+review_provider="none"
+review_status="not_run"
+fallback_reason="none"
+
+if [[ "$fork_pr" == "true" ]]; then
+  echo "SCENARIO=$scenario"
+  echo "PATH=skip_fork"
+  echo "FINAL_COMMENT=false"
+  echo "COMMENT_PUBLISHER=none"
+  echo "REVIEW_PROVIDER=none"
+  echo "REVIEW_STATUS=skipped"
+  echo "FALLBACK_REASON=fork_pr"
+  exit 0
+fi
+
+if [[ "$pat_available" == "true" ]]; then
+  comment_publisher="maintainer_pat"
+else
+  comment_publisher="github_token"
+fi
+
+final_comment="true"
+
+if [[ "$review_enabled" != "true" ]]; then
+  review_status="disabled"
+  fallback_reason="codex_review_disabled"
+else
+  if [[ "$openai_present" == "true" && "$openai_result" == "completed" ]]; then
+    review_provider="openai"
+    review_status="completed"
+  elif [[ "$openrouter_present" == "true" && "$openrouter_result" == "completed" ]]; then
+    review_provider="openrouter"
+    review_status="completed"
+    if [[ "$openai_present" == "true" && "$openai_result" != "completed" ]]; then
+      fallback_reason="openai_${openai_result}"
+    fi
+  else
+    review_status="fallback_human"
+    if [[ "$openrouter_present" != "true" ]]; then
+      fallback_reason="openrouter_unavailable"
+    elif [[ "$openrouter_result" != "completed" ]]; then
+      fallback_reason="openrouter_${openrouter_result}"
+    elif [[ "$openai_present" != "true" ]]; then
+      fallback_reason="openai_unavailable"
+    else
+      fallback_reason="openai_${openai_result}"
+    fi
+  fi
+fi
+
+echo "SCENARIO=$scenario"
+echo "PATH=standard"
+echo "FINAL_COMMENT=$final_comment"
+echo "COMMENT_PUBLISHER=$comment_publisher"
+echo "REVIEW_PROVIDER=$review_provider"
+echo "REVIEW_STATUS=$review_status"
+echo "FALLBACK_REASON=$fallback_reason"

--- a/.github/workflows/codex-review-smoke.yml
+++ b/.github/workflows/codex-review-smoke.yml
@@ -1,0 +1,129 @@
+name: Codex Review Smoke
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - feature/**
+      - chore/**
+      - fix/**
+    paths:
+      - .github/workflows/codex-review.yml
+      - .github/workflows/codex-review-smoke.yml
+      - .github/prompts/codex-review.md
+      - .github/prompts/codex-fallback.md
+      - .github/prompts/codex-readiness.md
+      - .github/scripts/codex-review-smoke.sh
+
+permissions:
+  contents: read
+
+jobs:
+  codex-review-smoke:
+    name: codex-review-smoke (${{ matrix.scenario }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - scenario: pat_invalid
+            fork_pr: "false"
+            review_enabled: "true"
+            pat_available: "false"
+            openai_present: "true"
+            openai_result: "completed"
+            openrouter_present: "true"
+            openrouter_result: "completed"
+            expected_final_comment: "true"
+            expected_comment_publisher: "github_token"
+            expected_review_provider: "openai"
+            expected_review_status: "completed"
+          - scenario: openai_unavailable
+            fork_pr: "false"
+            review_enabled: "true"
+            pat_available: "true"
+            openai_present: "true"
+            openai_result: "failed"
+            openrouter_present: "true"
+            openrouter_result: "completed"
+            expected_final_comment: "true"
+            expected_comment_publisher: "maintainer_pat"
+            expected_review_provider: "openrouter"
+            expected_review_status: "completed"
+          - scenario: openrouter_unavailable
+            fork_pr: "false"
+            review_enabled: "true"
+            pat_available: "true"
+            openai_present: "true"
+            openai_result: "failed"
+            openrouter_present: "false"
+            openrouter_result: "failed"
+            expected_final_comment: "true"
+            expected_comment_publisher: "maintainer_pat"
+            expected_review_provider: "none"
+            expected_review_status: "fallback_human"
+          - scenario: fork_pr
+            fork_pr: "true"
+            review_enabled: "true"
+            pat_available: "true"
+            openai_present: "true"
+            openai_result: "completed"
+            openrouter_present: "true"
+            openrouter_result: "completed"
+            expected_final_comment: "false"
+            expected_comment_publisher: "none"
+            expected_review_provider: "none"
+            expected_review_status: "skipped"
+          - scenario: happy_path
+            fork_pr: "false"
+            review_enabled: "true"
+            pat_available: "true"
+            openai_present: "true"
+            openai_result: "completed"
+            openrouter_present: "true"
+            openrouter_result: "completed"
+            expected_final_comment: "true"
+            expected_comment_publisher: "maintainer_pat"
+            expected_review_provider: "openai"
+            expected_review_status: "completed"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run codex-review smoke scenario
+        env:
+          SCENARIO: ${{ matrix.scenario }}
+          FORK_PR: ${{ matrix.fork_pr }}
+          CODEX_REVIEW_ENABLED: ${{ matrix.review_enabled }}
+          PAT_AVAILABLE: ${{ matrix.pat_available }}
+          OPENAI_PRESENT: ${{ matrix.openai_present }}
+          OPENAI_RESULT: ${{ matrix.openai_result }}
+          OPENROUTER_PRESENT: ${{ matrix.openrouter_present }}
+          OPENROUTER_RESULT: ${{ matrix.openrouter_result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash "$GITHUB_WORKSPACE/.github/scripts/codex-review-smoke.sh" | tee "$RUNNER_TEMP/codex-review-smoke.log"
+
+      - name: Assert expected smoke path
+        env:
+          EXPECTED_FINAL_COMMENT: ${{ matrix.expected_final_comment }}
+          EXPECTED_COMMENT_PUBLISHER: ${{ matrix.expected_comment_publisher }}
+          EXPECTED_REVIEW_PROVIDER: ${{ matrix.expected_review_provider }}
+          EXPECTED_REVIEW_STATUS: ${{ matrix.expected_review_status }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          log_path="$RUNNER_TEMP/codex-review-smoke.log"
+
+          grep -q "^FINAL_COMMENT=${EXPECTED_FINAL_COMMENT}$" "$log_path"
+          grep -q "^COMMENT_PUBLISHER=${EXPECTED_COMMENT_PUBLISHER}$" "$log_path"
+          grep -q "^REVIEW_PROVIDER=${EXPECTED_REVIEW_PROVIDER}$" "$log_path"
+          grep -q "^REVIEW_STATUS=${EXPECTED_REVIEW_STATUS}$" "$log_path"


### PR DESCRIPTION
## Resumo
Esta PR adiciona cobertura smoke no n�vel de workflow para o `codex-review`, validando os caminhos cr�ticos da automa��o sem depender apenas de PRs reais e chamadas externas. A mudan�a reduz regress�es na orquestra��o de coment�rio, fallback e skip seguro.

## O que foi alterado
- Adiciona o workflow `.github/workflows/codex-review-smoke.yml` com matrix para cen�rios cr�ticos da automa��o.
- Adiciona o script `.github/scripts/codex-review-smoke.sh` para simular os caminhos principais do `codex-review` sem chamar providers reais.
- Valida cen�rios de PAT indispon�vel, OpenAI indispon�vel, OpenRouter indispon�vel, fork PR e caminho feliz por meio de assertions sobre logs e outputs.

## Motiva��o
O `codex-review` ganhou mais caminhos operacionais e fallbacks, mas ainda dependia de valida��o manual em PRs reais. Esta cobertura smoke cria uma prote��o m�nima contra regress�es na orquestra��o do workflow, mantendo o escopo restrito � automa��o.

## Como validar
- Executar `npm.cmd run lint`.
- Executar `npm.cmd run typecheck`.
- Validar o parse estrutural de `.github/workflows/codex-review-smoke.yml`.
- Executar manualmente os cen�rios simulados no script `.github/scripts/codex-review-smoke.sh`.
- Confirmar no GitHub Actions que o workflow `Codex Review Smoke` passa na matrix de cen�rios.

## Riscos e impactos
- A cobertura smoke valida uma simula��o controlada da orquestra��o, n�o a execu��o end-to-end com providers reais.
- Se o workflow principal evoluir sem atualiza��o correspondente do smoke, pode surgir drift entre comportamento real e cobertura.
- O risco operacional � baixo porque a mudan�a adiciona valida��o auxiliar e n�o altera a execu��o do workflow principal.

## Evid�ncias
- `git diff --check`
- parse YAML com `PyYAML`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- execu��o manual local dos cen�rios: `pat_invalid`, `openai_unavailable`, `openrouter_unavailable`, `fork_pr`, `happy_path`

## Checklist
- [x] Altera��o limitada ao objetivo da PR
- [x] Sem mudan�as desconexas
- [x] Impactos principais descritos
- [x] Valida��o documentada
- [x] Riscos identificados

Closes #95
