### PR TITLE
feat(backend): adiciona baseline de summary do codex review

### DIFF
--- a/backend/prisma/migrations/20260402001000_add_codex_review_summary/migration.sql
+++ b/backend/prisma/migrations/20260402001000_add_codex_review_summary/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "CodexReviewSummarySource" AS ENUM ('github_review', 'workflow_comment');
+
+-- CreateTable
+CREATE TABLE "CodexReviewSummary" (
+    "id" TEXT NOT NULL,
+    "pullRequestId" TEXT NOT NULL,
+    "source" "CodexReviewSummarySource" NOT NULL,
+    "summary" TEXT NOT NULL,
+    "blockersCount" INTEGER NOT NULL,
+    "suggestionsCount" INTEGER NOT NULL,
+    "risksCount" INTEGER NOT NULL,
+    "rawContent" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CodexReviewSummary_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CodexReviewSummary_pullRequestId_key" ON "CodexReviewSummary"("pullRequestId");
+
+-- CreateIndex
+CREATE INDEX "CodexReviewSummary_pullRequestId_createdAt_idx" ON "CodexReviewSummary"("pullRequestId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "CodexReviewSummary" ADD CONSTRAINT "CodexReviewSummary_pullRequestId_fkey" FOREIGN KEY ("pullRequestId") REFERENCES "PullRequest"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -91,10 +91,27 @@ model PullRequest {
   createdAt    DateTime         @default(now())
   updatedAt    DateTime         @updatedAt
   repository   Repository       @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
+  codexReviewSummary CodexReviewSummary?
 
   @@unique([repositoryId, githubPrId])
   @@unique([repositoryId, number])
   @@index([repositoryId, createdAt])
+}
+
+model CodexReviewSummary {
+  id               String                   @id @default(cuid())
+  pullRequestId    String                   @unique
+  source           CodexReviewSummarySource
+  summary          String
+  blockersCount    Int
+  suggestionsCount Int
+  risksCount       Int
+  rawContent       String
+  createdAt        DateTime                 @default(now())
+  updatedAt        DateTime                 @updatedAt
+  pullRequest      PullRequest              @relation(fields: [pullRequestId], references: [id], onDelete: Cascade)
+
+  @@index([pullRequestId, createdAt])
 }
 
 enum WorkflowState {
@@ -135,5 +152,10 @@ enum PullRequestState {
   open
   closed
   merged
+}
+
+enum CodexReviewSummarySource {
+  github_review
+  workflow_comment
 }
 

--- a/backend/src/app/create-server.ts
+++ b/backend/src/app/create-server.ts
@@ -25,6 +25,9 @@ import { WorkflowRunService } from '../modules/workflow-runs/workflow-run.servic
 import { PrismaPullRequestRepository } from '../modules/pull-request-insights/pull-request.prisma-repository.js';
 import type { PullRequestRepository } from '../modules/pull-request-insights/pull-request.repository.js';
 import { PullRequestService } from '../modules/pull-request-insights/pull-request.service.js';
+import { PrismaCodexReviewSummaryRepository } from '../modules/pull-request-insights/codex-review-summary.prisma-repository.js';
+import { CodexReviewSummaryService } from '../modules/pull-request-insights/codex-review-summary.service.js';
+import type { CodexReviewSummaryRepository } from '../modules/pull-request-insights/codex-review-summary.repository.js';
 import type { OperatorAuthVerifier } from '../shared/auth/operator-auth-verifier.js';
 
 export interface CreateServerOptions {
@@ -37,6 +40,7 @@ export interface CreateServerOptions {
   workflowCatalogRepository?: WorkflowRepository;
   workflowRunRepository?: WorkflowRunRepository;
   pullRequestRepository?: PullRequestRepository;
+  codexReviewSummaryRepository?: CodexReviewSummaryRepository;
 }
 
 export const createServer = (options: CreateServerOptions) => {
@@ -57,7 +61,8 @@ export const createServer = (options: CreateServerOptions) => {
     options.repositoryRegistryRepository &&
     options.workflowCatalogRepository &&
     options.workflowRunRepository &&
-    options.pullRequestRepository
+    options.pullRequestRepository &&
+    options.codexReviewSummaryRepository
       ? null
       : createPrismaClient();
   const githubBoundary =
@@ -80,6 +85,9 @@ export const createServer = (options: CreateServerOptions) => {
   const pullRequestRepository =
     options.pullRequestRepository ??
     new PrismaPullRequestRepository(prismaClient!.pullRequest);
+  const codexReviewSummaryRepository =
+    options.codexReviewSummaryRepository ??
+    new PrismaCodexReviewSummaryRepository(prismaClient!.codexReviewSummary);
   const healthService = new HealthService({
     githubBoundary,
     repository: healthRepository,
@@ -101,6 +109,13 @@ export const createServer = (options: CreateServerOptions) => {
     repositoryRegistryRepository,
     pullRequestRepository,
     githubBoundary,
+    codexReviewSummaryService: new CodexReviewSummaryService({
+      repositoryRegistryRepository,
+      pullRequestRepository,
+      codexReviewSummaryRepository,
+      githubBoundary,
+      logger: app.log,
+    }),
     logger: app.log,
   });
   const repositoryService = new RepositoryService({

--- a/backend/src/modules/github/github-app.boundary.ts
+++ b/backend/src/modules/github/github-app.boundary.ts
@@ -67,6 +67,14 @@ export interface GitHubPullRequestDescriptor {
   headBranch: string;
 }
 
+export interface GitHubPullRequestReviewCommentDescriptor {
+  githubReviewCommentId: string;
+  reviewerLogin: string;
+  body: string;
+  path: string | null;
+  createdAt: Date | null;
+}
+
 export interface GitHubAppBoundary {
   readonly mode: 'github-app';
   readonly configured: boolean;
@@ -87,6 +95,10 @@ export interface GitHubAppBoundary {
   listPullRequests(
     repository: GitHubRepositoryDescriptor,
   ): Promise<GitHubPullRequestDescriptor[]>;
+  listPullRequestReviewComments(
+    repository: GitHubRepositoryDescriptor,
+    pullRequestNumber: number,
+  ): Promise<GitHubPullRequestReviewCommentDescriptor[]>;
 }
 
 export interface GitHubAppStatus {

--- a/backend/src/modules/github/github-app.errors.ts
+++ b/backend/src/modules/github/github-app.errors.ts
@@ -40,6 +40,16 @@ export class GitHubPullRequestSyncError extends ApplicationError {
   }
 }
 
+export class GitHubPullRequestReviewSyncError extends ApplicationError {
+  constructor() {
+    super(
+      'GitHub pull request reviews are currently unavailable.',
+      503,
+      'github_pull_request_review_sync_unavailable',
+    );
+  }
+}
+
 export class GitHubWebhookVerificationError extends ApplicationError {
   constructor() {
     super(

--- a/backend/src/modules/github/providers/github-app.provider.ts
+++ b/backend/src/modules/github/providers/github-app.provider.ts
@@ -5,6 +5,7 @@ import type {
   GitHubInstallationRepository,
   GitHubAppStatus,
   GitHubPullRequestDescriptor,
+  GitHubPullRequestReviewCommentDescriptor,
   GitHubRepositoryDescriptor,
   GitHubWorkflowDescriptor,
   GitHubWorkflowJobDescriptor,
@@ -15,6 +16,7 @@ import { ConfigurationError } from '../../../shared/errors/configuration-error.j
 import {
   GitHubRepositoryDiscoveryError,
   GitHubPullRequestSyncError,
+  GitHubPullRequestReviewSyncError,
   GitHubWorkflowCatalogSyncError,
   GitHubWorkflowRunsSyncError,
 } from '../github-app.errors.js';
@@ -105,6 +107,20 @@ const githubPullRequestsSchema = z.array(
     head: z.object({
       ref: z.string().trim().min(1),
     }),
+  }),
+);
+
+const githubPullRequestReviewCommentsSchema = z.array(
+  z.object({
+    id: z.number().int().nonnegative(),
+    body: z.string().nullable(),
+    path: z.string().trim().min(1).nullable(),
+    created_at: z.string().trim().min(1).nullable(),
+    user: z
+      .object({
+        login: z.string().trim().min(1),
+      })
+      .nullable(),
   }),
 );
 
@@ -330,6 +346,38 @@ export class GitHubAppProvider implements GitHubAppBoundary {
     }
   }
 
+  public async listPullRequestReviewComments(
+    repository: GitHubRepositoryDescriptor,
+    pullRequestNumber: number,
+  ): Promise<GitHubPullRequestReviewCommentDescriptor[]> {
+    this.assertConfigured();
+
+    try {
+      const installationToken = await this.createInstallationAccessToken();
+      const payload = await this.requestJson(
+        `${this.apiBaseUrl}/repos/${repository.owner}/${repository.name}/pulls/${pullRequestNumber}/comments?per_page=100`,
+        {
+          method: 'GET',
+          headers: this.createJsonHeaders(`Bearer ${installationToken}`),
+        },
+        githubPullRequestReviewCommentsSchema,
+      );
+
+      return payload.map((comment) =>
+        mapGitHubPullRequestReviewCommentDescriptor(comment),
+      );
+    } catch (error) {
+      if (
+        error instanceof ConfigurationError ||
+        error instanceof GitHubPullRequestReviewSyncError
+      ) {
+        throw error;
+      }
+
+      throw new GitHubPullRequestReviewSyncError();
+    }
+  }
+
   private async createInstallationAccessToken(): Promise<string> {
     const config = this.config;
 
@@ -458,6 +506,18 @@ const mapGitHubPullRequestDescriptor = (
     author: pullRequest.user?.login ?? 'unknown',
     baseBranch: pullRequest.base.ref,
     headBranch: pullRequest.head.ref,
+  };
+};
+
+const mapGitHubPullRequestReviewCommentDescriptor = (
+  comment: z.infer<typeof githubPullRequestReviewCommentsSchema>[number],
+): GitHubPullRequestReviewCommentDescriptor => {
+  return {
+    githubReviewCommentId: String(comment.id),
+    reviewerLogin: comment.user?.login ?? 'unknown',
+    body: comment.body ?? '',
+    path: comment.path,
+    createdAt: parseGitHubDate(comment.created_at),
   };
 };
 

--- a/backend/src/modules/pull-request-insights/codex-review-summary.entity.ts
+++ b/backend/src/modules/pull-request-insights/codex-review-summary.entity.ts
@@ -1,0 +1,24 @@
+export type CodexReviewSummarySource = 'github_review' | 'workflow_comment';
+
+export interface CodexReviewSummary {
+  id: string;
+  pullRequestId: string;
+  source: CodexReviewSummarySource;
+  summary: string;
+  blockersCount: number;
+  suggestionsCount: number;
+  risksCount: number;
+  rawContent: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface UpsertCodexReviewSummaryInput {
+  pullRequestId: string;
+  source: CodexReviewSummarySource;
+  summary: string;
+  blockersCount: number;
+  suggestionsCount: number;
+  risksCount: number;
+  rawContent: string;
+}

--- a/backend/src/modules/pull-request-insights/codex-review-summary.errors.ts
+++ b/backend/src/modules/pull-request-insights/codex-review-summary.errors.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from '../../shared/errors/application-error.js';
+
+export class CodexReviewSummaryAlreadyExistsError extends ApplicationError {
+  constructor(message = 'Codex review summary is already synchronized.') {
+    super(message, 409, 'codex_review_summary_already_exists');
+  }
+}

--- a/backend/src/modules/pull-request-insights/codex-review-summary.prisma-repository.ts
+++ b/backend/src/modules/pull-request-insights/codex-review-summary.prisma-repository.ts
@@ -1,0 +1,162 @@
+import { CodexReviewSummaryAlreadyExistsError } from './codex-review-summary.errors.js';
+import type {
+  CodexReviewSummary,
+  CodexReviewSummarySource,
+  UpsertCodexReviewSummaryInput,
+} from './codex-review-summary.entity.js';
+import type { CodexReviewSummaryRepository } from './codex-review-summary.repository.js';
+
+interface CodexReviewSummaryRecord {
+  id: string;
+  pullRequestId: string;
+  source: CodexReviewSummarySource;
+  summary: string;
+  blockersCount: number;
+  suggestionsCount: number;
+  risksCount: number;
+  rawContent: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+type CodexReviewSummaryDelegate = {
+  create(args: {
+    data: {
+      pullRequestId: string;
+      source: CodexReviewSummarySource;
+      summary: string;
+      blockersCount: number;
+      suggestionsCount: number;
+      risksCount: number;
+      rawContent: string;
+    };
+  }): Promise<CodexReviewSummaryRecord>;
+  upsert(args: {
+    where: {
+      pullRequestId: string;
+    };
+    create: {
+      pullRequestId: string;
+      source: CodexReviewSummarySource;
+      summary: string;
+      blockersCount: number;
+      suggestionsCount: number;
+      risksCount: number;
+      rawContent: string;
+    };
+    update: {
+      source: CodexReviewSummarySource;
+      summary: string;
+      blockersCount: number;
+      suggestionsCount: number;
+      risksCount: number;
+      rawContent: string;
+    };
+  }): Promise<CodexReviewSummaryRecord>;
+  findUnique(args: {
+    where: {
+      pullRequestId: string;
+    };
+  }): Promise<CodexReviewSummaryRecord | null>;
+};
+
+const isUniqueConstraintError = (error: unknown): boolean => {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'P2002'
+  );
+};
+
+const toCodexReviewSummary = (
+  record: CodexReviewSummaryRecord,
+): CodexReviewSummary => {
+  return {
+    id: record.id,
+    pullRequestId: record.pullRequestId,
+    source: record.source,
+    summary: record.summary,
+    blockersCount: record.blockersCount,
+    suggestionsCount: record.suggestionsCount,
+    risksCount: record.risksCount,
+    rawContent: record.rawContent,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+};
+
+export class PrismaCodexReviewSummaryRepository
+  implements CodexReviewSummaryRepository
+{
+  constructor(
+    private readonly codexReviewSummary: CodexReviewSummaryDelegate,
+  ) {}
+
+  async create(
+    input: UpsertCodexReviewSummaryInput,
+  ): Promise<CodexReviewSummary> {
+    try {
+      const record = await this.codexReviewSummary.create({
+        data: {
+          pullRequestId: input.pullRequestId,
+          source: input.source,
+          summary: input.summary,
+          blockersCount: input.blockersCount,
+          suggestionsCount: input.suggestionsCount,
+          risksCount: input.risksCount,
+          rawContent: input.rawContent,
+        },
+      });
+
+      return toCodexReviewSummary(record);
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw new CodexReviewSummaryAlreadyExistsError();
+      }
+
+      throw error;
+    }
+  }
+
+  async upsert(
+    input: UpsertCodexReviewSummaryInput,
+  ): Promise<CodexReviewSummary> {
+    const record = await this.codexReviewSummary.upsert({
+      where: {
+        pullRequestId: input.pullRequestId,
+      },
+      create: {
+        pullRequestId: input.pullRequestId,
+        source: input.source,
+        summary: input.summary,
+        blockersCount: input.blockersCount,
+        suggestionsCount: input.suggestionsCount,
+        risksCount: input.risksCount,
+        rawContent: input.rawContent,
+      },
+      update: {
+        source: input.source,
+        summary: input.summary,
+        blockersCount: input.blockersCount,
+        suggestionsCount: input.suggestionsCount,
+        risksCount: input.risksCount,
+        rawContent: input.rawContent,
+      },
+    });
+
+    return toCodexReviewSummary(record);
+  }
+
+  async findByPullRequestId(
+    pullRequestId: string,
+  ): Promise<CodexReviewSummary | null> {
+    const record = await this.codexReviewSummary.findUnique({
+      where: {
+        pullRequestId,
+      },
+    });
+
+    return record ? toCodexReviewSummary(record) : null;
+  }
+}

--- a/backend/src/modules/pull-request-insights/codex-review-summary.repository.ts
+++ b/backend/src/modules/pull-request-insights/codex-review-summary.repository.ts
@@ -1,0 +1,10 @@
+import type {
+  CodexReviewSummary,
+  UpsertCodexReviewSummaryInput,
+} from './codex-review-summary.entity.js';
+
+export interface CodexReviewSummaryRepository {
+  create(input: UpsertCodexReviewSummaryInput): Promise<CodexReviewSummary>;
+  upsert(input: UpsertCodexReviewSummaryInput): Promise<CodexReviewSummary>;
+  findByPullRequestId(pullRequestId: string): Promise<CodexReviewSummary | null>;
+}

--- a/backend/src/modules/pull-request-insights/codex-review-summary.service.ts
+++ b/backend/src/modules/pull-request-insights/codex-review-summary.service.ts
@@ -1,0 +1,222 @@
+import type { Logger } from 'pino';
+import { GitHubPullRequestReviewSyncError } from '../github/github-app.errors.js';
+import type {
+  GitHubAppBoundary,
+  GitHubPullRequestReviewCommentDescriptor,
+} from '../github/github-app.boundary.js';
+import { RepositoryNotFoundError } from '../repository-registry/repository.errors.js';
+import type { RepositoryRepository } from '../repository-registry/repository.repository.js';
+import { PullRequestNotFoundError } from './pull-request.errors.js';
+import type { PullRequest } from './pull-request.entity.js';
+import type { PullRequestRepository } from './pull-request.repository.js';
+import type { CodexReviewSummary } from './codex-review-summary.entity.js';
+import type { CodexReviewSummaryRepository } from './codex-review-summary.repository.js';
+
+type ServiceLogger = Pick<Logger, 'info' | 'error'>;
+
+const noopLogger: ServiceLogger = {
+  info: () => undefined,
+  error: () => undefined,
+};
+
+export interface CodexReviewSummaryServiceOptions {
+  repositoryRegistryRepository: RepositoryRepository;
+  pullRequestRepository: PullRequestRepository;
+  codexReviewSummaryRepository: CodexReviewSummaryRepository;
+  githubBoundary: GitHubAppBoundary;
+  logger?: ServiceLogger;
+}
+
+export class CodexReviewSummaryService {
+  constructor(private readonly options: CodexReviewSummaryServiceOptions) {}
+
+  async findByPullRequestId(
+    pullRequestId: string,
+  ): Promise<CodexReviewSummary | null> {
+    const pullRequest = await this.options.pullRequestRepository.findById(
+      pullRequestId,
+    );
+
+    if (!pullRequest) {
+      throw new PullRequestNotFoundError();
+    }
+
+    return this.options.codexReviewSummaryRepository.findByPullRequestId(
+      pullRequestId,
+    );
+  }
+
+  async syncByPullRequestId(
+    pullRequestId: string,
+  ): Promise<CodexReviewSummary | null> {
+    const pullRequest = await this.options.pullRequestRepository.findById(
+      pullRequestId,
+    );
+
+    if (!pullRequest) {
+      throw new PullRequestNotFoundError();
+    }
+
+    return this.syncByPullRequest(pullRequest);
+  }
+
+  async syncByPullRequest(
+    pullRequest: PullRequest,
+  ): Promise<CodexReviewSummary | null> {
+    const repository =
+      await this.options.repositoryRegistryRepository.findById(
+        pullRequest.repositoryId,
+      );
+
+    if (!repository) {
+      throw new RepositoryNotFoundError();
+    }
+
+    try {
+      const listPullRequestReviewComments =
+        this.options.githubBoundary.listPullRequestReviewComments;
+
+      if (!listPullRequestReviewComments) {
+        throw new GitHubPullRequestReviewSyncError();
+      }
+
+      const comments = await listPullRequestReviewComments(
+        {
+          owner: repository.owner,
+          name: repository.name,
+        },
+        pullRequest.number,
+      );
+      const codexComments = selectCodexComments(comments);
+
+      if (codexComments.length === 0) {
+        this.logger.info(
+          {
+            event: 'codex_review_summary_sync_skipped',
+            pullRequestId: pullRequest.id,
+            repositoryId: repository.id,
+            githubPrNumber: pullRequest.number,
+          },
+          'Codex review summary sync skipped because no Codex review comments were found.',
+        );
+
+        return null;
+      }
+
+      const rawContent = codexComments
+        .map((comment) => formatCommentForStorage(comment))
+        .join('\n\n---\n\n');
+      const blockersCount = countMatches(
+        rawContent,
+        /\[(?:p0|p1|alto|bloqueante)\]/gi,
+      );
+      const suggestionsCount = countMatches(
+        rawContent,
+        /\[(?:p2|p3|medio|baixo)\]/gi,
+      );
+      const risksCount = countMatches(
+        rawContent,
+        /\b(risco|regress|seguranca|boundary|tipagem|scope|escopo|teste)\b/gi,
+      );
+      const summary = buildSummary(codexComments);
+
+      const persistedSummary =
+        await this.options.codexReviewSummaryRepository.upsert({
+          pullRequestId: pullRequest.id,
+          source: 'github_review',
+          summary,
+          blockersCount,
+          suggestionsCount,
+          risksCount,
+          rawContent,
+        });
+
+      this.logger.info(
+        {
+          event: 'codex_review_summary_sync_succeeded',
+          pullRequestId: pullRequest.id,
+          repositoryId: repository.id,
+          githubPrNumber: pullRequest.number,
+          codexCommentCount: codexComments.length,
+        },
+        'Codex review summary sync completed.',
+      );
+
+      return persistedSummary;
+    } catch (error) {
+      this.logger.error(
+        {
+          event: 'codex_review_summary_sync_failed',
+          pullRequestId: pullRequest.id,
+          repositoryId: pullRequest.repositoryId,
+          errorName: error instanceof Error ? error.name : 'UnknownError',
+        },
+        'Codex review summary sync failed.',
+      );
+
+      throw error;
+    }
+  }
+
+  private get logger(): ServiceLogger {
+    return this.options.logger ?? noopLogger;
+  }
+}
+
+const selectCodexComments = (
+  comments: GitHubPullRequestReviewCommentDescriptor[],
+): GitHubPullRequestReviewCommentDescriptor[] => {
+  return comments
+    .filter((comment) => isCodexReviewer(comment.reviewerLogin))
+    .filter((comment) => comment.body.trim().length > 0)
+    .sort((left, right) => {
+      const leftTime = left.createdAt?.getTime() ?? 0;
+      const rightTime = right.createdAt?.getTime() ?? 0;
+
+      return rightTime - leftTime;
+    });
+};
+
+const isCodexReviewer = (reviewerLogin: string): boolean => {
+  return reviewerLogin.toLowerCase().includes('codex');
+};
+
+const formatCommentForStorage = (
+  comment: GitHubPullRequestReviewCommentDescriptor,
+): string => {
+  const pathPrefix = comment.path ? `[${comment.path}]` : '[unknown-file]';
+  return `${pathPrefix}\n${comment.body.trim()}`;
+};
+
+const buildSummary = (
+  comments: GitHubPullRequestReviewCommentDescriptor[],
+): string => {
+  const titles = comments
+    .slice(0, 3)
+    .map((comment) => extractHeadline(comment.body))
+    .filter((headline) => headline.length > 0);
+
+  if (titles.length === 0) {
+    return `Codex sinalizou ${comments.length} achados no pull request.`;
+  }
+
+  return `Codex sinalizou ${comments.length} achados no pull request: ${titles.join(
+    '; ',
+  )}`;
+};
+
+const extractHeadline = (body: string): string => {
+  const normalizedBody = body.replace(/\r\n/g, '\n').trim();
+  const firstLine = normalizedBody.split('\n').find((line) => line.trim().length > 0);
+
+  if (!firstLine) {
+    return '';
+  }
+
+  return firstLine.trim().slice(0, 160);
+};
+
+const countMatches = (value: string, pattern: RegExp): number => {
+  const matches = value.match(pattern);
+  return matches ? matches.length : 0;
+};

--- a/backend/src/modules/pull-request-insights/pull-request.service.ts
+++ b/backend/src/modules/pull-request-insights/pull-request.service.ts
@@ -5,6 +5,7 @@ import { RepositoryNotFoundError } from '../repository-registry/repository.error
 import type { RepositoryRepository } from '../repository-registry/repository.repository.js';
 import type { PullRequest } from './pull-request.entity.js';
 import type { PullRequestRepository } from './pull-request.repository.js';
+import type { CodexReviewSummaryService } from './codex-review-summary.service.js';
 
 type ServiceLogger = Pick<Logger, 'info' | 'error'>;
 
@@ -17,6 +18,10 @@ export interface PullRequestServiceOptions {
   repositoryRegistryRepository: RepositoryRepository;
   pullRequestRepository: PullRequestRepository;
   githubBoundary: GitHubAppBoundary;
+  codexReviewSummaryService?: Pick<
+    CodexReviewSummaryService,
+    'syncByPullRequest'
+  >;
   logger?: ServiceLogger;
 }
 
@@ -74,6 +79,16 @@ export class PullRequestService {
           }),
         ),
       );
+
+      if (this.options.codexReviewSummaryService) {
+        await Promise.all(
+          persistedPullRequests.map((pullRequest) =>
+            this.options.codexReviewSummaryService!.syncByPullRequest(
+              pullRequest,
+            ),
+          ),
+        );
+      }
 
       this.logger.info(
         {

--- a/backend/src/modules/pull-request-insights/pull-request.service.ts
+++ b/backend/src/modules/pull-request-insights/pull-request.service.ts
@@ -81,13 +81,31 @@ export class PullRequestService {
       );
 
       if (this.options.codexReviewSummaryService) {
-        await Promise.all(
+        const summarySyncResults = await Promise.allSettled(
           persistedPullRequests.map((pullRequest) =>
-            this.options.codexReviewSummaryService!.syncByPullRequest(
-              pullRequest,
-            ),
+            this.options.codexReviewSummaryService!.syncByPullRequest(pullRequest),
           ),
         );
+
+        summarySyncResults.forEach((result, index) => {
+          if (result.status === 'fulfilled') {
+            return;
+          }
+
+          const pullRequest = persistedPullRequests[index];
+
+          this.logger.error(
+            {
+              event: 'codex_review_summary_sync_failed_non_blocking',
+              repositoryId: repository.id,
+              pullRequestId: pullRequest?.id,
+              githubPrId: pullRequest?.githubPrId,
+              githubPrNumber: pullRequest?.number,
+              ...serializeApplicationError(result.reason),
+            },
+            'Codex review summary sync failed, but pull request sync will continue.',
+          );
+        });
       }
 
       this.logger.info(

--- a/backend/src/tests/app/create-server.test.ts
+++ b/backend/src/tests/app/create-server.test.ts
@@ -227,6 +227,7 @@ const createProtectedServer = (overrides?: {
       listWorkflowRuns: async () => [],
       listWorkflowRunJobs: async () => [],
       listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
     },
     repositoryRegistryRepository: {
       list: async () => [...repositoryStore],

--- a/backend/src/tests/modules/github/github-app.provider.test.ts
+++ b/backend/src/tests/modules/github/github-app.provider.test.ts
@@ -3,6 +3,7 @@ import { createGitHubAppBoundary } from '../../../modules/github/github-app.boun
 import {
   GitHubRepositoryDiscoveryError,
   GitHubPullRequestSyncError,
+  GitHubPullRequestReviewSyncError,
   GitHubWorkflowCatalogSyncError,
   GitHubWorkflowRunsSyncError,
 } from '../../../modules/github/github-app.errors.js';
@@ -518,6 +519,117 @@ describe('GitHubAppProvider', () => {
         name: 'backend',
       }),
     ).rejects.toBeInstanceOf(GitHubPullRequestSyncError);
+  });
+
+  it('should exchange credentials and normalize pull request review comments', async () => {
+    const fetchImplementation = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: 'installation-token' }), {
+          status: 201,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              id: 7001,
+              body: '[P1] Validar input da rota',
+              path: 'src/api.ts',
+              created_at: '2026-04-02T00:10:00.000Z',
+              user: {
+                login: 'codex-reviewer',
+              },
+            },
+            {
+              id: 7002,
+              body: null,
+              path: null,
+              created_at: null,
+              user: null,
+            },
+          ]),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+    const boundary = createGitHubAppBoundary(buildConfig(), {
+      apiBaseUrl: 'https://api.github.test',
+      fetchImplementation,
+      appJwtFactory: () => 'app-jwt',
+      now: () => new Date('2026-04-02T00:11:00.000Z'),
+    });
+
+    await expect(
+      boundary.listPullRequestReviewComments(
+        {
+          owner: 'forgeops',
+          name: 'backend',
+        },
+        42,
+      ),
+    ).resolves.toEqual([
+      {
+        githubReviewCommentId: '7001',
+        reviewerLogin: 'codex-reviewer',
+        body: '[P1] Validar input da rota',
+        path: 'src/api.ts',
+        createdAt: new Date('2026-04-02T00:10:00.000Z'),
+      },
+      {
+        githubReviewCommentId: '7002',
+        reviewerLogin: 'unknown',
+        body: '',
+        path: null,
+        createdAt: null,
+      },
+    ]);
+
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.test/repos/forgeops/backend/pulls/42/comments?per_page=100',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Accept: 'application/vnd.github+json',
+          Authorization: 'Bearer installation-token',
+        }),
+      }),
+    );
+  });
+
+  it('should raise a safe pull request review sync error when review comment sync fails', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'rate limited' }), {
+        status: 403,
+        headers: {
+          'content-type': 'application/json',
+        },
+      }),
+    );
+    const boundary = createGitHubAppBoundary(buildConfig(), {
+      apiBaseUrl: 'https://api.github.test',
+      fetchImplementation,
+      appJwtFactory: () => 'app-jwt',
+      now: () => new Date('2026-04-02T00:12:00.000Z'),
+    });
+
+    await expect(
+      boundary.listPullRequestReviewComments(
+        {
+          owner: 'forgeops',
+          name: 'backend',
+        },
+        42,
+      ),
+    ).rejects.toBeInstanceOf(GitHubPullRequestReviewSyncError);
   });
 
   it('should fail safely when GitHub returns an unsupported workflow run status', async () => {

--- a/backend/src/tests/modules/pull-request-insights/codex-review-summary.prisma-repository.test.ts
+++ b/backend/src/tests/modules/pull-request-insights/codex-review-summary.prisma-repository.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CodexReviewSummaryAlreadyExistsError } from '../../../modules/pull-request-insights/codex-review-summary.errors.js';
+import { PrismaCodexReviewSummaryRepository } from '../../../modules/pull-request-insights/codex-review-summary.prisma-repository.js';
+
+interface CodexReviewSummaryRecord {
+  id: string;
+  pullRequestId: string;
+  source: 'github_review' | 'workflow_comment';
+  summary: string;
+  blockersCount: number;
+  suggestionsCount: number;
+  risksCount: number;
+  rawContent: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const buildRecord = (
+  overrides: Partial<CodexReviewSummaryRecord> = {},
+): CodexReviewSummaryRecord => {
+  const createdAt = new Date('2026-04-02T00:10:00.000Z');
+
+  return {
+    id: 'summary_123',
+    pullRequestId: 'pr_123',
+    source: 'github_review',
+    summary: 'Codex sinalizou 2 achados no pull request.',
+    blockersCount: 1,
+    suggestionsCount: 1,
+    risksCount: 2,
+    rawContent: '[src/app.ts]\n[P1] Corrigir validacao',
+    createdAt,
+    updatedAt: createdAt,
+    ...overrides,
+  };
+};
+
+describe('PrismaCodexReviewSummaryRepository', () => {
+  it('should create and map a codex review summary record', async () => {
+    const create = vi.fn().mockResolvedValue(buildRecord());
+    const upsert = vi.fn();
+    const findUnique = vi.fn();
+    const repository = new PrismaCodexReviewSummaryRepository({
+      create,
+      upsert,
+      findUnique,
+    });
+
+    await expect(
+      repository.create({
+        pullRequestId: 'pr_123',
+        source: 'github_review',
+        summary: 'Codex sinalizou 2 achados no pull request.',
+        blockersCount: 1,
+        suggestionsCount: 1,
+        risksCount: 2,
+        rawContent: '[src/app.ts]\n[P1] Corrigir validacao',
+      }),
+    ).resolves.toEqual(buildRecord());
+
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        pullRequestId: 'pr_123',
+        source: 'github_review',
+        summary: 'Codex sinalizou 2 achados no pull request.',
+        blockersCount: 1,
+        suggestionsCount: 1,
+        risksCount: 2,
+        rawContent: '[src/app.ts]\n[P1] Corrigir validacao',
+      },
+    });
+  });
+
+  it('should find a codex review summary by pull request id', async () => {
+    const create = vi.fn();
+    const upsert = vi.fn();
+    const findUnique = vi.fn().mockResolvedValue(buildRecord());
+    const repository = new PrismaCodexReviewSummaryRepository({
+      create,
+      upsert,
+      findUnique,
+    });
+
+    await expect(repository.findByPullRequestId('pr_123')).resolves.toEqual(
+      buildRecord(),
+    );
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: {
+        pullRequestId: 'pr_123',
+      },
+    });
+  });
+
+  it('should translate unique constraint errors into a domain conflict', async () => {
+    const create = vi.fn().mockRejectedValue({ code: 'P2002' });
+    const upsert = vi.fn();
+    const findUnique = vi.fn();
+    const repository = new PrismaCodexReviewSummaryRepository({
+      create,
+      upsert,
+      findUnique,
+    });
+
+    await expect(
+      repository.create({
+        pullRequestId: 'pr_123',
+        source: 'github_review',
+        summary: 'Codex sinalizou 2 achados no pull request.',
+        blockersCount: 1,
+        suggestionsCount: 1,
+        risksCount: 2,
+        rawContent: '[src/app.ts]\n[P1] Corrigir validacao',
+      }),
+    ).rejects.toBeInstanceOf(CodexReviewSummaryAlreadyExistsError);
+  });
+
+  it('should upsert codex review summaries by pull request id', async () => {
+    const create = vi.fn();
+    const upsert = vi.fn().mockResolvedValue(
+      buildRecord({
+        summary: 'Codex sinalizou 3 achados no pull request.',
+        blockersCount: 2,
+        suggestionsCount: 1,
+        risksCount: 3,
+      }),
+    );
+    const findUnique = vi.fn();
+    const repository = new PrismaCodexReviewSummaryRepository({
+      create,
+      upsert,
+      findUnique,
+    });
+
+    await expect(
+      repository.upsert({
+        pullRequestId: 'pr_123',
+        source: 'github_review',
+        summary: 'Codex sinalizou 3 achados no pull request.',
+        blockersCount: 2,
+        suggestionsCount: 1,
+        risksCount: 3,
+        rawContent: '[src/app.ts]\n[P1] Corrigir validacao\n\n---\n\n[src/lib.ts]\n[P2] Simplificar teste',
+      }),
+    ).resolves.toEqual(
+      buildRecord({
+        summary: 'Codex sinalizou 3 achados no pull request.',
+        blockersCount: 2,
+        suggestionsCount: 1,
+        risksCount: 3,
+      }),
+    );
+
+    expect(upsert).toHaveBeenCalledWith({
+      where: {
+        pullRequestId: 'pr_123',
+      },
+      create: {
+        pullRequestId: 'pr_123',
+        source: 'github_review',
+        summary: 'Codex sinalizou 3 achados no pull request.',
+        blockersCount: 2,
+        suggestionsCount: 1,
+        risksCount: 3,
+        rawContent: '[src/app.ts]\n[P1] Corrigir validacao\n\n---\n\n[src/lib.ts]\n[P2] Simplificar teste',
+      },
+      update: {
+        source: 'github_review',
+        summary: 'Codex sinalizou 3 achados no pull request.',
+        blockersCount: 2,
+        suggestionsCount: 1,
+        risksCount: 3,
+        rawContent: '[src/app.ts]\n[P1] Corrigir validacao\n\n---\n\n[src/lib.ts]\n[P2] Simplificar teste',
+      },
+    });
+  });
+});

--- a/backend/src/tests/modules/pull-request-insights/codex-review-summary.service.test.ts
+++ b/backend/src/tests/modules/pull-request-insights/codex-review-summary.service.test.ts
@@ -1,0 +1,430 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GitHubPullRequestReviewSyncError } from '../../../modules/github/github-app.errors.js';
+import type { Repository } from '../../../modules/repository-registry/repository.entity.js';
+import { RepositoryNotFoundError } from '../../../modules/repository-registry/repository.errors.js';
+import type { CodexReviewSummary } from '../../../modules/pull-request-insights/codex-review-summary.entity.js';
+import { CodexReviewSummaryService } from '../../../modules/pull-request-insights/codex-review-summary.service.js';
+import type { PullRequest } from '../../../modules/pull-request-insights/pull-request.entity.js';
+import { PullRequestNotFoundError } from '../../../modules/pull-request-insights/pull-request.errors.js';
+
+const buildRepository = (overrides: Partial<Repository> = {}): Repository => {
+  const createdAt = new Date('2026-04-02T00:00:00.000Z');
+
+  return {
+    id: 'repo_123',
+    githubRepoId: '123456789',
+    owner: 'forgeops',
+    name: 'backend',
+    fullName: 'forgeops/backend',
+    defaultBranch: 'main',
+    isActive: true,
+    createdAt,
+    updatedAt: createdAt,
+    ...overrides,
+  };
+};
+
+const buildPullRequest = (overrides: Partial<PullRequest> = {}): PullRequest => {
+  const createdAt = new Date('2026-04-02T00:05:00.000Z');
+
+  return {
+    id: 'pr_123',
+    repositoryId: 'repo_123',
+    githubPrId: '987654321',
+    number: 42,
+    title: 'Add pull request insights',
+    state: 'open',
+    author: 'alessandrolsdev',
+    baseBranch: 'main',
+    headBranch: 'feature/pull-request-insights',
+    createdAt,
+    updatedAt: createdAt,
+    ...overrides,
+  };
+};
+
+const buildSummary = (
+  overrides: Partial<CodexReviewSummary> = {},
+): CodexReviewSummary => {
+  const createdAt = new Date('2026-04-02T00:08:00.000Z');
+
+  return {
+    id: 'summary_123',
+    pullRequestId: 'pr_123',
+    source: 'github_review',
+    summary:
+      'Codex sinalizou 2 achados no pull request: [P1] Validar input da rota; [P2] Cobrir fluxo vazio',
+    blockersCount: 1,
+    suggestionsCount: 1,
+    risksCount: 0,
+    rawContent:
+      '[src/api.ts]\n[P1] Validar input da rota\n\n---\n\n[src/tests/api.test.ts]\n[P2] Cobrir fluxo vazio',
+    createdAt,
+    updatedAt: createdAt,
+    ...overrides,
+  };
+};
+
+describe('CodexReviewSummaryService', () => {
+  it('should return a persisted summary by pull request id', async () => {
+    const findByPullRequestId = vi.fn().mockResolvedValue(buildSummary());
+    const service = new CodexReviewSummaryService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildRepository()),
+        deleteById: vi.fn(),
+      },
+      pullRequestRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildPullRequest()),
+      },
+      codexReviewSummaryRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        findByPullRequestId,
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+        listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
+      },
+    });
+
+    await expect(service.findByPullRequestId('pr_123')).resolves.toEqual(
+      buildSummary(),
+    );
+    expect(findByPullRequestId).toHaveBeenCalledWith('pr_123');
+  });
+
+  it('should fail with pull request not found when reading an unknown summary', async () => {
+    const service = new CodexReviewSummaryService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: vi.fn(),
+        deleteById: vi.fn(),
+      },
+      pullRequestRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId: vi.fn(),
+        findById: vi.fn().mockResolvedValue(null),
+      },
+      codexReviewSummaryRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        findByPullRequestId: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+        listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
+      },
+    });
+
+    await expect(service.findByPullRequestId('pr_missing')).rejects.toBeInstanceOf(
+      PullRequestNotFoundError,
+    );
+  });
+
+  it('should sync codex review comments into a persisted summary', async () => {
+    const upsert = vi.fn().mockResolvedValue(buildSummary());
+    const listPullRequestReviewComments = vi.fn().mockResolvedValue([
+      {
+        githubReviewCommentId: 'comment_2',
+        reviewerLogin: 'Codex-bot',
+        body: '[P2] Cobrir fluxo vazio',
+        path: 'src/tests/api.test.ts',
+        createdAt: new Date('2026-04-02T00:07:00.000Z'),
+      },
+      {
+        githubReviewCommentId: 'comment_1',
+        reviewerLogin: 'codex-reviewer',
+        body: '[P1] Validar input da rota',
+        path: 'src/api.ts',
+        createdAt: new Date('2026-04-02T00:08:00.000Z'),
+      },
+      {
+        githubReviewCommentId: 'comment_ignored',
+        reviewerLogin: 'alice',
+        body: 'Parece bom',
+        path: 'src/api.ts',
+        createdAt: new Date('2026-04-02T00:09:00.000Z'),
+      },
+    ]);
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    const service = new CodexReviewSummaryService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildRepository()),
+        deleteById: vi.fn(),
+      },
+      pullRequestRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildPullRequest()),
+      },
+      codexReviewSummaryRepository: {
+        create: vi.fn(),
+        upsert,
+        findByPullRequestId: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+        listPullRequests: async () => [],
+        listPullRequestReviewComments,
+      },
+      logger,
+    });
+
+    await expect(service.syncByPullRequestId('pr_123')).resolves.toEqual(
+      buildSummary(),
+    );
+
+    expect(listPullRequestReviewComments).toHaveBeenCalledWith(
+      {
+        owner: 'forgeops',
+        name: 'backend',
+      },
+      42,
+    );
+    expect(upsert).toHaveBeenCalledWith({
+      pullRequestId: 'pr_123',
+      source: 'github_review',
+      summary:
+        'Codex sinalizou 2 achados no pull request: [P1] Validar input da rota; [P2] Cobrir fluxo vazio',
+      blockersCount: 1,
+      suggestionsCount: 1,
+      risksCount: 0,
+      rawContent:
+        '[src/api.ts]\n[P1] Validar input da rota\n\n---\n\n[src/tests/api.test.ts]\n[P2] Cobrir fluxo vazio',
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      {
+        event: 'codex_review_summary_sync_succeeded',
+        pullRequestId: 'pr_123',
+        repositoryId: 'repo_123',
+        githubPrNumber: 42,
+        codexCommentCount: 2,
+      },
+      'Codex review summary sync completed.',
+    );
+  });
+
+  it('should return null and log a skip when no Codex review comments are available', async () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    const upsert = vi.fn();
+    const service = new CodexReviewSummaryService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildRepository()),
+        deleteById: vi.fn(),
+      },
+      pullRequestRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildPullRequest()),
+      },
+      codexReviewSummaryRepository: {
+        create: vi.fn(),
+        upsert,
+        findByPullRequestId: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+        listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [
+          {
+            githubReviewCommentId: 'comment_ignored',
+            reviewerLogin: 'alice',
+            body: 'Parece bom',
+            path: 'src/api.ts',
+            createdAt: new Date('2026-04-02T00:09:00.000Z'),
+          },
+        ],
+      },
+      logger,
+    });
+
+    await expect(service.syncByPullRequestId('pr_123')).resolves.toBeNull();
+    expect(upsert).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      {
+        event: 'codex_review_summary_sync_skipped',
+        pullRequestId: 'pr_123',
+        repositoryId: 'repo_123',
+        githubPrNumber: 42,
+      },
+      'Codex review summary sync skipped because no Codex review comments were found.',
+    );
+  });
+
+  it('should fail with repository not found when the pull request repository is missing', async () => {
+    const service = new CodexReviewSummaryService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: vi.fn().mockResolvedValue(null),
+        deleteById: vi.fn(),
+      },
+      pullRequestRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildPullRequest()),
+      },
+      codexReviewSummaryRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        findByPullRequestId: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+        listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
+      },
+    });
+
+    await expect(service.syncByPullRequestId('pr_123')).rejects.toBeInstanceOf(
+      RepositoryNotFoundError,
+    );
+  });
+
+  it('should log and rethrow safe GitHub review sync errors', async () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    const service = new CodexReviewSummaryService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildRepository()),
+        deleteById: vi.fn(),
+      },
+      pullRequestRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        listByRepositoryId: vi.fn(),
+        findById: vi.fn().mockResolvedValue(buildPullRequest()),
+      },
+      codexReviewSummaryRepository: {
+        create: vi.fn(),
+        upsert: vi.fn(),
+        findByPullRequestId: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+        listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => {
+          throw new GitHubPullRequestReviewSyncError();
+        },
+      },
+      logger,
+    });
+
+    await expect(service.syncByPullRequestId('pr_123')).rejects.toBeInstanceOf(
+      GitHubPullRequestReviewSyncError,
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        event: 'codex_review_summary_sync_failed',
+        pullRequestId: 'pr_123',
+        repositoryId: 'repo_123',
+        errorName: 'GitHubPullRequestReviewSyncError',
+      },
+      'Codex review summary sync failed.',
+    );
+  });
+});

--- a/backend/src/tests/modules/pull-request-insights/pull-request.service.test.ts
+++ b/backend/src/tests/modules/pull-request-insights/pull-request.service.test.ts
@@ -415,4 +415,76 @@ describe('PullRequestService', () => {
       'Pull request sync failed.',
     );
   });
+
+  it('should continue pull request sync when codex review summary sync fails', async () => {
+    const findById = vi.fn().mockResolvedValue(buildRepository());
+    const listPullRequests = vi.fn().mockResolvedValue([buildRemotePullRequest()]);
+    const upsert = vi.fn().mockResolvedValue(buildPullRequest());
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    const service = new PullRequestService({
+      repositoryRegistryRepository: {
+        create: vi.fn(),
+        list: vi.fn(),
+        findById,
+        deleteById: vi.fn(),
+      },
+      pullRequestRepository: {
+        create: vi.fn(),
+        upsert,
+        listByRepositoryId: vi.fn(),
+        findById: vi.fn(),
+      },
+      githubBoundary: {
+        mode: 'github-app',
+        configured: true,
+        getStatus: () => ({
+          mode: 'github-app',
+          configured: true,
+          appId: '12****56',
+          installationId: '78****10',
+          webhookConfigured: true,
+        }),
+        assertConfigured: () => undefined,
+        listInstallationRepositories: async () => [],
+        listRepositoryWorkflows: async () => [],
+        listWorkflowRuns: async () => [],
+        listWorkflowRunJobs: async () => [],
+        listPullRequests,
+        listPullRequestReviewComments: async () => [],
+      },
+      codexReviewSummaryService: {
+        syncByPullRequest: vi.fn().mockRejectedValue(new Error('upstream timeout')),
+      },
+      logger,
+    });
+
+    await expect(service.syncByRepositoryId('repo_123')).resolves.toEqual([
+      buildPullRequest(),
+    ]);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        event: 'codex_review_summary_sync_failed_non_blocking',
+        repositoryId: 'repo_123',
+        pullRequestId: 'pr_123',
+        githubPrId: '987654321',
+        githubPrNumber: 42,
+        errorName: 'Error',
+      },
+      'Codex review summary sync failed, but pull request sync will continue.',
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      {
+        event: 'pull_request_sync_succeeded',
+        repositoryId: 'repo_123',
+        fullName: 'forgeops/backend',
+        remotePullRequestCount: 1,
+        persistedPullRequestCount: 1,
+      },
+      'Pull request sync completed.',
+    );
+  });
 });

--- a/backend/src/tests/modules/pull-request-insights/pull-request.service.test.ts
+++ b/backend/src/tests/modules/pull-request-insights/pull-request.service.test.ts
@@ -111,6 +111,7 @@ describe('PullRequestService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -160,6 +161,7 @@ describe('PullRequestService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -190,6 +192,7 @@ describe('PullRequestService', () => {
           state: 'merged',
         }),
       );
+    const syncByPullRequest = vi.fn().mockResolvedValue(null);
     const service = new PullRequestService({
       repositoryRegistryRepository: {
         create: vi.fn(),
@@ -219,6 +222,10 @@ describe('PullRequestService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests,
+        listPullRequestReviewComments: async () => [],
+      },
+      codexReviewSummaryService: {
+        syncByPullRequest,
       },
     });
 
@@ -258,6 +265,17 @@ describe('PullRequestService', () => {
       baseBranch: 'main',
       headBranch: 'feature/pull-request-insights',
     });
+    expect(syncByPullRequest).toHaveBeenNthCalledWith(1, buildPullRequest());
+    expect(syncByPullRequest).toHaveBeenNthCalledWith(
+      2,
+      buildPullRequest({
+        id: 'pr_456',
+        githubPrId: '987654322',
+        number: 43,
+        title: 'Close flaky workflow gap',
+        state: 'merged',
+      }),
+    );
   });
 
   it('should return an empty list when GitHub has no pull requests for the repository', async () => {
@@ -291,6 +309,7 @@ describe('PullRequestService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests,
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -331,6 +350,7 @@ describe('PullRequestService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -375,6 +395,7 @@ describe('PullRequestService', () => {
         listPullRequests: async () => {
           throw new GitHubPullRequestSyncError();
         },
+        listPullRequestReviewComments: async () => [],
       },
       logger,
     });

--- a/backend/src/tests/modules/repository-registry/repository.service.test.ts
+++ b/backend/src/tests/modules/repository-registry/repository.service.test.ts
@@ -93,6 +93,7 @@ describe('RepositoryService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -144,6 +145,7 @@ describe('RepositoryService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
       workflowCatalogSync: {
         syncByRepositoryId: vi.fn().mockResolvedValue([]),
@@ -201,6 +203,7 @@ describe('RepositoryService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
       workflowCatalogSync: {
         syncByRepositoryId: vi.fn().mockResolvedValue([]),
@@ -257,6 +260,7 @@ describe('RepositoryService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
       workflowCatalogSync: {
         syncByRepositoryId: vi.fn(),
@@ -311,6 +315,7 @@ describe('RepositoryService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
       workflowCatalogSync: {
         syncByRepositoryId: vi
@@ -375,6 +380,7 @@ describe('RepositoryService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -419,6 +425,7 @@ describe('RepositoryService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
       workflowCatalogSync: {
         syncByRepositoryId: vi.fn().mockResolvedValue([]),

--- a/backend/src/tests/modules/workflow-catalog/workflow.service.test.ts
+++ b/backend/src/tests/modules/workflow-catalog/workflow.service.test.ts
@@ -101,6 +101,7 @@ describe('WorkflowService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
       logger,
     });
@@ -183,6 +184,7 @@ describe('WorkflowService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
       logger,
     });
@@ -238,6 +240,7 @@ describe('WorkflowService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
       logger,
     });

--- a/backend/src/tests/modules/workflow-runs/workflow-run.service.test.ts
+++ b/backend/src/tests/modules/workflow-runs/workflow-run.service.test.ts
@@ -134,6 +134,7 @@ describe('WorkflowRunService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -194,6 +195,7 @@ describe('WorkflowRunService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -254,6 +256,7 @@ describe('WorkflowRunService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -318,6 +321,7 @@ describe('WorkflowRunService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -366,6 +370,7 @@ describe('WorkflowRunService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -413,6 +418,7 @@ describe('WorkflowRunService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -460,6 +466,7 @@ describe('WorkflowRunService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -514,6 +521,7 @@ describe('WorkflowRunService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -564,6 +572,7 @@ describe('WorkflowRunService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -615,6 +624,7 @@ describe('WorkflowRunService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
     });
 
@@ -741,6 +751,7 @@ describe('WorkflowRunService', () => {
         listWorkflowRuns,
         listWorkflowRunJobs,
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
       logger,
     });
@@ -882,6 +893,7 @@ describe('WorkflowRunService', () => {
         listWorkflowRuns,
         listWorkflowRunJobs,
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
       logger,
     });
@@ -944,6 +956,7 @@ describe('WorkflowRunService', () => {
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
       logger,
     });
@@ -1007,6 +1020,7 @@ describe('WorkflowRunService', () => {
         },
         listWorkflowRunJobs: async () => [],
         listPullRequests: async () => [],
+        listPullRequestReviewComments: async () => [],
       },
       logger,
     });


### PR DESCRIPTION
## Resumo
Adiciona a baseline persistente de summary de review do Codex por pull request no backend. A mudança inclui modelagem Prisma, ingestão mínima via GitHub App e integração do sync ao fluxo existente de pull requests.

## O que foi alterado
- Adiciona o model `CodexReviewSummary`, enum de origem e migration correspondente no Prisma.
- Implementa entidade, repository Prisma e service de ingestão para sintetizar e persistir snapshots de review do Codex por PR.
- Expande a boundary do GitHub App para listar review comments de pull requests com erro seguro dedicado.
- Integra o sync de summary ao `PullRequestService` e ao bootstrap do backend.
- Atualiza e cria testes para persistência, provider GitHub, sync de summary e doubles do boundary.

## Motivação
O próximo slice do produto precisa exibir detalhe de pull request com um summary persistido de review automatizado. Sem essa baseline, a API detail e a UI não teriam uma fonte estável e idempotente para o resumo do Codex.

## Como validar
- Executar `npm.cmd --prefix backend run prisma:generate`.
- Executar `npm.cmd --prefix backend run typecheck`.
- Executar `npm.cmd --prefix backend run lint`.
- Executar `npm.cmd --prefix backend run test`.
- Executar `npm.cmd run typecheck`.
- Executar `npm.cmd run lint`.
- Executar `npm.cmd run test`.

## Riscos e impactos
- A classificação de blockers, suggestions e risks usa heurísticas simples por regex; serve como baseline, mas pode exigir refinamento com payloads reais.
- O filtro de comentários depende do login do reviewer conter `codex`; mudanças no naming do reviewer exigirão ajuste posterior.
- `prisma validate` continua dependendo de `DATABASE_URL` no ambiente local.

## Evidências
- Não há evidências anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados
