### PR TITLE
docs(smoke): registra validacao local do fluxo do produto

### DIFF
--- a/docs/plans/local-product-smoke-validation.md
+++ b/docs/plans/local-product-smoke-validation.md
@@ -1,0 +1,70 @@
+# Local Product Smoke Validation
+
+## Issue
+- #119 — Validate local end-to-end product flow after auth and database bootstrap
+
+## Goal
+Validate that the local ForgeOps stack can run the current product slice end to end with:
+- database bootstrap working
+- operator auth working
+- backend protected routes reachable
+- frontend reachable through the local proxy
+
+## Runtime used
+- Docker Compose local stack
+- `FORGEOPS_PROXY_PORT=8082`
+- `TRAEFIK_DOCKER_PROVIDER_ENABLED=false`
+- `OPERATOR_AUTH_ENABLED=true`
+- `OPERATOR_AUTH_MODE=shared-secret`
+- `OPERATOR_AUTH_ISSUER=forgeops-local`
+- `OPERATOR_AUTH_AUDIENCE=forgeops-operator`
+
+## Validation summary
+
+### Infrastructure
+- PostgreSQL healthy
+- Redis healthy
+- Backend healthy
+- Frontend healthy
+- Traefik proxy healthy
+- Proxy liveness confirmed through `/ping`
+
+### Auth
+- `GET /api/v1/auth/me` returned `200` with a valid local HS256 bearer token
+- Protected API no longer degraded to `auth_not_configured`
+
+### Database
+- Prisma migration status returned `Database schema is up to date!`
+
+### Backend slice
+- `GET /api/v1/repositories` returned `200`
+- `GET /api/v1/repositories/repo_smoke_1/workflows` returned `200`
+- `GET /api/v1/repositories/repo_smoke_1/workflows/wf_smoke_1/runs` returned `200`
+- `GET /api/v1/repositories/repo_smoke_1/workflows/wf_smoke_1/runs/run_smoke_1` returned `200`
+- `GET /api/v1/repositories/repo_smoke_1/pull-requests` returned `200`
+- `GET /api/v1/repositories/repo_smoke_1/pull-requests/pr_smoke_1` returned `200`
+
+The validated data came from the local smoke dataset already present in the database:
+- repository `repo_smoke_1`
+- workflow `wf_smoke_1`
+- workflow run `run_smoke_1`
+- workflow job `job_smoke_1`
+- pull request `pr_smoke_1`
+- codex review summary linked to the pull request
+
+### Frontend through proxy
+- `GET /` via `forgeops.local` returned `200`
+- `GET /repositories` via `forgeops.local` returned `200`
+
+## Known limitations after validation
+- Real repository discovery via GitHub App is still a separate follow-up.
+- The route `GET /api/v1/repositories/discovery` currently does not participate in this smoke validation outcome.
+- End-to-end onboarding with a real GitHub installation remains tracked separately in #122.
+
+## Conclusion
+The local product flow is executable for the current monitored repository slice once:
+- auth is configured
+- migrations are applied
+- the local proxy is healthy
+
+The remaining gap is not in the core monitored repository slice; it is in local GitHub App-backed discovery onboarding.


### PR DESCRIPTION
## Resumo
Documenta a validação local do fluxo principal do ForgeOps após os destravamentos de autenticação, bootstrap do banco e proxy local. A PR registra o que foi efetivamente validado no slice atual e isola com clareza o que permanece fora do escopo imediato.

## O que foi alterado
- Adiciona um documento de smoke validation em `docs/plans/` com o ambiente usado, sinais observados e resultado da validação local.
- Registra a validação do caminho principal do produto para repositório monitorado, workflows, workflow runs e pull requests.
- Deixa explícito que o follow-up restante está concentrado no onboarding com GitHub App, sem reabrir escopo na issue atual.

## Motivação
Depois das correções de autenticação, migration e proxy, faltava uma evidência rastreável de que o produto local realmente ficou utilizável no slice atual. Sem esse registro, a issue #119 continuava dependente do histórico operacional da sessão e não de um artefato auditável no repositório.

## Como validar
- Configurar a stack local com:
  - `FORGEOPS_PROXY_PORT=8082`
  - `TRAEFIK_DOCKER_PROVIDER_ENABLED=false`
  - `OPERATOR_AUTH_ENABLED=true`
  - `OPERATOR_AUTH_MODE=shared-secret`
  - `OPERATOR_AUTH_ISSUER=forgeops-local`
  - `OPERATOR_AUTH_AUDIENCE=forgeops-operator`
  - `OPERATOR_AUTH_SHARED_SECRET=<segredo-local>`
- Executar `docker compose up -d --force-recreate backend frontend proxy`.
- Verificar `docker compose ps` com backend, frontend e proxy em estado `healthy`.
- Validar `GET /api/v1/auth/me` via `api.forgeops.local` com bearer token HS256 válido.
- Validar `GET /api/v1/repositories`, workflows, workflow runs e detalhe de pull request via `api.forgeops.local`.
- Validar `GET /` e `GET /repositories` via `forgeops.local`.

## Riscos e impactos
- O impacto é baixo porque a PR adiciona apenas documentação de validação.
- A validação registrada depende de um dataset local de smoke já presente no banco.
- O onboarding real com GitHub App continua fora desta PR e segue como follow-up separado.

## Evidências
- Auth protegida respondeu `200` com principal autenticado.
- Repositórios, workflows, workflow runs e pull request detail responderam `200` no ambiente local.
- `forgeops.local` e `api.forgeops.local` responderam `200` com a stack estável.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #119