### PR TITLE
fix(ci): garante comentario final sem pat no codex-review

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -85,6 +85,7 @@ jobs:
           set -euo pipefail
 
           response_path="$RUNNER_TEMP/codex-review/commenter.json"
+          mkdir -p "$(dirname "$response_path")"
           http_status=$(
             curl -s \
               -o "$response_path" \
@@ -622,8 +623,8 @@ jobs:
           echo "provider=none" >> "$GITHUB_OUTPUT"
           echo "fallback_reason=Nenhum provider de review automatizado estava configurado para este repositorio." >> "$GITHUB_OUTPUT"
 
-      - name: Publish Codex review status as maintainer
-        if: ${{ !github.event.pull_request.head.repo.fork && steps.commenter.outputs.available == 'true' }}
+      - name: Publish Codex review status
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
         env:
           CODEX_REVIEW_ENABLED: ${{ steps.review-config.outputs.enabled }}
           CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}


### PR DESCRIPTION
## Resumo
Esta PR corrige uma inconsist�ncia cr�tica no workflow `codex-review`: o coment�rio final deixava de ser publicado quando `CODEX_REVIEW_PAT` estava ausente ou inv�lido, tornando o fallback inalcan��vel. A mudan�a preserva o PAT como melhoria opcional para comentar como usu�rio real, mas garante publica��o final via `GITHUB_TOKEN` quando necess�rio.

## O que foi alterado
- Remove o gating incorreto da publica��o final baseado em `steps.commenter.outputs.available == 'true'`.
- Faz o step de publica��o final rodar sempre em PRs n�o-fork usando `always()`.
- Mant�m a sele��o din�mica entre `CODEX_REVIEW_PAT` e `GITHUB_TOKEN` dentro do step final.
- Garante a cria��o do diret�rio tempor�rio antes da resolu��o do commenter para evitar degrada��o silenciosa do modo autenticado.

## Motiva��o
O comportamento real do workflow divergia da inten��o operacional e da expectativa j� coberta pelos smoke tests: sem PAT v�lido, o workflow n�o publicava coment�rio final algum. Isso tornava falhas de configura��o silenciosas e impedia o fallback advisory de cumprir seu papel.

## Como validar
- Executar `npm.cmd run lint`.
- Executar `npm.cmd run typecheck`.
- Validar o parse estrutural de `.github/workflows/codex-review.yml`.
- Abrir um PR de teste sem `CODEX_REVIEW_PAT` v�lido e confirmar que o coment�rio final ainda � publicado como bot.
- Abrir um PR de teste com `CODEX_REVIEW_PAT` v�lido e confirmar que o commenter autenticado continua funcionando.

## Riscos e impactos
- O risco funcional � baixo porque a mudan�a corrige o caminho de degrada��o sem alterar a arquitetura geral do workflow.
- A confirma��o final do comportamento operacional ainda depende de execu��o real no GitHub Actions em cen�rios com e sem PAT v�lido.
- A mudan�a n�o altera providers, regras de merge nem a pol�tica advisory do review.

## Evid�ncias
- `git diff --check`
- parse YAML com `PyYAML`
- `npm.cmd run lint`
- `npm.cmd run typecheck`

## Checklist
- [x] Altera��o limitada ao objetivo da PR
- [x] Sem mudan�as desconexas
- [x] Impactos principais descritos
- [x] Valida��o documentada
- [x] Riscos identificados

Closes #97
