### PR TITLE
feat(ui): liste pull requests monitoradas no frontend

### DIFF
--- a/frontend/src/features/repositories/repositories-view.tsx
+++ b/frontend/src/features/repositories/repositories-view.tsx
@@ -10,6 +10,7 @@ import {
   createApiClient,
   type ForgeOpsApiClient,
   type MonitoredRepository,
+  type PullRequestItem,
   type RepositoryDiscoveryItem,
   type WorkflowCatalogItem,
   type WorkflowRunDetailResponse,
@@ -20,6 +21,7 @@ const STORAGE_KEY = 'forgeops.operator-access-token';
 const EMPTY_MONITORED_REPOSITORIES: MonitoredRepository[] = [];
 const EMPTY_DISCOVERED_REPOSITORIES: RepositoryDiscoveryItem[] = [];
 const EMPTY_WORKFLOWS: WorkflowCatalogItem[] = [];
+const EMPTY_PULL_REQUESTS: PullRequestItem[] = [];
 const EMPTY_WORKFLOW_RUNS: WorkflowRunItem[] = [];
 const EMPTY_WORKFLOW_RUN_DETAIL_JOBS: WorkflowRunDetailResponse['jobs'] = [];
 
@@ -124,6 +126,15 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
   });
 
   const repositoryWorkflows = workflowsQuery.data ?? EMPTY_WORKFLOWS;
+
+  const pullRequestsQuery = useQuery({
+    queryKey: ['pull-requests', accessToken, selectedRepositoryId],
+    queryFn: () => client.getPullRequests(accessToken, selectedRepositoryId!),
+    enabled: hasAccessToken && selectedRepositoryId !== null,
+    retry: false,
+  });
+
+  const pullRequests = pullRequestsQuery.data ?? EMPTY_PULL_REQUESTS;
 
   useEffect(() => {
     if (repositoryWorkflows.length === 0) {
@@ -274,6 +285,9 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
       queryKey: ['repository-workflows'],
     });
     void queryClient.removeQueries({
+      queryKey: ['pull-requests'],
+    });
+    void queryClient.removeQueries({
       queryKey: ['workflow-runs'],
     });
     void queryClient.removeQueries({
@@ -419,6 +433,69 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
           )}
         </Card>
       </div>
+
+      <Card
+        eyebrow="Pull requests"
+        title={
+          selectedRepository
+            ? `Pull requests for ${selectedRepository.fullName}`
+            : 'Pull requests'
+        }
+      >
+        {!hasAccessToken ? (
+          <p className="empty-state">
+            Add an operator token to inspect pull requests for monitored repositories.
+          </p>
+        ) : monitoredRepositoriesQuery.isLoading ? (
+          <p className="empty-state">Loading repositories before fetching pull requests...</p>
+        ) : monitoredRepositories.length === 0 ? (
+          <p className="empty-state">
+            Connect a repository first so ForgeOps can show pull requests.
+          </p>
+        ) : !selectedRepository ? (
+          <p className="empty-state">
+            Select a monitored repository to inspect pull requests.
+          </p>
+        ) : pullRequestsQuery.isLoading ? (
+          <p className="empty-state">Loading pull requests...</p>
+        ) : pullRequestsQuery.isError ? (
+          <p className="empty-state">
+            {getErrorMessage(pullRequestsQuery.error, 'Unable to load pull requests.')}
+          </p>
+        ) : pullRequests.length === 0 ? (
+          <p className="empty-state">
+            ForgeOps has not synchronized pull requests for this repository yet.
+          </p>
+        ) : (
+          <ul className="workflow-runs-list">
+            {pullRequests.map((pullRequest) => (
+              <li key={pullRequest.id} className="workflow-runs-list__item">
+                <div className="workflow-runs-list__summary">
+                  <strong>PR #{pullRequest.number}</strong>
+                  <span>{pullRequest.title}</span>
+                </div>
+                <div className="workflow-runs-list__meta">
+                  <span className="repository-list__badge repository-list__badge--neutral">
+                    state: {pullRequest.state}
+                  </span>
+                  <span className="repository-list__badge repository-list__badge--neutral">
+                    author: {pullRequest.author}
+                  </span>
+                  <span className="repository-list__badge repository-list__badge--neutral">
+                    base: {pullRequest.baseBranch}
+                  </span>
+                  <span className="repository-list__badge repository-list__badge--neutral">
+                    head: {pullRequest.headBranch}
+                  </span>
+                  <span className="repository-list__badge repository-list__badge--neutral">
+                    updated: {formatTimestamp(pullRequest.updatedAt)}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
 
       <Card
         eyebrow="Workflow catalog"

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -90,6 +90,23 @@ const workflowCatalogResponseSchema = z.object({
   workflows: z.array(workflowCatalogItemSchema),
 });
 
+const pullRequestItemSchema = z.object({
+  id: z.string().min(1),
+  githubPrId: z.string().min(1),
+  number: z.number().int().nonnegative(),
+  title: z.string().min(1),
+  state: z.enum(['open', 'closed', 'merged']),
+  author: z.string().min(1),
+  baseBranch: z.string().min(1),
+  headBranch: z.string().min(1),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+const pullRequestsResponseSchema = z.object({
+  pullRequests: z.array(pullRequestItemSchema),
+});
+
 const workflowRunItemSchema = z.object({
   id: z.string().min(1),
   workflowId: z.string().min(1),
@@ -156,6 +173,7 @@ export type MonitoredRepository = z.infer<typeof monitoredRepositorySchema>;
 export type RepositoryDiscoveryItem = z.infer<typeof repositoryDiscoveryItemSchema>;
 export type CreateRepositoryInput = z.infer<typeof createRepositoryInputSchema>;
 export type WorkflowCatalogItem = z.infer<typeof workflowCatalogItemSchema>;
+export type PullRequestItem = z.infer<typeof pullRequestItemSchema>;
 export type WorkflowRunItem = z.infer<typeof workflowRunItemSchema>;
 export type WorkflowRunJobItem = z.infer<typeof workflowRunJobItemSchema>;
 export type WorkflowRunDetailResponse = z.infer<typeof workflowRunDetailResponseSchema>;
@@ -186,6 +204,7 @@ export interface ForgeOpsApiClient {
     accessToken: string,
     repositoryId: string,
   ): Promise<WorkflowCatalogItem[]>;
+  getPullRequests(accessToken: string, repositoryId: string): Promise<PullRequestItem[]>;
   getWorkflowRuns(
     accessToken: string,
     repositoryId: string,
@@ -282,6 +301,24 @@ export const createApiClient = (options: CreateApiClientOptions = {}): ForgeOpsA
       }
 
       return workflowCatalogResponseSchema.parse(await response.json()).workflows;
+    },
+
+    async getPullRequests(
+      accessToken: string,
+      repositoryId: string,
+    ): Promise<PullRequestItem[]> {
+      const response = await fetcher(
+        `${baseUrl}/api/v1/repositories/${repositoryId}/pull-requests`,
+        {
+          headers: buildHeaders(accessToken),
+        },
+      );
+
+      if (!response.ok) {
+        throw await createApiError(response, `Failed to fetch pull requests (${response.status})`);
+      }
+
+      return pullRequestsResponseSchema.parse(await response.json()).pullRequests;
     },
 
     async getWorkflowRuns(

--- a/frontend/src/tests/api-client.test.ts
+++ b/frontend/src/tests/api-client.test.ts
@@ -281,6 +281,63 @@ describe('createApiClient', () => {
     );
   });
 
+  it('should fetch pull requests with operator authorization', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          pullRequests: [
+            {
+              id: 'pr_123',
+              githubPrId: '987654321',
+              number: 42,
+              title: 'Add pull request insights',
+              state: 'open',
+              author: 'alessandrolsdev',
+              baseBranch: 'main',
+              headBranch: 'feature/pull-request-insights',
+              createdAt: '2026-03-31T18:20:00.000Z',
+              updatedAt: '2026-03-31T18:20:00.000Z',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+      ),
+    );
+    const client = createApiClient({
+      baseUrl: 'http://localhost:3333',
+      fetcher,
+    });
+
+    await expect(client.getPullRequests('trusted-token', 'repo_123')).resolves.toEqual([
+      {
+        id: 'pr_123',
+        githubPrId: '987654321',
+        number: 42,
+        title: 'Add pull request insights',
+        state: 'open',
+        author: 'alessandrolsdev',
+        baseBranch: 'main',
+        headBranch: 'feature/pull-request-insights',
+        createdAt: '2026-03-31T18:20:00.000Z',
+        updatedAt: '2026-03-31T18:20:00.000Z',
+      },
+    ]);
+    expect(fetcher).toHaveBeenCalledWith(
+      'http://localhost:3333/api/v1/repositories/repo_123/pull-requests',
+      {
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer trusted-token',
+        },
+      },
+    );
+  });
+
   it('should fetch workflow run detail with jobs', async () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(

--- a/frontend/src/tests/repositories-view.test.tsx
+++ b/frontend/src/tests/repositories-view.test.tsx
@@ -26,6 +26,7 @@ describe('RepositoriesView', () => {
       getRepositories: vi.fn(),
       getRepositoryDiscovery: vi.fn(),
       getRepositoryWorkflows: vi.fn(),
+      getPullRequests: vi.fn(),
       getWorkflowRuns: vi.fn(),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
@@ -45,12 +46,18 @@ describe('RepositoriesView', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
+        'Add an operator token to inspect pull requests for monitored repositories.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
         'Add an operator token to inspect workflow catalogs for monitored repositories.',
       ),
     ).toBeInTheDocument();
     expect(client.getRepositories).not.toHaveBeenCalled();
     expect(client.getRepositoryDiscovery).not.toHaveBeenCalled();
     expect(client.getRepositoryWorkflows).not.toHaveBeenCalled();
+    expect(client.getPullRequests).not.toHaveBeenCalled();
     expect(client.getWorkflowRuns).not.toHaveBeenCalled();
   });
 
@@ -98,6 +105,20 @@ describe('RepositoriesView', () => {
         },
       ]);
     const createRepository = vi.fn<ForgeOpsApiClient['createRepository']>();
+    const getPullRequests = vi.fn<ForgeOpsApiClient['getPullRequests']>().mockResolvedValue([
+      {
+        id: 'pr_123',
+        githubPrId: '987654321',
+        number: 42,
+        title: 'Add pull request insights',
+        state: 'open',
+        author: 'alessandrolsdev',
+        baseBranch: 'main',
+        headBranch: 'feature/pull-request-insights',
+        createdAt: '2026-03-31T18:20:00.000Z',
+        updatedAt: '2026-03-31T18:20:00.000Z',
+      },
+    ]);
     const getWorkflowRuns = vi
       .fn<ForgeOpsApiClient['getWorkflowRuns']>()
       .mockResolvedValue([
@@ -122,6 +143,7 @@ describe('RepositoriesView', () => {
       getRepositories,
       getRepositoryDiscovery,
       getRepositoryWorkflows,
+      getPullRequests,
       getWorkflowRuns,
       getWorkflowRunDetail: vi.fn().mockResolvedValue({
         run: {
@@ -160,12 +182,183 @@ describe('RepositoriesView', () => {
     });
 
     expect(getRepositoryWorkflows).toHaveBeenCalledWith('trusted-token', 'repo_123');
+    expect(getPullRequests).toHaveBeenCalledWith('trusted-token', 'repo_123');
     await waitFor(() => {
       expect(getWorkflowRuns).toHaveBeenCalledWith(
         'trusted-token',
         'repo_123',
         'workflow_123',
       );
+    });
+  });
+
+  it('should render pull requests for the selected monitored repository', async () => {
+    const getPullRequests = vi
+      .fn<ForgeOpsApiClient['getPullRequests']>()
+      .mockResolvedValue([
+        {
+          id: 'pr_123',
+          githubPrId: '987654321',
+          number: 42,
+          title: 'Add pull request insights',
+          state: 'open',
+          author: 'alessandrolsdev',
+          baseBranch: 'main',
+          headBranch: 'feature/pull-request-insights',
+          createdAt: '2026-03-31T18:20:00.000Z',
+          updatedAt: '2026-03-31T18:20:00.000Z',
+        },
+      ]);
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
+      getPullRequests,
+      getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      getWorkflowRunDetail: vi.fn(),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Pull requests for forgeops/backend')).toBeInTheDocument();
+      expect(screen.getByText('PR #42')).toBeInTheDocument();
+      expect(screen.getByText('Add pull request insights')).toBeInTheDocument();
+      expect(screen.getByText('author: alessandrolsdev')).toBeInTheDocument();
+      expect(screen.getByText('state: open')).toBeInTheDocument();
+    });
+
+    expect(getPullRequests).toHaveBeenCalledWith('trusted-token', 'repo_123');
+  });
+
+  it('should render pull requests loading state', async () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
+      getPullRequests: vi.fn().mockImplementation(() => new Promise(() => undefined)),
+      getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      getWorkflowRunDetail: vi.fn(),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Loading pull requests...')).toBeInTheDocument();
+    });
+  });
+
+  it('should render pull requests empty state', async () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
+      getPullRequests: vi.fn().mockResolvedValue([]),
+      getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      getWorkflowRunDetail: vi.fn(),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('ForgeOps has not synchronized pull requests for this repository yet.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should render pull requests errors clearly', async () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
+      getPullRequests: vi
+        .fn()
+        .mockRejectedValue(new ApiClientError('Pull requests are currently unavailable.', 503)),
+      getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      getWorkflowRunDetail: vi.fn(),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Pull requests are currently unavailable.')).toBeInTheDocument();
     });
   });
 
@@ -199,6 +392,7 @@ describe('RepositoriesView', () => {
           updatedAt: '2026-03-28T00:00:00.000Z',
         },
       ]),
+      getPullRequests: vi.fn().mockResolvedValue([]),
       getWorkflowRuns: vi.fn().mockImplementation(() => new Promise(() => undefined)),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
@@ -246,6 +440,7 @@ describe('RepositoriesView', () => {
           updatedAt: '2026-03-28T00:00:00.000Z',
         },
       ]),
+      getPullRequests: vi.fn().mockResolvedValue([]),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
@@ -295,6 +490,7 @@ describe('RepositoriesView', () => {
           updatedAt: '2026-03-28T00:00:00.000Z',
         },
       ]),
+      getPullRequests: vi.fn().mockResolvedValue([]),
       getWorkflowRuns: vi
         .fn()
         .mockRejectedValue(new ApiClientError('Workflow runs are currently unavailable.', 503)),
@@ -377,6 +573,7 @@ describe('RepositoriesView', () => {
           updatedAt: '2026-03-28T00:00:00.000Z',
         },
       ]),
+      getPullRequests: vi.fn().mockResolvedValue([]),
       getWorkflowRuns: vi.fn().mockResolvedValue([
         {
           id: 'run_123',
@@ -455,6 +652,7 @@ describe('RepositoriesView', () => {
           updatedAt: '2026-03-28T00:00:00.000Z',
         },
       ]),
+      getPullRequests: vi.fn().mockResolvedValue([]),
       getWorkflowRuns: vi.fn().mockResolvedValue([
         {
           id: 'run_123',
@@ -524,6 +722,7 @@ describe('RepositoriesView', () => {
           updatedAt: '2026-03-28T00:00:00.000Z',
         },
       ]),
+      getPullRequests: vi.fn().mockResolvedValue([]),
       getWorkflowRuns: vi.fn().mockResolvedValue([
         {
           id: 'run_123',
@@ -611,6 +810,7 @@ describe('RepositoriesView', () => {
           updatedAt: '2026-03-28T00:00:00.000Z',
         },
       ]),
+      getPullRequests: vi.fn().mockResolvedValue([]),
       getWorkflowRuns: vi.fn().mockResolvedValue([
         {
           id: 'run_123',
@@ -713,6 +913,7 @@ describe('RepositoriesView', () => {
       getRepositories,
       getRepositoryDiscovery,
       getRepositoryWorkflows,
+      getPullRequests: vi.fn().mockResolvedValue([]),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
       createRepository,
@@ -757,6 +958,7 @@ describe('RepositoriesView', () => {
           new ApiClientError('GitHub repository discovery is currently unavailable.', 503),
         ),
       getRepositoryWorkflows: vi.fn(),
+      getPullRequests: vi.fn(),
       getWorkflowRuns: vi.fn(),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
@@ -807,6 +1009,7 @@ describe('RepositoriesView', () => {
         },
       ]),
       getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
+      getPullRequests: vi.fn().mockResolvedValue([]),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi
@@ -858,6 +1061,7 @@ describe('RepositoriesView', () => {
         .mockRejectedValue(
           new ApiClientError('Repository was not found.', 404, 'repository_not_found'),
         ),
+      getPullRequests: vi.fn().mockResolvedValue([]),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),


### PR DESCRIPTION
﻿## Resumo
Adiciona ao frontend a listagem de pull requests monitoradas para o repositório selecionado, consumindo a API protegida já existente. A entrega mantém o fluxo atual da tela de repositórios e cobre explicitamente os estados de loading, vazio, erro e sucesso.

## O que foi alterado
- adiciona `getPullRequests` ao cliente HTTP tipado do frontend
- inclui a seção de pull requests na `RepositoriesView`, integrada ao repositório monitorado selecionado
- renderiza dados mínimos de PR de forma estável sem antecipar a navegação de detalhe
- amplia os testes do cliente e da view para cobrir os estados principais da `#80`

## Motivação
A issue #80 é a próxima etapa obrigatória do Epic #74 para sair de infraestrutura e chegar a produto funcional, permitindo visualizar PRs persistidas no frontend antes do detalhe completo da `#81`.

## Como validar
- `npm.cmd --prefix frontend run lint`
- `npm.cmd --prefix frontend run typecheck`
- `npm.cmd --prefix frontend run test`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run test`
- abrir a tela de repositórios, informar um token de operador válido e verificar a seção `Pull requests` para um repositório monitorado

## Riscos e impactos
- A tela continua agregando várias capacidades em `RepositoriesView`; isso preserva o padrão atual, mas ainda não separa a experiência específica de PRs.
- A listagem depende do contrato backend já existente; qualquer drift futuro deve ser tratado junto com a `#81`.
- Risco baixo e restrito ao frontend, sem alteração de schema ou backend.

## Evidências
- `npm.cmd --prefix frontend run lint`
- `npm.cmd --prefix frontend run typecheck`
- `npm.cmd --prefix frontend run test`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run test`

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #80
