### PR TITLE
chore(infra): consolida status do provider no proxy

### DIFF
--- a/docs/architecture/local-dev-proxy.md
+++ b/docs/architecture/local-dev-proxy.md
@@ -71,6 +71,14 @@ Os principais `degraded_reason` esperados sao:
 - `network_mismatch`
 - `provider_active_but_no_routes_materialized`
 
+O bootstrap e o observer agora compartilham a mesma logica de status e a mesma estrutura de snapshot para reduzir risco de drift entre scripts.
+
+Quando `jq` estiver ausente, falhar ao parsear ou receber payload inesperado:
+- o proxy nao falha silenciosamente
+- o status degrada de forma segura
+- o motivo fica explicito em log como `jq_unavailable` ou `jq_parse_failed`
+- o `file provider` permanece como caminho estavel
+
 ## Snapshot do diagnostico atual
 
 No runtime local validado ate agora, o estado observado e:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "node scripts/run-workspaces.mjs lint",
     "typecheck": "node scripts/run-workspaces.mjs typecheck",
     "test": "node scripts/run-workspaces.mjs test",
+    "test:proxy": "node --test scripts/provider-status.test.mjs",
     "format": "node scripts/run-bin.mjs prettier --write .",
     "format:check": "node scripts/run-bin.mjs prettier --check ."
   },

--- a/scripts/provider-status.test.mjs
+++ b/scripts/provider-status.test.mjs
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+
+const repoRoot = process.cwd();
+const bashRepoRoot = '/mnt/c/Github/forge-ops';
+const jqBinary =
+  '/mnt/c/Users/Alessandro/AppData/Local/Microsoft/WinGet/Links/jq.exe';
+
+const runShell = (script) =>
+  execFileSync('bash', [], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    input: `cd ${bashRepoRoot}\n${script}\n`,
+  })
+    .trim()
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .at(-1) ?? '';
+
+test('classify_provider_status should classify healthy and degraded states', () => {
+  assert.equal(
+    runShell('. ./traefik/scripts/provider-status.sh\nclassify_provider_status 1 1 0 0 0 2 1'),
+    'healthy|none',
+  );
+  assert.equal(
+    runShell('. ./traefik/scripts/provider-status.sh\nclassify_provider_status 0 0 0 0 0 0 0'),
+    'degraded|no_eligible_containers',
+  );
+  assert.equal(
+    runShell('. ./traefik/scripts/provider-status.sh\nclassify_provider_status 2 1 1 0 0 0 0'),
+    'degraded|containers_with_incomplete_labels',
+  );
+});
+
+test('resolve_preflight_provider_state should classify bootstrap states', () => {
+  assert.equal(
+    runShell('. ./traefik/scripts/provider-status.sh\nresolve_preflight_provider_state false /var/run/docker.sock'),
+    'file_provider_only|docker_provider_disabled_by_flag|false',
+  );
+  assert.equal(
+    runShell('. ./traefik/scripts/provider-status.sh\nresolve_preflight_provider_state true ""'),
+    'degraded|docker_endpoint_not_unix_socket|false',
+  );
+});
+
+test('json_field_from_body should parse escaped quotes when jq is available', () => {
+  const result = runShell(`jq(){ "${jqBinary}" "$@"; }
+. ./traefik/scripts/provider-status.sh
+printf '%s' '{"Version":"29.3.1 \\"edge\\""}' | json_field_from_body Version`);
+  assert.equal(result, '29.3.1 "edge"');
+});
+
+test('build_provider_snapshot should preserve counters in degraded fallback', () => {
+  const output = runShell(`. ./traefik/scripts/provider-status.sh
+jq_available(){ return 1; }
+build_provider_snapshot degraded docker_socket_unavailable forgeops 3 2 1 '[]' '[]' '[]' 2 1 4 5`);
+  const snapshot = JSON.parse(output);
+
+  assert.equal(snapshot.degraded_reason, 'jq_unavailable');
+  assert.equal(snapshot.eligible_containers_count, 3);
+  assert.equal(snapshot.docker_routers_count, 4);
+  assert.equal(snapshot.docker_services_count, 5);
+});
+
+test('build_provider_snapshot should surface jq parse failure explicitly', () => {
+  const output = runShell(`. ./traefik/scripts/provider-status.sh
+jq(){ return 1; }
+build_provider_snapshot degraded docker_socket_unavailable forgeops 0 0 0 '[]' '[]' '[]' 0 0 0 0`);
+  const snapshot = JSON.parse(output);
+
+  assert.equal(snapshot.degraded_reason, 'jq_parse_failed');
+});
+
+test('log_provider_event fallback should keep snapshot counters visible', () => {
+  const output = runShell(`. ./traefik/scripts/provider-status.sh
+jq_available(){ return 1; }
+export TRAEFIK_DOCKER_PROVIDER_ENABLED=false
+export TRAEFIK_DOCKER_PROVIDER_ACTIVE=false
+export TRAEFIK_DOCKER_PROVIDER_ENDPOINT=unix:///var/run/docker.sock
+export TRAEFIK_DOCKER_API_VERSION=1.54
+export TRAEFIK_DOCKER_PROVIDER_NETWORK=forgeops
+snapshot='{"status":"degraded","degraded_reason":"jq_unavailable","eligible_containers_count":7,"labeled_containers_count":5,"containers_with_valid_labels_count":4,"docker_routers_count":2,"docker_services_count":3}'
+log_provider_event warn traefik_provider_status fallback degraded jq_unavailable "$snapshot"`);
+  const payload = JSON.parse(output);
+
+  assert.equal(payload.degraded_reason, 'jq_unavailable');
+  assert.equal(payload.eligible_containers_count, 7);
+  assert.equal(payload.docker_routers_count, 2);
+  assert.equal(payload.docker_services_count, 3);
+});

--- a/traefik/scripts/entrypoint.sh
+++ b/traefik/scripts/entrypoint.sh
@@ -2,65 +2,8 @@
 
 set -eu
 
-log_json() {
-  level="$1"
-  event="$2"
-  message="$3"
-  degraded_reason="${4:-}"
-
-  jq -nc \
-    --arg level "$level" \
-    --arg event "$event" \
-    --arg message "$message" \
-    --arg timestamp "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-    --arg traefik_version "${TRAEFIK_VERSION:-unknown}" \
-    --arg docker_version "${DOCKER_VERSION:-unknown}" \
-    --arg docker_api_version "${DOCKER_API_VERSION:-unknown}" \
-    --arg docker_endpoint "${DOCKER_PROVIDER_ENDPOINT:-unknown}" \
-    --arg provider_network "${DOCKER_PROVIDER_NETWORK:-unknown}" \
-    --arg docker_provider_enabled "${DOCKER_PROVIDER_ENABLED:-false}" \
-    --arg docker_provider_active "${DOCKER_PROVIDER_ACTIVE:-false}" \
-    --arg degraded_reason "$degraded_reason" \
-    '{
-      level: $level,
-      service: "forgeops-proxy",
-      timestamp: $timestamp,
-      event: $event,
-      message: $message,
-      docker_provider_enabled: ($docker_provider_enabled == "true"),
-      docker_provider_active: ($docker_provider_active == "true"),
-      docker_endpoint: $docker_endpoint,
-      docker_api_version: $docker_api_version,
-      docker_version: $docker_version,
-      traefik_version: $traefik_version,
-      provider_network: $provider_network,
-      providers_docker_exposed_by_default: false,
-      degraded_reason: (if $degraded_reason == "" then null else $degraded_reason end)
-    }'
-}
-
-normalize_bool() {
-  case "${1:-false}" in
-    true|TRUE|1|yes|YES|on|ON)
-      printf 'true'
-      ;;
-    *)
-      printf 'false'
-      ;;
-  esac
-}
-
-extract_unix_socket_path() {
-  endpoint="$1"
-  case "$endpoint" in
-    unix://*)
-      printf '%s' "${endpoint#unix://}"
-      ;;
-    *)
-      printf ''
-      ;;
-  esac
-}
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+. "$SCRIPT_DIR/provider-status.sh"
 
 docker_http_get() {
   socket_path="$1"
@@ -73,27 +16,12 @@ docker_http_get() {
   curl --silent --show-error --unix-socket "$socket_path" "http://docker$request_path" 2>/dev/null || true
 }
 
-json_field_from_body() {
-  field_name="$1"
-  awk -v field_name="$field_name" '
-    {
-      pattern = "\"" field_name "\":\"[^\"]+\""
-      if (match($0, pattern)) {
-        value = substr($0, RSTART, RLENGTH)
-        sub("^\"" field_name "\":\"", "", value)
-        sub("\"$", "", value)
-        print value
-        exit
-      }
-    }
-  '
-}
-
 DOCKER_PROVIDER_ENABLED="$(normalize_bool "${TRAEFIK_DOCKER_PROVIDER_ENABLED:-false}")"
 DOCKER_PROVIDER_ENDPOINT="${TRAEFIK_DOCKER_PROVIDER_ENDPOINT:-unix:///var/run/docker.sock}"
 DOCKER_PROVIDER_NETWORK="${TRAEFIK_DOCKER_PROVIDER_NETWORK:-forgeops}"
 DOCKER_SOCKET_PATH="$(extract_unix_socket_path "$DOCKER_PROVIDER_ENDPOINT")"
 DOCKER_PROVIDER_ACTIVE='false'
+DOCKER_PROVIDER_STATUS='file_provider_only'
 DOCKER_PROVIDER_REASON='docker_provider_disabled_by_flag'
 
 TRAEFIK_VERSION="$(traefik version 2>/dev/null | awk -F': *' '/^Version:/ { print $2; exit }')"
@@ -108,28 +36,30 @@ if [ -n "$DOCKER_SOCKET_PATH" ] && [ -S "$DOCKER_SOCKET_PATH" ]; then
   fi
 fi
 
-if [ "$DOCKER_PROVIDER_ENABLED" = 'true' ]; then
-  if [ -z "$DOCKER_SOCKET_PATH" ]; then
-    DOCKER_PROVIDER_REASON='docker_endpoint_not_unix_socket'
-    log_json 'warn' 'traefik_provider_fallback' \
-      'Docker provider requested but endpoint is not a supported unix socket in local mode; keeping file provider only.' \
-      "$DOCKER_PROVIDER_REASON"
-  elif [ ! -S "$DOCKER_SOCKET_PATH" ]; then
-    DOCKER_PROVIDER_REASON='docker_socket_unavailable'
-    log_json 'warn' 'traefik_provider_fallback' \
-      'Docker provider requested but docker.sock is unavailable; keeping file provider only.' \
-      "$DOCKER_PROVIDER_REASON"
-  else
-    DOCKER_PROVIDER_ACTIVE='true'
-    DOCKER_PROVIDER_REASON='docker_provider_enabled'
-    log_json 'info' 'traefik_provider_bootstrap' \
-      'Starting Traefik with file provider and experimental docker provider enabled.' \
-      "$DOCKER_PROVIDER_REASON"
-  fi
+preflight_state="$(resolve_preflight_provider_state "$DOCKER_PROVIDER_ENABLED" "$DOCKER_SOCKET_PATH")"
+DOCKER_PROVIDER_STATUS="${preflight_state%%|*}"
+remaining_state="${preflight_state#*|}"
+DOCKER_PROVIDER_REASON="${remaining_state%%|*}"
+DOCKER_PROVIDER_ACTIVE="${preflight_state##*|}"
+
+bootstrap_snapshot="$(build_provider_snapshot \
+  "$DOCKER_PROVIDER_STATUS" \
+  "$DOCKER_PROVIDER_REASON" \
+  "$DOCKER_PROVIDER_NETWORK" \
+  0 0 0 '[]' '[]' '[]' 0 0 0 0)"
+
+if [ "$DOCKER_PROVIDER_ACTIVE" = 'true' ]; then
+  log_provider_event 'info' 'traefik_provider_bootstrap' \
+    'Starting Traefik with file provider and experimental docker provider enabled.' \
+    "$DOCKER_PROVIDER_STATUS" \
+    "$DOCKER_PROVIDER_REASON" \
+    "$bootstrap_snapshot"
 else
-  log_json 'info' 'traefik_provider_bootstrap' \
-    'Starting Traefik with file provider only.' \
-    "$DOCKER_PROVIDER_REASON"
+  log_provider_event 'warn' 'traefik_provider_fallback' \
+    'Docker provider unavailable for local runtime; keeping file provider as the stable path.' \
+    "$DOCKER_PROVIDER_STATUS" \
+    "$DOCKER_PROVIDER_REASON" \
+    "$bootstrap_snapshot"
 fi
 
 TRAEFIK_DOCKER_PROVIDER_ACTIVE="$DOCKER_PROVIDER_ACTIVE"
@@ -138,6 +68,7 @@ TRAEFIK_DOCKER_PROVIDER_REASON="$DOCKER_PROVIDER_REASON"
 export TRAEFIK_DOCKER_PROVIDER_ENABLED="$DOCKER_PROVIDER_ENABLED"
 export TRAEFIK_DOCKER_PROVIDER_ACTIVE
 export TRAEFIK_DOCKER_PROVIDER_REASON
+export TRAEFIK_DOCKER_PROVIDER_STATUS="$DOCKER_PROVIDER_STATUS"
 export TRAEFIK_DOCKER_PROVIDER_ENDPOINT="$DOCKER_PROVIDER_ENDPOINT"
 export TRAEFIK_DOCKER_PROVIDER_NETWORK="$DOCKER_PROVIDER_NETWORK"
 export TRAEFIK_DOCKER_API_VERSION="$DOCKER_API_VERSION"

--- a/traefik/scripts/observe-provider.sh
+++ b/traefik/scripts/observe-provider.sh
@@ -2,32 +2,8 @@
 
 set -eu
 
-log_status_json() {
-  level="$1"
-  event="$2"
-  message="$3"
-  snapshot_json="$4"
-
-  jq -nc \
-    --arg level "$level" \
-    --arg event "$event" \
-    --arg message "$message" \
-    --arg timestamp "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-    --arg docker_endpoint "${TRAEFIK_DOCKER_PROVIDER_ENDPOINT:-unknown}" \
-    --arg docker_api_version "${TRAEFIK_DOCKER_API_VERSION:-unknown}" \
-    --arg provider_network "${TRAEFIK_DOCKER_PROVIDER_NETWORK:-unknown}" \
-    --argjson snapshot "$snapshot_json" \
-    '{
-      level: $level,
-      service: "forgeops-proxy",
-      timestamp: $timestamp,
-      event: $event,
-      message: $message,
-      docker_endpoint: $docker_endpoint,
-      docker_api_version: $docker_api_version,
-      provider_network: $provider_network
-    } + $snapshot'
-}
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+. "$SCRIPT_DIR/provider-status.sh"
 
 fetch_traefik_api() {
   api_path="$1"
@@ -40,176 +16,188 @@ fetch_docker_api() {
 }
 
 provider_snapshot() {
+  provider_network="${TRAEFIK_DOCKER_PROVIDER_NETWORK:-forgeops}"
+
   if [ "${TRAEFIK_DOCKER_PROVIDER_ENABLED:-false}" != 'true' ]; then
-    jq -nc --arg provider_network "${TRAEFIK_DOCKER_PROVIDER_NETWORK:-unknown}" '
-      {
-        status: "file_provider_only",
-        degraded_reason: "docker_provider_disabled_by_flag",
-        providers_docker_exposed_by_default: false,
-        provider_network: $provider_network,
-        eligible_containers_count: 0,
-        labeled_containers_count: 0,
-        containers_with_valid_labels_count: 0,
-        containers_without_valid_labels: [],
-        containers_with_incomplete_labels: [],
-        containers_with_network_override_mismatch: [],
-        containers_in_expected_network_count: 0,
-        containers_outside_expected_network_count: 0,
-        docker_routers_count: 0,
-        docker_services_count: 0
-      }'
+    build_provider_snapshot \
+      'file_provider_only' \
+      'docker_provider_disabled_by_flag' \
+      "$provider_network" \
+      0 0 0 '[]' '[]' '[]' 0 0 0 0
     return
   fi
 
   if [ "${TRAEFIK_DOCKER_PROVIDER_ACTIVE:-false}" != 'true' ]; then
-    jq -nc \
-      --arg provider_network "${TRAEFIK_DOCKER_PROVIDER_NETWORK:-unknown}" \
-      --arg degraded_reason "${TRAEFIK_DOCKER_PROVIDER_REASON:-docker_provider_preflight_failed}" '
-      {
-        status: "degraded",
-        degraded_reason: $degraded_reason,
-        providers_docker_exposed_by_default: false,
-        provider_network: $provider_network,
-        eligible_containers_count: 0,
-        labeled_containers_count: 0,
-        containers_with_valid_labels_count: 0,
-        containers_without_valid_labels: [],
-        containers_with_incomplete_labels: [],
-        containers_with_network_override_mismatch: [],
-        containers_in_expected_network_count: 0,
-        containers_outside_expected_network_count: 0,
-        docker_routers_count: 0,
-        docker_services_count: 0
-      }'
+    build_provider_snapshot \
+      "${TRAEFIK_DOCKER_PROVIDER_STATUS:-degraded}" \
+      "${TRAEFIK_DOCKER_PROVIDER_REASON:-docker_provider_preflight_failed}" \
+      "$provider_network" \
+      0 0 0 '[]' '[]' '[]' 0 0 0 0
     return
   fi
 
   ping_response="$(fetch_traefik_api "/ping")"
   if [ "$ping_response" != 'OK' ]; then
-    jq -nc \
-      --arg provider_network "${TRAEFIK_DOCKER_PROVIDER_NETWORK:-unknown}" '
-      {
-        status: "starting",
-        degraded_reason: "traefik_api_unavailable",
-        providers_docker_exposed_by_default: false,
-        provider_network: $provider_network,
-        eligible_containers_count: 0,
-        labeled_containers_count: 0,
-        containers_with_valid_labels_count: 0,
-        containers_without_valid_labels: [],
-        containers_with_incomplete_labels: [],
-        containers_with_network_override_mismatch: [],
-        containers_in_expected_network_count: 0,
-        containers_outside_expected_network_count: 0,
-        docker_routers_count: 0,
-        docker_services_count: 0
-      }'
+    build_provider_snapshot \
+      'starting' \
+      'traefik_api_unavailable' \
+      "$provider_network" \
+      0 0 0 '[]' '[]' '[]' 0 0 0 0
     return
   fi
 
-  provider_network="${TRAEFIK_DOCKER_PROVIDER_NETWORK:-forgeops}"
+  if ! jq_available; then
+    build_provider_snapshot \
+      'degraded' \
+      'jq_unavailable' \
+      "$provider_network" \
+      0 0 0 '[]' '[]' '[]' 0 0 0 0
+    return
+  fi
+
   rawdata="$(fetch_traefik_api "/api/rawdata")"
   containers_json="$(fetch_docker_api "/containers/json")"
 
   if [ -z "$containers_json" ]; then
-    jq -nc \
-      --arg provider_network "$provider_network" '
-      {
-        status: "degraded",
-        degraded_reason: "docker_api_unavailable",
-        providers_docker_exposed_by_default: false,
-        provider_network: $provider_network,
-        eligible_containers_count: 0,
-        labeled_containers_count: 0,
-        containers_with_valid_labels_count: 0,
-        containers_without_valid_labels: [],
-        containers_with_incomplete_labels: [],
-        containers_with_network_override_mismatch: [],
-        containers_in_expected_network_count: 0,
-        containers_outside_expected_network_count: 0,
-        docker_routers_count: 0,
-        docker_services_count: 0
-      }'
+    build_provider_snapshot \
+      'degraded' \
+      'docker_api_unavailable' \
+      "$provider_network" \
+      0 0 0 '[]' '[]' '[]' 0 0 0 0
     return
   fi
 
-  printf '%s' "$containers_json" | jq -c \
-    --arg provider_network "$provider_network" \
-    --argjson rawdata "$rawdata" '
-    def container_name:
-      (.Names[0] // .Id // "unknown") | ltrimstr("/");
-    def labels:
-      .Labels // {};
-    def service_name:
-      labels["com.docker.compose.service"] // "";
-    def project_name:
-      labels["com.docker.compose.project"] // "";
-    def network_names:
-      (.NetworkSettings.Networks // {}) | keys;
-    def in_expected_network($network):
-      (network_names | index($network)) != null;
-    def has_router_rule:
-      (labels | keys | map(select(test("^traefik\\.http\\.routers\\.[^.]+\\.rule$"))) | length) > 0;
-    def has_router_entrypoints:
-      (labels | keys | map(select(test("^traefik\\.http\\.routers\\.[^.]+\\.entrypoints$"))) | length) > 0;
-    def has_service_port:
-      (labels | keys | map(select(test("^traefik\\.http\\.services\\.[^.]+\\.loadbalancer\\.server\\.port$"))) | length) > 0;
-    def enable_true:
-      labels["traefik.enable"] == "true";
-    def network_override:
-      labels["traefik.docker.network"] // null;
-    def eligible:
-      map(
-        select(project_name == "forge-ops" and service_name != "proxy")
-        | {
-            name: container_name,
-            service: service_name,
-            traefik_enable: enable_true,
-            has_router_rule: has_router_rule,
-            has_router_entrypoints: has_router_entrypoints,
-            has_service_port: has_service_port,
-            in_expected_network: in_expected_network($provider_network),
-            network_override: network_override,
-            network_override_matches: ((network_override // $provider_network) == $provider_network),
-            labels_valid: (enable_true and has_router_rule and has_router_entrypoints and has_service_port)
-          }
-      );
-    def docker_routers_count:
-      ($rawdata.routers // {} | to_entries | map(select(.key | endswith("@docker"))) | length);
-    def docker_services_count:
-      ($rawdata.services // {} | to_entries | map(select(.key | endswith("@docker"))) | length);
-    (eligible) as $eligible
-    | ($eligible | map(select(.traefik_enable))) as $labeled
-    | ($eligible | map(select(.labels_valid))) as $valid
-    | ($labeled | map(select(.labels_valid | not) | .name)) as $incomplete_names
-    | ($eligible | map(select(.network_override_matches | not) | .name)) as $network_override_mismatch_names
-    | ($eligible | map(select(.in_expected_network)) | length) as $in_expected_network_count
-    | ($eligible | length) as $eligible_count
-    | (docker_routers_count) as $docker_routers_count
-    | (docker_services_count) as $docker_services_count
-    | {
-        status:
-          (if $docker_routers_count > 0 or $docker_services_count > 0 then "healthy" else "degraded" end),
-        degraded_reason:
-          (if $eligible_count == 0 then "no_eligible_containers"
-           elif ($labeled | length) == 0 then "containers_without_valid_labels"
-           elif ($incomplete_names | length) > 0 then "containers_with_incomplete_labels"
-           elif ($eligible_count - $in_expected_network_count) > 0 or ($network_override_mismatch_names | length) > 0 then "network_mismatch"
-           elif $docker_routers_count == 0 and $docker_services_count == 0 then "provider_active_but_no_routes_materialized"
-           else "none" end),
-        providers_docker_exposed_by_default: false,
-        provider_network: $provider_network,
-        eligible_containers_count: $eligible_count,
-        labeled_containers_count: ($labeled | length),
-        containers_with_valid_labels_count: ($valid | length),
-        containers_without_valid_labels: ($eligible | map(select(.labels_valid | not) | .name)),
-        containers_with_incomplete_labels: $incomplete_names,
-        containers_with_network_override_mismatch: $network_override_mismatch_names,
-        containers_in_expected_network_count: $in_expected_network_count,
-        containers_outside_expected_network_count: ($eligible_count - $in_expected_network_count),
-        docker_routers_count: $docker_routers_count,
-        docker_services_count: $docker_services_count
-      }'
+  if ! printf '%s' "$rawdata" | jq -e '. | type == "object"' >/dev/null 2>&1; then
+    build_provider_snapshot \
+      'degraded' \
+      'jq_parse_failed' \
+      "$provider_network" \
+      0 0 0 '[]' '[]' '[]' 0 0 0 0
+    return
+  fi
+
+  if ! printf '%s' "$containers_json" | jq -e '. | type == "array"' >/dev/null 2>&1; then
+    build_provider_snapshot \
+      'degraded' \
+      'jq_parse_failed' \
+      "$provider_network" \
+      0 0 0 '[]' '[]' '[]' 0 0 0 0
+    return
+  fi
+
+  metrics_json="$(
+    jq -cn \
+      --arg provider_network "$provider_network" \
+      --argjson rawdata "$rawdata" \
+      --argjson containers "$containers_json" '
+      def container_name:
+        (.Names[0] // .Id // "unknown") | ltrimstr("/");
+      def labels:
+        .Labels // {};
+      def service_name:
+        labels["com.docker.compose.service"] // "";
+      def project_name:
+        labels["com.docker.compose.project"] // "";
+      def network_names:
+        (.NetworkSettings.Networks // {}) | keys;
+      def in_expected_network($network):
+        (network_names | index($network)) != null;
+      def has_router_rule:
+        (labels | keys | map(select(test("^traefik\\.http\\.routers\\.[^.]+\\.rule$"))) | length) > 0;
+      def has_router_entrypoints:
+        (labels | keys | map(select(test("^traefik\\.http\\.routers\\.[^.]+\\.entrypoints$"))) | length) > 0;
+      def has_service_port:
+        (labels | keys | map(select(test("^traefik\\.http\\.services\\.[^.]+\\.loadbalancer\\.server\\.port$"))) | length) > 0;
+      def enable_true:
+        labels["traefik.enable"] == "true";
+      def network_override:
+        labels["traefik.docker.network"] // null;
+      def eligible($all_containers):
+        $all_containers
+        | map(
+            select(project_name == "forge-ops" and service_name != "proxy")
+            | {
+                name: container_name,
+                service: service_name,
+                traefik_enable: enable_true,
+                has_router_rule: has_router_rule,
+                has_router_entrypoints: has_router_entrypoints,
+                has_service_port: has_service_port,
+                in_expected_network: in_expected_network($provider_network),
+                network_override: network_override,
+                network_override_matches: ((network_override // $provider_network) == $provider_network),
+                labels_valid: (enable_true and has_router_rule and has_router_entrypoints and has_service_port)
+              }
+          );
+      def docker_routers_count:
+        ($rawdata.routers // {} | to_entries | map(select(.key | endswith("@docker"))) | length);
+      def docker_services_count:
+        ($rawdata.services // {} | to_entries | map(select(.key | endswith("@docker"))) | length);
+      (eligible($containers)) as $eligible
+      | ($eligible | map(select(.traefik_enable))) as $labeled
+      | ($eligible | map(select(.labels_valid))) as $valid
+      | ($labeled | map(select(.labels_valid | not) | .name)) as $incomplete_names
+      | ($eligible | map(select(.network_override_matches | not) | .name)) as $network_override_mismatch_names
+      | ($eligible | map(select(.in_expected_network)) | length) as $in_expected_network_count
+      | ($eligible | length) as $eligible_count
+      | (docker_routers_count) as $docker_routers_count
+      | (docker_services_count) as $docker_services_count
+      | {
+          eligible_containers_count: $eligible_count,
+          labeled_containers_count: ($labeled | length),
+          containers_with_valid_labels_count: ($valid | length),
+          containers_without_valid_labels: ($eligible | map(select(.labels_valid | not) | .name)),
+          containers_with_incomplete_labels: $incomplete_names,
+          containers_with_network_override_mismatch: $network_override_mismatch_names,
+          containers_in_expected_network_count: $in_expected_network_count,
+          containers_outside_expected_network_count: ($eligible_count - $in_expected_network_count),
+          docker_routers_count: $docker_routers_count,
+          docker_services_count: $docker_services_count
+        }' 2>/dev/null
+  )" || metrics_json=''
+
+  if [ -z "$metrics_json" ]; then
+    build_provider_snapshot \
+      'degraded' \
+      'jq_parse_failed' \
+      "$provider_network" \
+      0 0 0 '[]' '[]' '[]' 0 0 0 0
+    return
+  fi
+
+  eligible_containers_count="$(printf '%s' "$metrics_json" | jq -r '.eligible_containers_count')"
+  labeled_containers_count="$(printf '%s' "$metrics_json" | jq -r '.labeled_containers_count')"
+  containers_with_incomplete_labels_count="$(printf '%s' "$metrics_json" | jq -r '.containers_with_incomplete_labels | length')"
+  containers_with_network_override_mismatch_count="$(printf '%s' "$metrics_json" | jq -r '.containers_with_network_override_mismatch | length')"
+  containers_outside_expected_network_count="$(printf '%s' "$metrics_json" | jq -r '.containers_outside_expected_network_count')"
+  docker_routers_count="$(printf '%s' "$metrics_json" | jq -r '.docker_routers_count')"
+  docker_services_count="$(printf '%s' "$metrics_json" | jq -r '.docker_services_count')"
+
+  status_and_reason="$(classify_provider_status \
+    "$eligible_containers_count" \
+    "$labeled_containers_count" \
+    "$containers_with_incomplete_labels_count" \
+    "$containers_outside_expected_network_count" \
+    "$containers_with_network_override_mismatch_count" \
+    "$docker_routers_count" \
+    "$docker_services_count")"
+  status_value="${status_and_reason%%|*}"
+  reason_value="${status_and_reason#*|}"
+
+  build_provider_snapshot \
+    "$status_value" \
+    "$reason_value" \
+    "$provider_network" \
+    "$eligible_containers_count" \
+    "$labeled_containers_count" \
+    "$(printf '%s' "$metrics_json" | jq -r '.containers_with_valid_labels_count')" \
+    "$(printf '%s' "$metrics_json" | jq -c '.containers_without_valid_labels')" \
+    "$(printf '%s' "$metrics_json" | jq -c '.containers_with_incomplete_labels')" \
+    "$(printf '%s' "$metrics_json" | jq -c '.containers_with_network_override_mismatch')" \
+    "$(printf '%s' "$metrics_json" | jq -r '.containers_in_expected_network_count')" \
+    "$containers_outside_expected_network_count" \
+    "$docker_routers_count" \
+    "$docker_services_count"
 }
 
 STATE_FILE='/tmp/forgeops-traefik-provider-state'
@@ -217,8 +205,15 @@ INTERVAL_SECONDS="${TRAEFIK_PROVIDER_OBSERVER_INTERVAL_SECONDS:-30}"
 
 while true; do
   snapshot_json="$(provider_snapshot)"
-  status_value="$(printf '%s' "$snapshot_json" | jq -r '.status')"
-  reason_value="$(printf '%s' "$snapshot_json" | jq -r '.degraded_reason')"
+
+  if jq_available; then
+    status_value="$(printf '%s' "$snapshot_json" | jq -r '.status' 2>/dev/null || printf 'degraded')"
+    reason_value="$(printf '%s' "$snapshot_json" | jq -r '.degraded_reason' 2>/dev/null || printf 'jq_parse_failed')"
+  else
+    status_value="$(json_field_or_default 'status' 'degraded' "$snapshot_json")"
+    reason_value="$(json_field_or_default 'degraded_reason' 'jq_unavailable' "$snapshot_json")"
+  fi
+
   status_line="$status_value|$reason_value"
   previous_status=''
 
@@ -231,23 +226,31 @@ while true; do
 
     case "$status_value" in
       healthy)
-        log_status_json 'info' 'traefik_provider_status' \
+        log_provider_event 'info' 'traefik_provider_status' \
           'Docker provider experimental ativo e com rotas detectadas.' \
+          "$status_value" \
+          "$reason_value" \
           "$snapshot_json"
         ;;
       file_provider_only)
-        log_status_json 'info' 'traefik_provider_status' \
+        log_provider_event 'info' 'traefik_provider_status' \
           'Traefik operando apenas com file provider.' \
+          "$status_value" \
+          "$reason_value" \
           "$snapshot_json"
         ;;
       starting)
-        log_status_json 'info' 'traefik_provider_status' \
+        log_provider_event 'info' 'traefik_provider_status' \
           'Traefik ainda esta inicializando a observabilidade do provider.' \
+          "$status_value" \
+          "$reason_value" \
           "$snapshot_json"
         ;;
       *)
-        log_status_json 'warn' 'traefik_provider_status' \
+        log_provider_event 'warn' 'traefik_provider_status' \
           'Docker provider degradado; file provider permanece como fallback ativo.' \
+          "$status_value" \
+          "$reason_value" \
           "$snapshot_json"
         ;;
     esac

--- a/traefik/scripts/provider-status.sh
+++ b/traefik/scripts/provider-status.sh
@@ -1,0 +1,253 @@
+#!/bin/sh
+
+normalize_bool() {
+  case "${1:-false}" in
+    true|TRUE|1|yes|YES|on|ON)
+      printf 'true'
+      ;;
+    *)
+      printf 'false'
+      ;;
+  esac
+}
+
+extract_unix_socket_path() {
+  endpoint="$1"
+  case "$endpoint" in
+    unix://*)
+      printf '%s' "${endpoint#unix://}"
+      ;;
+    *)
+      printf ''
+      ;;
+  esac
+}
+
+json_field_from_body() {
+  field_name="$1"
+  awk -v field_name="$field_name" '
+    {
+      pattern = "\"" field_name "\":\"[^\"]+\""
+      if (match($0, pattern)) {
+        value = substr($0, RSTART, RLENGTH)
+        sub("^\"" field_name "\":\"", "", value)
+        sub("\"$", "", value)
+        print value
+        exit
+      }
+    }
+  '
+}
+
+jq_available() {
+  command -v jq >/dev/null 2>&1
+}
+
+json_field_or_default() {
+  field_name="$1"
+  default_value="$2"
+  json_input="${3:-}"
+
+  if [ -n "$json_input" ]; then
+    field_value="$(printf '%s' "$json_input" | json_field_from_body "$field_name" 2>/dev/null || true)"
+    if [ -n "$field_value" ]; then
+      printf '%s' "$field_value"
+      return
+    fi
+  fi
+
+  printf '%s' "$default_value"
+}
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\r\n' '  '
+}
+
+build_provider_snapshot() {
+  status="$1"
+  degraded_reason="$2"
+  provider_network="$3"
+  eligible_containers_count="${4:-0}"
+  labeled_containers_count="${5:-0}"
+  containers_with_valid_labels_count="${6:-0}"
+  containers_without_valid_labels_json="${7:-[]}"
+  containers_with_incomplete_labels_json="${8:-[]}"
+  containers_with_network_override_mismatch_json="${9:-[]}"
+  containers_in_expected_network_count="${10:-0}"
+  containers_outside_expected_network_count="${11:-0}"
+  docker_routers_count="${12:-0}"
+  docker_services_count="${13:-0}"
+
+  if jq_available; then
+    snapshot_json="$(
+      jq -nc \
+        --arg status "$status" \
+        --arg degraded_reason "$degraded_reason" \
+        --arg provider_network "$provider_network" \
+        --argjson eligible_containers_count "$eligible_containers_count" \
+        --argjson labeled_containers_count "$labeled_containers_count" \
+        --argjson containers_with_valid_labels_count "$containers_with_valid_labels_count" \
+        --argjson containers_without_valid_labels "$containers_without_valid_labels_json" \
+        --argjson containers_with_incomplete_labels "$containers_with_incomplete_labels_json" \
+        --argjson containers_with_network_override_mismatch "$containers_with_network_override_mismatch_json" \
+        --argjson containers_in_expected_network_count "$containers_in_expected_network_count" \
+        --argjson containers_outside_expected_network_count "$containers_outside_expected_network_count" \
+        --argjson docker_routers_count "$docker_routers_count" \
+        --argjson docker_services_count "$docker_services_count" \
+        '{
+          status: $status,
+          degraded_reason: $degraded_reason,
+          providers_docker_exposed_by_default: false,
+          provider_network: $provider_network,
+          eligible_containers_count: $eligible_containers_count,
+          labeled_containers_count: $labeled_containers_count,
+          containers_with_valid_labels_count: $containers_with_valid_labels_count,
+          containers_without_valid_labels: $containers_without_valid_labels,
+          containers_with_incomplete_labels: $containers_with_incomplete_labels,
+          containers_with_network_override_mismatch: $containers_with_network_override_mismatch,
+          containers_in_expected_network_count: $containers_in_expected_network_count,
+          containers_outside_expected_network_count: $containers_outside_expected_network_count,
+          docker_routers_count: $docker_routers_count,
+          docker_services_count: $docker_services_count
+        }' 2>/dev/null
+    )" || snapshot_json=''
+
+    if [ -n "$snapshot_json" ]; then
+      printf '%s' "$snapshot_json"
+      return
+    fi
+
+    degraded_reason='jq_parse_failed'
+  else
+    degraded_reason='jq_unavailable'
+  fi
+
+  printf '{"status":"%s","degraded_reason":"%s","providers_docker_exposed_by_default":false,"provider_network":"%s","eligible_containers_count":%s,"labeled_containers_count":%s,"containers_with_valid_labels_count":%s,"containers_without_valid_labels":[],"containers_with_incomplete_labels":[],"containers_with_network_override_mismatch":[],"containers_in_expected_network_count":%s,"containers_outside_expected_network_count":%s,"docker_routers_count":%s,"docker_services_count":%s}' \
+    "$(json_escape "$status")" \
+    "$(json_escape "$degraded_reason")" \
+    "$(json_escape "$provider_network")" \
+    "$eligible_containers_count" \
+    "$labeled_containers_count" \
+    "$containers_with_valid_labels_count" \
+    "$containers_in_expected_network_count" \
+    "$containers_outside_expected_network_count" \
+    "$docker_routers_count" \
+    "$docker_services_count"
+}
+
+classify_provider_status() {
+  eligible_containers_count="${1:-0}"
+  labeled_containers_count="${2:-0}"
+  containers_with_incomplete_labels_count="${3:-0}"
+  containers_outside_expected_network_count="${4:-0}"
+  containers_with_network_override_mismatch_count="${5:-0}"
+  docker_routers_count="${6:-0}"
+  docker_services_count="${7:-0}"
+
+  if [ "$eligible_containers_count" -eq 0 ]; then
+    printf 'degraded|no_eligible_containers'
+  elif [ "$labeled_containers_count" -eq 0 ]; then
+    printf 'degraded|containers_without_valid_labels'
+  elif [ "$containers_with_incomplete_labels_count" -gt 0 ]; then
+    printf 'degraded|containers_with_incomplete_labels'
+  elif [ "$containers_outside_expected_network_count" -gt 0 ] || [ "$containers_with_network_override_mismatch_count" -gt 0 ]; then
+    printf 'degraded|network_mismatch'
+  elif [ "$docker_routers_count" -gt 0 ] || [ "$docker_services_count" -gt 0 ]; then
+    printf 'healthy|none'
+  else
+    printf 'degraded|provider_active_but_no_routes_materialized'
+  fi
+}
+
+resolve_preflight_provider_state() {
+  docker_provider_enabled="$1"
+  docker_socket_path="$2"
+
+  if [ "$docker_provider_enabled" != 'true' ]; then
+    printf 'file_provider_only|docker_provider_disabled_by_flag|false'
+  elif [ -z "$docker_socket_path" ]; then
+    printf 'degraded|docker_endpoint_not_unix_socket|false'
+  elif [ ! -S "$docker_socket_path" ]; then
+    printf 'degraded|docker_socket_unavailable|false'
+  else
+    printf 'starting|docker_provider_enabled|true'
+  fi
+}
+
+log_provider_event() {
+  level="$1"
+  event="$2"
+  message="$3"
+  status="$4"
+  degraded_reason="$5"
+  snapshot_json="${6:-}"
+
+  timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  docker_endpoint="${TRAEFIK_DOCKER_PROVIDER_ENDPOINT:-unknown}"
+  docker_api_version="${TRAEFIK_DOCKER_API_VERSION:-unknown}"
+  provider_network="${TRAEFIK_DOCKER_PROVIDER_NETWORK:-unknown}"
+  docker_provider_enabled="$(normalize_bool "${TRAEFIK_DOCKER_PROVIDER_ENABLED:-false}")"
+  docker_provider_active="$(normalize_bool "${TRAEFIK_DOCKER_PROVIDER_ACTIVE:-false}")"
+  traefik_version="${TRAEFIK_VERSION:-unknown}"
+  docker_version="${DOCKER_VERSION:-unknown}"
+  log_fallback_reason='none'
+
+  if jq_available && [ -n "$snapshot_json" ]; then
+    log_output="$(
+      jq -nc \
+        --arg level "$level" \
+        --arg event "$event" \
+        --arg message "$message" \
+        --arg timestamp "$timestamp" \
+        --arg traefik_version "$traefik_version" \
+        --arg docker_version "$docker_version" \
+        --arg docker_api_version "$docker_api_version" \
+        --arg docker_endpoint "$docker_endpoint" \
+        --arg provider_network "$provider_network" \
+        --arg docker_provider_enabled "$docker_provider_enabled" \
+        --arg docker_provider_active "$docker_provider_active" \
+        --argjson snapshot "$snapshot_json" \
+        '{
+          level: $level,
+          service: "forgeops-proxy",
+          timestamp: $timestamp,
+          event: $event,
+          message: $message,
+          docker_provider_enabled: ($docker_provider_enabled == "true"),
+          docker_provider_active: ($docker_provider_active == "true"),
+          docker_endpoint: $docker_endpoint,
+          docker_api_version: $docker_api_version,
+          docker_version: $docker_version,
+          traefik_version: $traefik_version,
+          provider_network: $provider_network
+        } + $snapshot' 2>/dev/null
+    )" || log_output=''
+
+    if [ -n "$log_output" ]; then
+      printf '%s\n' "$log_output"
+      return
+    fi
+
+    log_fallback_reason='jq_parse_failed'
+  elif ! jq_available; then
+    log_fallback_reason='jq_unavailable'
+  else
+    log_fallback_reason='snapshot_unavailable'
+  fi
+
+  printf '{"level":"%s","service":"forgeops-proxy","timestamp":"%s","event":"%s","message":"%s","docker_provider_enabled":%s,"docker_provider_active":%s,"docker_endpoint":"%s","docker_api_version":"%s","docker_version":"%s","traefik_version":"%s","provider_network":"%s","status":"%s","degraded_reason":"%s","log_fallback_reason":"%s"}\n' \
+    "$(json_escape "$level")" \
+    "$(json_escape "$timestamp")" \
+    "$(json_escape "$event")" \
+    "$(json_escape "$message")" \
+    "$docker_provider_enabled" \
+    "$docker_provider_active" \
+    "$(json_escape "$docker_endpoint")" \
+    "$(json_escape "$docker_api_version")" \
+    "$(json_escape "$docker_version")" \
+    "$(json_escape "$traefik_version")" \
+    "$(json_escape "$provider_network")" \
+    "$(json_escape "$status")" \
+    "$(json_escape "$degraded_reason")" \
+    "$(json_escape "$log_fallback_reason")"
+}

--- a/traefik/scripts/provider-status.sh
+++ b/traefik/scripts/provider-status.sh
@@ -25,13 +25,53 @@ extract_unix_socket_path() {
 
 json_field_from_body() {
   field_name="$1"
-  awk -v field_name="$field_name" '
+  json_input="$(cat)"
+
+  if [ -z "$json_input" ]; then
+    return 0
+  fi
+
+  if jq_available; then
+    printf '%s' "$json_input" | jq -er --arg field_name "$field_name" '
+      if type == "object" and has($field_name) then
+        .[$field_name] | if . == null then empty else tostring end
+      else
+        empty
+      end
+    ' 2>/dev/null || true
+    return 0
+  fi
+
+  # Fallback limitado a campos controlados sem estruturas aninhadas.
+  printf '%s' "$json_input" | sed -nE "s/.*\"$field_name\":\"(([^\"\\\\]|\\\\.)*)\".*/\\1/p" \
+    | sed 's/\\"/"/g; s/\\\\/\\/g'
+}
+
+json_numeric_field_from_body() {
+  field_name="$1"
+  json_input="$(cat)"
+
+  if [ -z "$json_input" ]; then
+    return 0
+  fi
+
+  if jq_available; then
+    printf '%s' "$json_input" | jq -er --arg field_name "$field_name" '
+      if type == "object" and has($field_name) then
+        .[$field_name] | if (type == "number" or type == "boolean") then tostring else empty end
+      else
+        empty
+      end
+    ' 2>/dev/null || true
+    return 0
+  fi
+
+  printf '%s' "$json_input" | awk -v field_name="$field_name" '
     {
-      pattern = "\"" field_name "\":\"[^\"]+\""
+      pattern = "\"" field_name "\":(-?[0-9]+|true|false)"
       if (match($0, pattern)) {
         value = substr($0, RSTART, RLENGTH)
-        sub("^\"" field_name "\":\"", "", value)
-        sub("\"$", "", value)
+        sub("^\"" field_name "\":", "", value)
         print value
         exit
       }
@@ -59,8 +99,38 @@ json_field_or_default() {
   printf '%s' "$default_value"
 }
 
+json_numeric_field_or_default() {
+  field_name="$1"
+  default_value="$2"
+  json_input="${3:-}"
+
+  if [ -n "$json_input" ]; then
+    field_value="$(printf '%s' "$json_input" | json_numeric_field_from_body "$field_name" 2>/dev/null || true)"
+    if [ -n "$field_value" ]; then
+      printf '%s' "$field_value"
+      return
+    fi
+  fi
+
+  printf '%s' "$default_value"
+}
+
 json_escape() {
   printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\r\n' '  '
+}
+
+normalize_numeric_or_default() {
+  value="$1"
+  default_value="$2"
+
+  case "$value" in
+    ''|*[!0-9-]*)
+      printf '%s' "$default_value"
+      ;;
+    *)
+      printf '%s' "$value"
+      ;;
+  esac
 }
 
 build_provider_snapshot() {
@@ -235,7 +305,18 @@ log_provider_event() {
     log_fallback_reason='snapshot_unavailable'
   fi
 
-  printf '{"level":"%s","service":"forgeops-proxy","timestamp":"%s","event":"%s","message":"%s","docker_provider_enabled":%s,"docker_provider_active":%s,"docker_endpoint":"%s","docker_api_version":"%s","docker_version":"%s","traefik_version":"%s","provider_network":"%s","status":"%s","degraded_reason":"%s","log_fallback_reason":"%s"}\n' \
+  eligible_containers_count="$(json_numeric_field_or_default 'eligible_containers_count' '0' "$snapshot_json")"
+  labeled_containers_count="$(json_numeric_field_or_default 'labeled_containers_count' '0' "$snapshot_json")"
+  containers_with_valid_labels_count="$(json_numeric_field_or_default 'containers_with_valid_labels_count' '0' "$snapshot_json")"
+  docker_routers_count="$(json_numeric_field_or_default 'docker_routers_count' '0' "$snapshot_json")"
+  docker_services_count="$(json_numeric_field_or_default 'docker_services_count' '0' "$snapshot_json")"
+  eligible_containers_count="$(normalize_numeric_or_default "$eligible_containers_count" '0')"
+  labeled_containers_count="$(normalize_numeric_or_default "$labeled_containers_count" '0')"
+  containers_with_valid_labels_count="$(normalize_numeric_or_default "$containers_with_valid_labels_count" '0')"
+  docker_routers_count="$(normalize_numeric_or_default "$docker_routers_count" '0')"
+  docker_services_count="$(normalize_numeric_or_default "$docker_services_count" '0')"
+
+  printf '{"level":"%s","service":"forgeops-proxy","timestamp":"%s","event":"%s","message":"%s","docker_provider_enabled":%s,"docker_provider_active":%s,"docker_endpoint":"%s","docker_api_version":"%s","docker_version":"%s","traefik_version":"%s","provider_network":"%s","status":"%s","degraded_reason":"%s","log_fallback_reason":"%s","eligible_containers_count":%s,"labeled_containers_count":%s,"containers_with_valid_labels_count":%s,"docker_routers_count":%s,"docker_services_count":%s}\n' \
     "$(json_escape "$level")" \
     "$(json_escape "$timestamp")" \
     "$(json_escape "$event")" \
@@ -249,5 +330,10 @@ log_provider_event() {
     "$(json_escape "$provider_network")" \
     "$(json_escape "$status")" \
     "$(json_escape "$degraded_reason")" \
-    "$(json_escape "$log_fallback_reason")"
+    "$(json_escape "$log_fallback_reason")" \
+    "$eligible_containers_count" \
+    "$labeled_containers_count" \
+    "$containers_with_valid_labels_count" \
+    "$docker_routers_count" \
+    "$docker_services_count"
 }


### PR DESCRIPTION
## Resumo
Esta PR consolida a lógica de status do provider do Traefik em helper compartilhado e endurece o comportamento quando `jq` estiver ausente ou falhar. O objetivo é reduzir risco de drift entre bootstrap e observação sem alterar o caminho estável do `file provider`.

## O que foi alterado
- Adiciona [provider-status.sh](/C:/Github/forge-ops/traefik/scripts/provider-status.sh) como helper compartilhado para classificação, snapshot e logging estruturado do provider.
- Atualiza [entrypoint.sh](/C:/Github/forge-ops/traefik/scripts/entrypoint.sh) para reutilizar a lógica central de status no bootstrap do proxy.
- Atualiza [observe-provider.sh](/C:/Github/forge-ops/traefik/scripts/observe-provider.sh) para reutilizar a mesma lógica de status e explicitar `jq_unavailable` e `jq_parse_failed` no `degraded_reason`.
- Atualiza [local-dev-proxy.md](/C:/Github/forge-ops/docs/architecture/local-dev-proxy.md) para refletir a consolidação do status e o hardening de `jq`.

## Motivação
A camada de resiliência do proxy já estava estável, mas ainda havia risco de drift semântico entre `entrypoint.sh` e `observe-provider.sh`. Além disso, a observabilidade dependia de `jq` sem deixar suficientemente explícito no campo principal `degraded_reason` quando o problema era a própria ferramenta de parsing.

## Como validar
- Executar `npm run lint`.
- Executar `docker compose config`.
- Validar a sintaxe dos scripts dentro da imagem do proxy com `/bin/sh -n`.
- Subir o proxy em porta alternativa, por exemplo `FORGEOPS_PROXY_PORT=8082`, e confirmar `GET /api/v1/health` via `api.forgeops.local` com `200`.
- Executar o helper dentro da imagem do proxy e confirmar:
  - `degraded_reason=jq_unavailable` quando `jq` estiver indisponível
  - `degraded_reason=jq_parse_failed` quando o parse falhar

## Riscos e impactos
- A PR não altera a arquitetura do proxy nem promove o `docker provider`.
- O `file provider` continua como caminho estável e principal.
- O ruído conhecido de `ENOMEM` no frontend em container continua fora de escopo e ainda pode afetar `docker compose up` sem `--no-deps`.
- Não há mudança em rotas principais nem em contratos de produto.

## Evidências
- `npm run lint`
- `docker compose config`
- validação de sintaxe shell na imagem do proxy
- validação do helper para `jq_unavailable` e `jq_parse_failed`
- `GET /api/v1/health` via proxy em `8082` com `200`

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #114