### PR TITLE
fix(prisma): remove BOM from blocking migration bootstrap

### DIFF
--- a/backend/prisma/migrations/20260331171000_add_pull_request/migration.sql
+++ b/backend/prisma/migrations/20260331171000_add_pull_request/migration.sql
@@ -1,4 +1,4 @@
-﻿-- CreateEnum
+-- CreateEnum
 CREATE TYPE "PullRequestState" AS ENUM ('open', 'closed', 'merged');
 
 -- CreateTable


### PR DESCRIPTION
## Resumo
Remove o BOM da migration `20260331171000_add_pull_request`, que estava quebrando o bootstrap local do banco com erro de parsing no PostgreSQL. A PR mantém o escopo mínimo: corrige apenas o encoding do arquivo e revalida a aplicação das migrations.

## O que foi alterado
- Regrava `backend/prisma/migrations/20260331171000_add_pull_request/migration.sql` sem BOM.
- Revalida a migration em banco limpo temporário.
- Recupera o estado travado do banco local padrão via `prisma migrate resolve` e reaplica as migrations pendentes.

## Motivação
O produto local continuava bloqueado mesmo após a correção da autenticação, porque o banco não conseguia completar o bootstrap do schema. A causa raiz estava no primeiro byte da migration de pull requests, que fazia o PostgreSQL falhar com `syntax error at or near "\u{feff}"`.

## Como validar
- Executar `docker compose exec -T postgres psql -U forgeops -d postgres -c "DROP DATABASE IF EXISTS forgeops_bom_test;" -c "CREATE DATABASE forgeops_bom_test;"`.
- Executar `docker compose exec -T backend sh -lc "cd /workspace/backend && DATABASE_URL=postgresql://forgeops:forgeops@postgres:5432/forgeops_bom_test node ../scripts/run-bin.mjs prisma migrate deploy"`.
- Confirmar que todas as 5 migrations aplicam com sucesso no banco temporário.
- Executar `docker compose exec -T backend sh -lc "cd /workspace/backend && node ../scripts/run-bin.mjs prisma migrate status"`.
- Confirmar `Database schema is up to date!` no banco padrão do compose.

## Riscos e impactos
- Risco baixo: a mudança é restrita ao encoding da migration, sem alterar o SQL.
- Em ambientes locais já marcados com falha anterior, ainda é necessário resolver o estado travado de `_prisma_migrations` antes de reaplicar.
- Não há mudança de contrato de API nem de comportamento de produto nesta PR.

## Evidências
- Antes da correção, `prisma migrate deploy` falhava com `P3018` e `syntax error at or near "\u{feff}"`.
- Após a correção, o banco temporário aplica as 5 migrations com sucesso.
- `prisma migrate status` no banco padrão retornou `Database schema is up to date!`.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #118