### PR TITLE
feat(ui): exiba detalhe de pull request no frontend

### DIFF
--- a/frontend/src/features/repositories/repositories-view.tsx
+++ b/frontend/src/features/repositories/repositories-view.tsx
@@ -10,6 +10,7 @@ import {
   createApiClient,
   type ForgeOpsApiClient,
   type MonitoredRepository,
+  type PullRequestDetailResponse,
   type PullRequestItem,
   type RepositoryDiscoveryItem,
   type WorkflowCatalogItem,
@@ -22,6 +23,7 @@ const EMPTY_MONITORED_REPOSITORIES: MonitoredRepository[] = [];
 const EMPTY_DISCOVERED_REPOSITORIES: RepositoryDiscoveryItem[] = [];
 const EMPTY_WORKFLOWS: WorkflowCatalogItem[] = [];
 const EMPTY_PULL_REQUESTS: PullRequestItem[] = [];
+const EMPTY_PULL_REQUEST_WORKFLOWS: PullRequestDetailResponse['workflows'] = [];
 const EMPTY_WORKFLOW_RUNS: WorkflowRunItem[] = [];
 const EMPTY_WORKFLOW_RUN_DETAIL_JOBS: WorkflowRunDetailResponse['jobs'] = [];
 
@@ -66,6 +68,7 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
   const [draftAccessToken, setDraftAccessToken] = useState('');
   const [accessToken, setAccessToken] = useState('');
   const [selectedRepositoryId, setSelectedRepositoryId] = useState<string | null>(null);
+  const [selectedPullRequestId, setSelectedPullRequestId] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [selectedWorkflowRunId, setSelectedWorkflowRunId] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -135,6 +138,33 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
   });
 
   const pullRequests = pullRequestsQuery.data ?? EMPTY_PULL_REQUESTS;
+
+  useEffect(() => {
+    if (pullRequests.length === 0) {
+      setSelectedPullRequestId(null);
+      return;
+    }
+
+    const selectedExists = pullRequests.some(
+      (pullRequest) => pullRequest.id === selectedPullRequestId,
+    );
+    const firstPullRequest = pullRequests[0];
+
+    if (!selectedPullRequestId || !selectedExists) {
+      setSelectedPullRequestId(firstPullRequest?.id ?? null);
+    }
+  }, [pullRequests, selectedPullRequestId]);
+
+  const pullRequestDetailQuery = useQuery({
+    queryKey: ['pull-request-detail', accessToken, selectedRepositoryId, selectedPullRequestId],
+    queryFn: () =>
+      client.getPullRequestDetail(accessToken, selectedRepositoryId!, selectedPullRequestId!),
+    enabled:
+      hasAccessToken &&
+      selectedRepositoryId !== null &&
+      selectedPullRequestId !== null,
+    retry: false,
+  });
 
   useEffect(() => {
     if (repositoryWorkflows.length === 0) {
@@ -223,6 +253,12 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
           queryKey: ['repository-workflows', accessToken, repository.id],
         }),
         queryClient.invalidateQueries({
+          queryKey: ['pull-requests', accessToken, repository.id],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['pull-request-detail', accessToken, repository.id],
+        }),
+        queryClient.invalidateQueries({
           queryKey: ['workflow-runs', accessToken, repository.id],
         }),
         queryClient.invalidateQueries({
@@ -246,10 +282,13 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
   );
   const selectedRepository =
     monitoredRepositories.find((repository) => repository.id === selectedRepositoryId) ?? null;
+  const selectedPullRequest =
+    pullRequests.find((pullRequest) => pullRequest.id === selectedPullRequestId) ?? null;
   const selectedWorkflow =
     repositoryWorkflows.find((workflow) => workflow.id === selectedWorkflowId) ?? null;
   const selectedWorkflowRun =
     workflowRuns.find((workflowRun) => workflowRun.id === selectedWorkflowRunId) ?? null;
+  const pullRequestDetail = pullRequestDetailQuery.data;
   const workflowRunDetail = workflowRunDetailQuery.data;
 
   const submitAccessToken = () => {
@@ -271,6 +310,7 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
     setDraftAccessToken('');
     setAccessToken('');
     setSelectedRepositoryId(null);
+    setSelectedPullRequestId(null);
     setSelectedWorkflowId(null);
     setSelectedWorkflowRunId(null);
     setTokenError(null);
@@ -286,6 +326,9 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
     });
     void queryClient.removeQueries({
       queryKey: ['pull-requests'],
+    });
+    void queryClient.removeQueries({
+      queryKey: ['pull-request-detail'],
     });
     void queryClient.removeQueries({
       queryKey: ['workflow-runs'],
@@ -491,9 +534,122 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
                     updated: {formatTimestamp(pullRequest.updatedAt)}
                   </span>
                 </div>
+                <div className="workflow-runs-list__actions">
+                  <Button
+                    variant={pullRequest.id === selectedPullRequestId ? 'secondary' : 'primary'}
+                    onClick={() => setSelectedPullRequestId(pullRequest.id)}
+                  >
+                    {pullRequest.id === selectedPullRequestId
+                      ? 'Viewing pull request detail'
+                      : 'View pull request detail'}
+                  </Button>
+                </div>
               </li>
             ))}
           </ul>
+        )}
+      </Card>
+
+      <Card
+        eyebrow="Pull request detail"
+        title={selectedPullRequest ? `PR #${selectedPullRequest.number}` : 'Pull request detail'}
+      >
+        {!hasAccessToken ? (
+          <p className="empty-state">
+            Add an operator token to inspect pull request details.
+          </p>
+        ) : !selectedRepository ? (
+          <p className="empty-state">Select a repository to inspect pull request details.</p>
+        ) : pullRequestsQuery.isLoading ? (
+          <p className="empty-state">Loading pull requests before showing detail...</p>
+        ) : pullRequestsQuery.isError ? (
+          <p className="empty-state">
+            {getErrorMessage(pullRequestsQuery.error, 'Unable to load pull requests.')}
+          </p>
+        ) : pullRequests.length === 0 ? (
+          <p className="empty-state">No pull requests are available yet for this repository.</p>
+        ) : !selectedPullRequest ? (
+          <p className="empty-state">Select a pull request to load detail.</p>
+        ) : pullRequestDetailQuery.isLoading ? (
+          <p className="empty-state">Loading pull request detail...</p>
+        ) : pullRequestDetailQuery.isError ? (
+          <p className="empty-state">
+            {getErrorMessage(
+              pullRequestDetailQuery.error,
+              'Unable to load pull request detail.',
+            )}
+          </p>
+        ) : !pullRequestDetail ? (
+          <p className="empty-state">Pull request detail is unavailable.</p>
+        ) : (
+          <div className="workflow-run-detail">
+            <div className="workflow-runs-list__meta">
+              <span className="repository-list__badge repository-list__badge--neutral">
+                status: {pullRequestDetail.status}
+              </span>
+              <span className="repository-list__badge repository-list__badge--neutral">
+                author: {pullRequestDetail.author}
+              </span>
+              <span className="repository-list__badge repository-list__badge--neutral">
+                title: {pullRequestDetail.title}
+              </span>
+            </div>
+
+            {pullRequestDetail.summary ? (
+              <div className="workflow-runs-list__meta">
+                <span className="repository-list__badge repository-list__badge--neutral">
+                  blockers: {pullRequestDetail.summary.blockersCount}
+                </span>
+                <span className="repository-list__badge repository-list__badge--neutral">
+                  risks: {pullRequestDetail.summary.risksCount}
+                </span>
+                <span className="repository-list__badge repository-list__badge--neutral">
+                  suggestions: {pullRequestDetail.summary.suggestionsCount}
+                </span>
+                <span className="repository-list__badge repository-list__badge--neutral">
+                  reviewed: {formatTimestamp(pullRequestDetail.summary.lastReviewedAt)}
+                </span>
+              </div>
+            ) : (
+              <p className="empty-state">
+                No Codex review summary is available for this pull request yet.
+              </p>
+            )}
+
+            {pullRequestDetail.workflows.length === 0 ? (
+              <p className="empty-state">
+                No linked workflow runs were found for this pull request.
+              </p>
+            ) : (
+              <ul className="workflow-runs-list">
+                {(pullRequestDetail.workflows ?? EMPTY_PULL_REQUEST_WORKFLOWS).map((workflow) => (
+                  <li
+                    key={`${workflow.name}-${workflow.startedAt ?? workflow.finishedAt ?? workflow.status}`}
+                    className="workflow-runs-list__item"
+                  >
+                    <div className="workflow-runs-list__summary">
+                      <strong>{workflow.name}</strong>
+                      <span>{workflow.conclusion ?? 'in progress'}</span>
+                    </div>
+                    <div className="workflow-runs-list__meta">
+                      <span className="repository-list__badge repository-list__badge--neutral">
+                        status: {workflow.status}
+                      </span>
+                      <span className="repository-list__badge repository-list__badge--neutral">
+                        conclusion: {workflow.conclusion ?? 'n/a'}
+                      </span>
+                      <span className="repository-list__badge repository-list__badge--neutral">
+                        started: {formatTimestamp(workflow.startedAt)}
+                      </span>
+                      <span className="repository-list__badge repository-list__badge--neutral">
+                        finished: {formatTimestamp(workflow.finishedAt)}
+                      </span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         )}
       </Card>
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -107,6 +107,43 @@ const pullRequestsResponseSchema = z.object({
   pullRequests: z.array(pullRequestItemSchema),
 });
 
+const pullRequestDetailResponseSchema = z.object({
+  id: z.string().min(1),
+  number: z.number().int().nonnegative(),
+  title: z.string().min(1),
+  status: z.enum(['open', 'closed', 'merged']),
+  author: z.string().min(1),
+  summary: z
+    .object({
+      blockersCount: z.number().int().nonnegative(),
+      risksCount: z.number().int().nonnegative(),
+      suggestionsCount: z.number().int().nonnegative(),
+      lastReviewedAt: z.string().datetime(),
+    })
+    .nullable(),
+  workflows: z.array(
+    z.object({
+      name: z.string().min(1),
+      status: z.enum(['queued', 'in_progress', 'completed', 'pending', 'waiting', 'requested']),
+      conclusion: z
+        .enum([
+          'success',
+          'failure',
+          'neutral',
+          'cancelled',
+          'skipped',
+          'timed_out',
+          'action_required',
+          'stale',
+          'startup_failure',
+        ])
+        .nullable(),
+      startedAt: z.string().datetime().nullable(),
+      finishedAt: z.string().datetime().nullable(),
+    }),
+  ),
+});
+
 const workflowRunItemSchema = z.object({
   id: z.string().min(1),
   workflowId: z.string().min(1),
@@ -174,6 +211,7 @@ export type RepositoryDiscoveryItem = z.infer<typeof repositoryDiscoveryItemSche
 export type CreateRepositoryInput = z.infer<typeof createRepositoryInputSchema>;
 export type WorkflowCatalogItem = z.infer<typeof workflowCatalogItemSchema>;
 export type PullRequestItem = z.infer<typeof pullRequestItemSchema>;
+export type PullRequestDetailResponse = z.infer<typeof pullRequestDetailResponseSchema>;
 export type WorkflowRunItem = z.infer<typeof workflowRunItemSchema>;
 export type WorkflowRunJobItem = z.infer<typeof workflowRunJobItemSchema>;
 export type WorkflowRunDetailResponse = z.infer<typeof workflowRunDetailResponseSchema>;
@@ -205,6 +243,11 @@ export interface ForgeOpsApiClient {
     repositoryId: string,
   ): Promise<WorkflowCatalogItem[]>;
   getPullRequests(accessToken: string, repositoryId: string): Promise<PullRequestItem[]>;
+  getPullRequestDetail(
+    accessToken: string,
+    repositoryId: string,
+    pullRequestId: string,
+  ): Promise<PullRequestDetailResponse>;
   getWorkflowRuns(
     accessToken: string,
     repositoryId: string,
@@ -319,6 +362,28 @@ export const createApiClient = (options: CreateApiClientOptions = {}): ForgeOpsA
       }
 
       return pullRequestsResponseSchema.parse(await response.json()).pullRequests;
+    },
+
+    async getPullRequestDetail(
+      accessToken: string,
+      repositoryId: string,
+      pullRequestId: string,
+    ): Promise<PullRequestDetailResponse> {
+      const response = await fetcher(
+        `${baseUrl}/api/v1/repositories/${repositoryId}/pull-requests/${pullRequestId}`,
+        {
+          headers: buildHeaders(accessToken),
+        },
+      );
+
+      if (!response.ok) {
+        throw await createApiError(
+          response,
+          `Failed to fetch pull request detail (${response.status})`,
+        );
+      }
+
+      return pullRequestDetailResponseSchema.parse(await response.json());
     },
 
     async getWorkflowRuns(

--- a/frontend/src/tests/api-client.test.ts
+++ b/frontend/src/tests/api-client.test.ts
@@ -338,6 +338,79 @@ describe('createApiClient', () => {
     );
   });
 
+  it('should fetch pull request detail with summary and workflows', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'pr_123',
+          number: 42,
+          title: 'Add pull request insights',
+          status: 'open',
+          author: 'alessandrolsdev',
+          summary: {
+            blockersCount: 1,
+            risksCount: 2,
+            suggestionsCount: 1,
+            lastReviewedAt: '2026-03-31T18:50:00.000Z',
+          },
+          workflows: [
+            {
+              name: 'Deploy',
+              status: 'in_progress',
+              conclusion: null,
+              startedAt: '2026-03-31T19:00:00.000Z',
+              finishedAt: null,
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+      ),
+    );
+    const client = createApiClient({
+      baseUrl: 'http://localhost:3333',
+      fetcher,
+    });
+
+    await expect(
+      client.getPullRequestDetail('trusted-token', 'repo_123', 'pr_123'),
+    ).resolves.toEqual({
+      id: 'pr_123',
+      number: 42,
+      title: 'Add pull request insights',
+      status: 'open',
+      author: 'alessandrolsdev',
+      summary: {
+        blockersCount: 1,
+        risksCount: 2,
+        suggestionsCount: 1,
+        lastReviewedAt: '2026-03-31T18:50:00.000Z',
+      },
+      workflows: [
+        {
+          name: 'Deploy',
+          status: 'in_progress',
+          conclusion: null,
+          startedAt: '2026-03-31T19:00:00.000Z',
+          finishedAt: null,
+        },
+      ],
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      'http://localhost:3333/api/v1/repositories/repo_123/pull-requests/pr_123',
+      {
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer trusted-token',
+        },
+      },
+    );
+  });
+
   it('should fetch workflow run detail with jobs', async () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(

--- a/frontend/src/tests/repositories-view.test.tsx
+++ b/frontend/src/tests/repositories-view.test.tsx
@@ -27,6 +27,15 @@ describe('RepositoriesView', () => {
       getRepositoryDiscovery: vi.fn(),
       getRepositoryWorkflows: vi.fn(),
       getPullRequests: vi.fn(),
+      getPullRequestDetail: vi.fn().mockResolvedValue({
+        id: 'pr_123',
+        number: 42,
+        title: 'Add pull request insights',
+        status: 'open',
+        author: 'alessandrolsdev',
+        summary: null,
+        workflows: [],
+      }),
       getWorkflowRuns: vi.fn(),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
@@ -58,6 +67,7 @@ describe('RepositoriesView', () => {
     expect(client.getRepositoryDiscovery).not.toHaveBeenCalled();
     expect(client.getRepositoryWorkflows).not.toHaveBeenCalled();
     expect(client.getPullRequests).not.toHaveBeenCalled();
+    expect(client.getPullRequestDetail).not.toHaveBeenCalled();
     expect(client.getWorkflowRuns).not.toHaveBeenCalled();
   });
 
@@ -144,6 +154,15 @@ describe('RepositoriesView', () => {
       getRepositoryDiscovery,
       getRepositoryWorkflows,
       getPullRequests,
+      getPullRequestDetail: vi.fn().mockResolvedValue({
+        id: 'pr_123',
+        number: 42,
+        title: 'Add pull request insights',
+        status: 'open',
+        author: 'alessandrolsdev',
+        summary: null,
+        workflows: [],
+      }),
       getWorkflowRuns,
       getWorkflowRunDetail: vi.fn().mockResolvedValue({
         run: {
@@ -227,6 +246,15 @@ describe('RepositoriesView', () => {
       getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
       getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
       getPullRequests,
+      getPullRequestDetail: vi.fn().mockResolvedValue({
+        id: 'pr_123',
+        number: 42,
+        title: 'Add pull request insights',
+        status: 'open',
+        author: 'alessandrolsdev',
+        summary: null,
+        workflows: [],
+      }),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
@@ -269,6 +297,7 @@ describe('RepositoriesView', () => {
       getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
       getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
       getPullRequests: vi.fn().mockImplementation(() => new Promise(() => undefined)),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
@@ -305,6 +334,7 @@ describe('RepositoriesView', () => {
       getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
       getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
       getPullRequests: vi.fn().mockResolvedValue([]),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
@@ -345,6 +375,7 @@ describe('RepositoriesView', () => {
       getPullRequests: vi
         .fn()
         .mockRejectedValue(new ApiClientError('Pull requests are currently unavailable.', 503)),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
@@ -358,7 +389,294 @@ describe('RepositoriesView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Pull requests are currently unavailable.')).toBeInTheDocument();
+      expect(
+        screen.getAllByText('Pull requests are currently unavailable.'),
+      ).toHaveLength(2);
+    });
+  });
+
+  it('should load pull request detail with summary and linked workflows after selecting a pull request', async () => {
+    const getPullRequestDetail = vi
+      .fn<ForgeOpsApiClient['getPullRequestDetail']>()
+      .mockResolvedValue({
+        id: 'pr_123',
+        number: 42,
+        title: 'Add pull request insights',
+        status: 'open',
+        author: 'alessandrolsdev',
+        summary: {
+          blockersCount: 1,
+          risksCount: 2,
+          suggestionsCount: 1,
+          lastReviewedAt: '2026-03-31T18:50:00.000Z',
+        },
+        workflows: [
+          {
+            name: 'Deploy',
+            status: 'in_progress',
+            conclusion: null,
+            startedAt: '2026-03-31T19:00:00.000Z',
+            finishedAt: null,
+          },
+          {
+            name: 'CI',
+            status: 'completed',
+            conclusion: 'success',
+            startedAt: '2026-03-31T18:40:00.000Z',
+            finishedAt: '2026-03-31T18:45:00.000Z',
+          },
+        ],
+      });
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
+      getPullRequests: vi.fn().mockResolvedValue([
+        {
+          id: 'pr_123',
+          githubPrId: '987654321',
+          number: 42,
+          title: 'Add pull request insights',
+          state: 'open',
+          author: 'alessandrolsdev',
+          baseBranch: 'main',
+          headBranch: 'feature/pull-request-insights',
+          createdAt: '2026-03-31T18:20:00.000Z',
+          updatedAt: '2026-03-31T18:20:00.000Z',
+        },
+      ]),
+      getPullRequestDetail,
+      getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      getWorkflowRunDetail: vi.fn(),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Viewing pull request detail' }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Viewing pull request detail' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Pull request detail')).toBeInTheDocument();
+      expect(screen.getByText('blockers: 1')).toBeInTheDocument();
+      expect(screen.getByText('risks: 2')).toBeInTheDocument();
+      expect(screen.getByText('suggestions: 1')).toBeInTheDocument();
+      expect(screen.getByText('Deploy')).toBeInTheDocument();
+      expect(screen.getByText('CI')).toBeInTheDocument();
+    });
+
+    expect(getPullRequestDetail).toHaveBeenCalledWith(
+      'trusted-token',
+      'repo_123',
+      'pr_123',
+    );
+  });
+
+  it('should render pull request detail loading state', async () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
+      getPullRequests: vi.fn().mockResolvedValue([
+        {
+          id: 'pr_123',
+          githubPrId: '987654321',
+          number: 42,
+          title: 'Add pull request insights',
+          state: 'open',
+          author: 'alessandrolsdev',
+          baseBranch: 'main',
+          headBranch: 'feature/pull-request-insights',
+          createdAt: '2026-03-31T18:20:00.000Z',
+          updatedAt: '2026-03-31T18:20:00.000Z',
+        },
+      ]),
+      getPullRequestDetail: vi.fn().mockImplementation(() => new Promise(() => undefined)),
+      getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      getWorkflowRunDetail: vi.fn(),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Viewing pull request detail' }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Viewing pull request detail' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Loading pull request detail...')).toBeInTheDocument();
+    });
+  });
+
+  it('should render pull request detail without summary and workflows', async () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
+      getPullRequests: vi.fn().mockResolvedValue([
+        {
+          id: 'pr_123',
+          githubPrId: '987654321',
+          number: 42,
+          title: 'Add pull request insights',
+          state: 'open',
+          author: 'alessandrolsdev',
+          baseBranch: 'main',
+          headBranch: 'feature/pull-request-insights',
+          createdAt: '2026-03-31T18:20:00.000Z',
+          updatedAt: '2026-03-31T18:20:00.000Z',
+        },
+      ]),
+      getPullRequestDetail: vi.fn().mockResolvedValue({
+        id: 'pr_123',
+        number: 42,
+        title: 'Add pull request insights',
+        status: 'open',
+        author: 'alessandrolsdev',
+        summary: null,
+        workflows: [],
+      }),
+      getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      getWorkflowRunDetail: vi.fn(),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Viewing pull request detail' }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Viewing pull request detail' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('No Codex review summary is available for this pull request yet.')).toBeInTheDocument();
+      expect(screen.getByText('No linked workflow runs were found for this pull request.')).toBeInTheDocument();
+    });
+  });
+
+  it('should render pull request detail errors clearly', async () => {
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
+      getPullRequests: vi.fn().mockResolvedValue([
+        {
+          id: 'pr_123',
+          githubPrId: '987654321',
+          number: 42,
+          title: 'Add pull request insights',
+          state: 'open',
+          author: 'alessandrolsdev',
+          baseBranch: 'main',
+          headBranch: 'feature/pull-request-insights',
+          createdAt: '2026-03-31T18:20:00.000Z',
+          updatedAt: '2026-03-31T18:20:00.000Z',
+        },
+      ]),
+      getPullRequestDetail: vi
+        .fn()
+        .mockRejectedValue(new ApiClientError('Pull request detail is unavailable.', 503)),
+      getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      getWorkflowRunDetail: vi.fn(),
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Viewing pull request detail' }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Viewing pull request detail' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Pull request detail is unavailable.')).toBeInTheDocument();
     });
   });
 
@@ -393,6 +711,7 @@ describe('RepositoriesView', () => {
         },
       ]),
       getPullRequests: vi.fn().mockResolvedValue([]),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockImplementation(() => new Promise(() => undefined)),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
@@ -441,6 +760,7 @@ describe('RepositoriesView', () => {
         },
       ]),
       getPullRequests: vi.fn().mockResolvedValue([]),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
@@ -491,6 +811,7 @@ describe('RepositoriesView', () => {
         },
       ]),
       getPullRequests: vi.fn().mockResolvedValue([]),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi
         .fn()
         .mockRejectedValue(new ApiClientError('Workflow runs are currently unavailable.', 503)),
@@ -574,6 +895,7 @@ describe('RepositoriesView', () => {
         },
       ]),
       getPullRequests: vi.fn().mockResolvedValue([]),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([
         {
           id: 'run_123',
@@ -653,6 +975,7 @@ describe('RepositoriesView', () => {
         },
       ]),
       getPullRequests: vi.fn().mockResolvedValue([]),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([
         {
           id: 'run_123',
@@ -723,6 +1046,7 @@ describe('RepositoriesView', () => {
         },
       ]),
       getPullRequests: vi.fn().mockResolvedValue([]),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([
         {
           id: 'run_123',
@@ -811,6 +1135,7 @@ describe('RepositoriesView', () => {
         },
       ]),
       getPullRequests: vi.fn().mockResolvedValue([]),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([
         {
           id: 'run_123',
@@ -914,6 +1239,7 @@ describe('RepositoriesView', () => {
       getRepositoryDiscovery,
       getRepositoryWorkflows,
       getPullRequests: vi.fn().mockResolvedValue([]),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
       createRepository,
@@ -959,6 +1285,7 @@ describe('RepositoriesView', () => {
         ),
       getRepositoryWorkflows: vi.fn(),
       getPullRequests: vi.fn(),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn(),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),
@@ -1010,6 +1337,7 @@ describe('RepositoriesView', () => {
       ]),
       getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
       getPullRequests: vi.fn().mockResolvedValue([]),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi
@@ -1062,6 +1390,7 @@ describe('RepositoriesView', () => {
           new ApiClientError('Repository was not found.', 404, 'repository_not_found'),
         ),
       getPullRequests: vi.fn().mockResolvedValue([]),
+      getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
       createRepository: vi.fn(),


### PR DESCRIPTION
## Resumo
Implementa a visualização de detalhe de pull request no frontend a partir da API protegida já exposta pelo backend. A tela passa a agregar dados principais da PR, summary do review do Codex e workflow runs vinculadas, preservando estados explícitos de carregamento, vazio, erro e sucesso.

## O que foi alterado
- Adiciona no cliente HTTP do frontend o contrato tipado e o método `getPullRequestDetail` para consumir `GET /api/v1/repositories/:repositoryId/pull-requests/:pullRequestId`.
- Estende a `RepositoriesView` para selecionar uma pull request e renderizar um card de detalhe com status, autor, summary e workflows vinculados.
- Atualiza os testes do cliente e da view para cobrir sucesso, loading, vazio, erro, seleção automática da PR e o contrato da API.

## Motivação
A issue #81 é a etapa necessária para transformar o slice de Pull Request Insights em fluxo utilizável no produto. Sem esse detalhe no frontend, a persistência e a API já entregues nas issues anteriores ainda não ficam acessíveis para o usuário final.

## Como validar
- Executar `npm run lint` na raiz do monorepo.
- Executar `npm run typecheck` na raiz do monorepo.
- Executar `npm run test` na raiz do monorepo.
- Subir a aplicação com backend e frontend configurados, selecionar um repositório monitorado e verificar a seção de pull requests.
- Confirmar que o card de detalhe exibe summary quando disponível e mostra estados vazios quando não houver summary ou workflows vinculados.

## Riscos e impactos
- O vínculo entre PR e workflow run continua dependente do contrato atual do backend, baseado em branch e data; isso é suficiente para o slice atual, mas pode exigir refinamento futuro.
- A experiência ainda permanece dentro da `RepositoriesView`, o que mantém o escopo controlado, mas limita refinamentos de navegação até a próxima evolução.
- O risco operacional é baixo porque a mudança está restrita ao frontend e validada por testes automatizados de contrato e interface.

## Evidências
- `npm run lint`
- `npm run typecheck`
- `npm run test`

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #81