### PR TITLE
fix(auth): conecta verifier ao bootstrap do backend

### DIFF
--- a/backend/src/infra/auth/create-operator-auth-verifier.ts
+++ b/backend/src/infra/auth/create-operator-auth-verifier.ts
@@ -1,0 +1,268 @@
+import {
+  createHmac,
+  createPublicKey,
+  timingSafeEqual,
+  verify as verifySignature,
+} from 'node:crypto';
+import type { JsonWebKey } from 'node:crypto';
+import type { OperatorAuthEnv } from '../config/auth-env.js';
+import type { OperatorAuthVerifier } from '../../shared/auth/operator-auth-verifier.js';
+import { createOperatorPrincipal } from '../../shared/auth/operator-principal.js';
+import { AuthenticationError } from '../../shared/errors/authentication-error.js';
+
+interface JwtHeader {
+  alg?: string;
+  kid?: string;
+}
+
+interface JwtPayload {
+  iss?: string;
+  aud?: string | string[];
+  sub?: string;
+  exp?: number;
+  nbf?: number;
+  email?: string;
+  name?: string;
+  capabilities?: unknown;
+  scope?: string;
+}
+
+interface JwksResponse {
+  keys?: JsonWebKey[];
+}
+
+const AUTH_FAILURE_MESSAGE = 'Authentication failed.';
+const JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface ParsedJwt {
+  signingInput: string;
+  header: JwtHeader;
+  payload: JwtPayload;
+  signature: Buffer;
+}
+
+const parseJsonSegment = <TValue>(segment: string): TValue => {
+  try {
+    return JSON.parse(Buffer.from(segment, 'base64url').toString('utf8')) as TValue;
+  } catch {
+    throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+  }
+};
+
+const parseJwt = (token: string): ParsedJwt => {
+  const segments = token.split('.');
+
+  if (segments.length !== 3) {
+    throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+  }
+
+  const [encodedHeader, encodedPayload, encodedSignature] = segments;
+
+  if (!encodedHeader || !encodedPayload || !encodedSignature) {
+    throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+  }
+
+  return {
+    signingInput: `${encodedHeader}.${encodedPayload}`,
+    header: parseJsonSegment<JwtHeader>(encodedHeader),
+    payload: parseJsonSegment<JwtPayload>(encodedPayload),
+    signature: Buffer.from(encodedSignature, 'base64url'),
+  };
+};
+
+const assertTemporalClaims = (payload: JwtPayload): void => {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+
+  if (typeof payload.nbf === 'number' && nowSeconds < payload.nbf) {
+    throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+  }
+
+  if (typeof payload.exp === 'number' && nowSeconds >= payload.exp) {
+    throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+  }
+};
+
+const assertIssuerAndAudience = (
+  payload: JwtPayload,
+  authConfig: OperatorAuthEnv,
+): void => {
+  if (payload.iss !== authConfig.issuer) {
+    throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+  }
+
+  const audience = payload.aud;
+  const audienceMatched =
+    typeof audience === 'string'
+      ? audience === authConfig.audience
+      : Array.isArray(audience) && audience.includes(authConfig.audience);
+
+  if (!audienceMatched) {
+    throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+  }
+};
+
+const toCapabilities = (payload: JwtPayload): string[] => {
+  if (Array.isArray(payload.capabilities)) {
+    return payload.capabilities.filter(
+      (capability): capability is string =>
+        typeof capability === 'string' && capability.trim().length > 0,
+    );
+  }
+
+  if (typeof payload.scope === 'string') {
+    return payload.scope
+      .split(' ')
+      .map((scope) => scope.trim())
+      .filter((scope) => scope.length > 0);
+  }
+
+  return [];
+};
+
+const toPrincipal = (payload: JwtPayload) => {
+  if (typeof payload.sub !== 'string' || payload.sub.trim().length === 0) {
+    throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+  }
+
+  return createOperatorPrincipal({
+    subject: payload.sub,
+    email: payload.email ?? null,
+    displayName: payload.name ?? null,
+    capabilities: toCapabilities(payload),
+  });
+};
+
+const createSharedSecretVerifier = (
+  authConfig: OperatorAuthEnv,
+): OperatorAuthVerifier => {
+  if (authConfig.verifierSource.type !== 'shared-secret') {
+    throw new Error('Shared-secret verifier requires shared-secret auth config.');
+  }
+
+  const sharedSecret = authConfig.verifierSource.sharedSecret;
+
+  return {
+    verify: async ({ token }) => {
+      const parsedToken = parseJwt(token);
+
+      if (parsedToken.header.alg !== 'HS256') {
+        throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+      }
+
+      const expectedSignature = createHmac(
+        'sha256',
+        sharedSecret,
+      )
+        .update(parsedToken.signingInput)
+        .digest();
+
+      if (
+        expectedSignature.length !== parsedToken.signature.length ||
+        !timingSafeEqual(expectedSignature, parsedToken.signature)
+      ) {
+        throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+      }
+
+      assertTemporalClaims(parsedToken.payload);
+      assertIssuerAndAudience(parsedToken.payload, authConfig);
+
+      return toPrincipal(parsedToken.payload);
+    },
+  };
+};
+
+const createJwksVerifier = (authConfig: OperatorAuthEnv): OperatorAuthVerifier => {
+  if (authConfig.verifierSource.type !== 'jwks') {
+    throw new Error('JWKS verifier requires jwks auth config.');
+  }
+
+  const jwksUrl = authConfig.verifierSource.jwksUrl;
+
+  let cachedKeys: JsonWebKey[] | null = null;
+  let cachedAt = 0;
+
+  const loadJwks = async (): Promise<JsonWebKey[]> => {
+    const now = Date.now();
+
+    if (cachedKeys && now - cachedAt < JWKS_CACHE_TTL_MS) {
+      return cachedKeys;
+    }
+
+    const response = await fetch(jwksUrl, {
+      signal: AbortSignal.timeout(5000),
+      headers: {
+        accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+    }
+
+    const json = (await response.json()) as JwksResponse;
+
+    if (!Array.isArray(json.keys) || json.keys.length === 0) {
+      throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+    }
+
+    cachedKeys = json.keys;
+    cachedAt = now;
+
+    return json.keys;
+  };
+
+  return {
+    verify: async ({ token }) => {
+      const parsedToken = parseJwt(token);
+
+      if (parsedToken.header.alg !== 'RS256') {
+        throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+      }
+
+      const keys = await loadJwks();
+      const matchingKey = keys.find((key) => {
+        const kidMatches =
+          typeof parsedToken.header.kid === 'string'
+            ? key.kid === parsedToken.header.kid
+            : true;
+
+        return kidMatches && key.kty === 'RSA';
+      });
+
+      if (!matchingKey) {
+        throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+      }
+
+      const publicKey = createPublicKey({
+        key: matchingKey,
+        format: 'jwk',
+      });
+
+      const verified = verifySignature(
+        'RSA-SHA256',
+        Buffer.from(parsedToken.signingInput),
+        publicKey,
+        parsedToken.signature,
+      );
+
+      if (!verified) {
+        throw new AuthenticationError(AUTH_FAILURE_MESSAGE);
+      }
+
+      assertTemporalClaims(parsedToken.payload);
+      assertIssuerAndAudience(parsedToken.payload, authConfig);
+
+      return toPrincipal(parsedToken.payload);
+    },
+  };
+};
+
+export const createOperatorAuthVerifier = (
+  authConfig: OperatorAuthEnv,
+): OperatorAuthVerifier => {
+  if (authConfig.verifierSource.type === 'shared-secret') {
+    return createSharedSecretVerifier(authConfig);
+  }
+
+  return createJwksVerifier(authConfig);
+};

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,22 +1,31 @@
+import { pathToFileURL } from 'node:url';
 import { createServer } from './app/create-server.js';
+import { createOperatorAuthVerifier } from './infra/auth/create-operator-auth-verifier.js';
 import { loadAppEnv } from './infra/config/app-env.js';
 import { loadOptionalOperatorAuthEnv } from './infra/config/auth-env.js';
 import { loadOptionalGitHubAppEnv } from './infra/config/github-app-env.js';
 
-const start = async (): Promise<void> => {
-  const env = loadAppEnv(process.env);
-  const authConfig = loadOptionalOperatorAuthEnv(process.env);
-  const githubConfig = loadOptionalGitHubAppEnv(process.env);
-  const server = createServer({
+export const resolveRuntimeServerOptions = (input: NodeJS.ProcessEnv) => {
+  const env = loadAppEnv(input);
+  const authConfig = loadOptionalOperatorAuthEnv(input);
+  const githubConfig = loadOptionalGitHubAppEnv(input);
+
+  return {
     env,
     authConfig,
+    authVerifier: authConfig ? createOperatorAuthVerifier(authConfig) : null,
     githubConfig,
-  });
+  };
+};
+
+const start = async (): Promise<void> => {
+  const runtimeOptions = resolveRuntimeServerOptions(process.env);
+  const server = createServer(runtimeOptions);
 
   try {
     await server.listen({
       host: '0.0.0.0',
-      port: env.PORT,
+      port: runtimeOptions.env.PORT,
     });
   } catch (error) {
     server.log.error(error, 'Failed to start ForgeOps backend');
@@ -24,4 +33,16 @@ const start = async (): Promise<void> => {
   }
 };
 
-void start();
+const isDirectExecution = (): boolean => {
+  const entrypointPath = process.argv[1];
+
+  if (!entrypointPath) {
+    return false;
+  }
+
+  return import.meta.url === pathToFileURL(entrypointPath).href;
+};
+
+if (isDirectExecution()) {
+  void start();
+}

--- a/backend/src/tests/infra/auth/create-operator-auth-verifier.test.ts
+++ b/backend/src/tests/infra/auth/create-operator-auth-verifier.test.ts
@@ -1,0 +1,172 @@
+import { createHmac, generateKeyPairSync, sign } from 'node:crypto';
+import type { JsonWebKey, KeyObject } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createOperatorAuthVerifier } from '../../../infra/auth/create-operator-auth-verifier.js';
+
+const encodeBase64Url = (value: string): string =>
+  Buffer.from(value, 'utf8').toString('base64url');
+
+const signHs256Token = ({
+  secret,
+  payload,
+  header = {},
+}: {
+  secret: string;
+  payload: Record<string, unknown>;
+  header?: Record<string, unknown>;
+}): string => {
+  const encodedHeader = encodeBase64Url(
+    JSON.stringify({
+      alg: 'HS256',
+      typ: 'JWT',
+      ...header,
+    }),
+  );
+  const encodedPayload = encodeBase64Url(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const signature = createHmac('sha256', secret)
+    .update(signingInput)
+    .digest('base64url');
+
+  return `${signingInput}.${signature}`;
+};
+
+const signRs256Token = ({
+  privateKey,
+  payload,
+  header = {},
+}: {
+  privateKey: KeyObject;
+  payload: Record<string, unknown>;
+  header?: Record<string, unknown>;
+}): string => {
+  const encodedHeader = encodeBase64Url(
+    JSON.stringify({
+      alg: 'RS256',
+      typ: 'JWT',
+      ...header,
+    }),
+  );
+  const encodedPayload = encodeBase64Url(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const signature = sign('RSA-SHA256', Buffer.from(signingInput), privateKey).toString(
+    'base64url',
+  );
+
+  return `${signingInput}.${signature}`;
+};
+
+describe('createOperatorAuthVerifier', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should verify a shared-secret token and map the operator principal', async () => {
+    const verifier = createOperatorAuthVerifier({
+      issuer: 'https://forgeops.local',
+      audience: 'forgeops-api',
+      verifierSource: {
+        type: 'shared-secret',
+        sharedSecret: 'local-secret',
+      },
+    });
+    const token = signHs256Token({
+      secret: 'local-secret',
+      payload: {
+        iss: 'https://forgeops.local',
+        aud: 'forgeops-api',
+        sub: 'operator:local-dev',
+        email: 'operator@forgeops.dev',
+        name: 'Local Operator',
+        capabilities: ['repositories:read', 'repositories:write'],
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+    });
+
+    const principal = await verifier.verify({ token });
+
+    expect(principal).toEqual({
+      kind: 'operator',
+      subject: 'operator:local-dev',
+      email: 'operator@forgeops.dev',
+      displayName: 'Local Operator',
+      capabilities: ['repositories:read', 'repositories:write'],
+    });
+  });
+
+  it('should reject an invalid shared-secret token', async () => {
+    const verifier = createOperatorAuthVerifier({
+      issuer: 'https://forgeops.local',
+      audience: 'forgeops-api',
+      verifierSource: {
+        type: 'shared-secret',
+        sharedSecret: 'local-secret',
+      },
+    });
+    const token = signHs256Token({
+      secret: 'wrong-secret',
+      payload: {
+        iss: 'https://forgeops.local',
+        aud: 'forgeops-api',
+        sub: 'operator:local-dev',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+    });
+
+    await expect(verifier.verify({ token })).rejects.toMatchObject({
+      code: 'authentication_required',
+    });
+  });
+
+  it('should verify a jwks token using the configured issuer and audience', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+    });
+    const jwk = publicKey.export({ format: 'jwk' }) as JsonWebKey;
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        keys: [
+          {
+            ...jwk,
+            kid: 'local-kid',
+          },
+        ],
+      }),
+    } as Response);
+
+    const verifier = createOperatorAuthVerifier({
+      issuer: 'https://forgeops.local',
+      audience: 'forgeops-api',
+      verifierSource: {
+        type: 'jwks',
+        jwksUrl: 'https://forgeops.local/.well-known/jwks.json',
+      },
+    });
+    const token = signRs256Token({
+      privateKey,
+      header: {
+        kid: 'local-kid',
+      },
+      payload: {
+        iss: 'https://forgeops.local',
+        aud: ['forgeops-api'],
+        sub: 'operator:jwks',
+        scope: 'repositories:read repositories:write',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+    });
+
+    const principal = await verifier.verify({ token });
+
+    expect(principal).toEqual({
+      kind: 'operator',
+      subject: 'operator:jwks',
+      email: null,
+      displayName: null,
+      capabilities: ['repositories:read', 'repositories:write'],
+    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/tests/server.test.ts
+++ b/backend/src/tests/server.test.ts
@@ -1,0 +1,159 @@
+import { createHmac } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer } from '../app/create-server.js';
+import { resolveRuntimeServerOptions } from '../server.js';
+
+const encodeBase64Url = (value: string): string =>
+  Buffer.from(value, 'utf8').toString('base64url');
+
+const signSharedSecretToken = (payload: Record<string, unknown>, secret: string): string => {
+  const encodedHeader = encodeBase64Url(
+    JSON.stringify({
+      alg: 'HS256',
+      typ: 'JWT',
+    }),
+  );
+  const encodedPayload = encodeBase64Url(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const signature = createHmac('sha256', secret)
+    .update(signingInput)
+    .digest('base64url');
+
+  return `${signingInput}.${signature}`;
+};
+
+const createRuntimeTestServer = (env: NodeJS.ProcessEnv) =>
+  createServer({
+    ...resolveRuntimeServerOptions(env),
+    repositoryRegistryRepository: {
+      list: async () => [],
+      findById: async () => null,
+      create: async () => {
+        throw new Error('Not implemented in runtime bootstrap test.');
+      },
+      deleteById: async () => undefined,
+    },
+    workflowCatalogRepository: {
+      create: async () => {
+        throw new Error('Not implemented in runtime bootstrap test.');
+      },
+      upsert: async () => {
+        throw new Error('Not implemented in runtime bootstrap test.');
+      },
+      listByRepositoryId: async () => [],
+      findById: async () => null,
+    },
+    workflowRunRepository: {
+      createRun: async () => {
+        throw new Error('Not implemented in runtime bootstrap test.');
+      },
+      upsertRun: async () => {
+        throw new Error('Not implemented in runtime bootstrap test.');
+      },
+      listRunsByWorkflowId: async () => [],
+      findRunById: async () => null,
+      createJob: async () => {
+        throw new Error('Not implemented in runtime bootstrap test.');
+      },
+      upsertJob: async () => {
+        throw new Error('Not implemented in runtime bootstrap test.');
+      },
+      listJobsByWorkflowRunId: async () => [],
+    },
+    pullRequestRepository: {
+      create: async () => {
+        throw new Error('Not implemented in runtime bootstrap test.');
+      },
+      upsert: async () => {
+        throw new Error('Not implemented in runtime bootstrap test.');
+      },
+      listByRepositoryId: async () => [],
+      findById: async () => null,
+    },
+    codexReviewSummaryRepository: {
+      create: async () => {
+        throw new Error('Not implemented in runtime bootstrap test.');
+      },
+      upsert: async () => {
+        throw new Error('Not implemented in runtime bootstrap test.');
+      },
+      findByPullRequestId: async () => null,
+    },
+  });
+
+describe('resolveRuntimeServerOptions', () => {
+  afterEach(async () => {
+    // explicit lifecycle placeholder
+  });
+
+  it('should keep protected routes degraded when auth is not configured', async () => {
+    const server = createRuntimeTestServer({
+      NODE_ENV: 'test',
+      PORT: '3333',
+      LOG_LEVEL: 'silent',
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/me',
+      headers: {
+        authorization: 'Bearer token',
+      },
+    });
+
+    expect(response.statusCode).toBe(503);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'auth_not_configured',
+        message: 'Operator authentication is not configured.',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should wire a runtime auth verifier when shared-secret auth is configured', async () => {
+    const server = createRuntimeTestServer({
+      NODE_ENV: 'test',
+      PORT: '3333',
+      LOG_LEVEL: 'silent',
+      OPERATOR_AUTH_ENABLED: 'true',
+      OPERATOR_AUTH_ISSUER: 'https://forgeops.local',
+      OPERATOR_AUTH_AUDIENCE: 'forgeops-api',
+      OPERATOR_AUTH_MODE: 'shared-secret',
+      OPERATOR_AUTH_SHARED_SECRET: 'local-secret',
+    });
+    const token = signSharedSecretToken(
+      {
+        iss: 'https://forgeops.local',
+        aud: 'forgeops-api',
+        sub: 'operator:trusted-token',
+        email: 'operator@forgeops.dev',
+        capabilities: ['repositories:read'],
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+      'local-secret',
+    );
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/me',
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      principal: {
+        kind: 'operator',
+        subject: 'operator:trusted-token',
+        email: 'operator@forgeops.dev',
+        displayName: null,
+        capabilities: ['repositories:read'],
+      },
+    });
+
+    await server.close();
+  });
+});


### PR DESCRIPTION
## Resumo
Esta PR conecta o `authVerifier` ao bootstrap do backend para que rotas protegidas validem autenticação de verdade quando a configuração estiver presente no runtime. O objetivo é remover o falso `503 auth_not_configured` que bloqueava o teste local do slice atual do produto.

## O que foi alterado
- Adiciona a factory de `OperatorAuthVerifier` com suporte aos modos `shared-secret` e `jwks` já previstos na configuração.
- Conecta `authConfig` e `authVerifier` no bootstrap de [server.ts](/C:/Github/forge-ops/backend/src/server.ts), reutilizando o wiring já aceito por `createServer`.
- Adiciona testes para o verifier e para o bootstrap do runtime com auth configurada e sem auth configurada.
- Valida no runtime local que `/api/v1/auth/me` deixa de retornar `503 auth_not_configured` quando a configuração de operador está presente.

## Motivação
O produto já sobe localmente com frontend, backend e proxy, mas as APIs protegidas continuavam indisponíveis porque o runtime carregava `authConfig` sem injetar um verifier. Isso impedia testar de verdade o fluxo protegido do produto e mascarava o próximo bloqueio operacional.

## Como validar
- Executar `npm run lint`.
- Executar `npm run typecheck`.
- Executar `npm run test`.
- Subir o ambiente local com `OPERATOR_AUTH_*` configurado em modo `shared-secret`.
- Chamar `GET /api/v1/auth/me` com token válido e confirmar `200`.
- Chamar `GET /api/v1/auth/me` sem configuração de auth e confirmar `503 auth_not_configured`.

## Riscos e impactos
- A PR não altera a arquitetura de autenticação; apenas corrige o wiring do bootstrap.
- O comportamento sem auth configurada continua degradando de forma segura.
- O fluxo fim a fim do produto ainda depende de corrigir o banco local, porque o schema atual não sobe por completo devido a uma migration inválida.
- A rota `/api/v1/github/repositories` não faz parte do backend atual; o fluxo equivalente segue por `/api/v1/repositories/discovery`.

## Evidências
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- Validação local de `GET /api/v1/auth/me` com `200` após recriar o backend com `OPERATOR_AUTH_*` configurado

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #112