### PR TITLE
fix(backend): expõe erro real do sync de workflows do GitHub

### DIFF
--- a/backend/src/modules/github/github-app.errors.ts
+++ b/backend/src/modules/github/github-app.errors.ts
@@ -1,4 +1,7 @@
-import { ApplicationError } from '../../shared/errors/application-error.js';
+import {
+  ApplicationError,
+  type ApplicationErrorDetails,
+} from '../../shared/errors/application-error.js';
 
 export class GitHubRepositoryDiscoveryError extends ApplicationError {
   constructor() {
@@ -11,11 +14,12 @@ export class GitHubRepositoryDiscoveryError extends ApplicationError {
 }
 
 export class GitHubWorkflowCatalogSyncError extends ApplicationError {
-  constructor() {
+  constructor(details: ApplicationErrorDetails | null = null) {
     super(
       'GitHub workflow catalog is currently unavailable.',
       503,
       'github_workflow_catalog_unavailable',
+      details,
     );
   }
 }

--- a/backend/src/modules/github/providers/github-app.provider.ts
+++ b/backend/src/modules/github/providers/github-app.provider.ts
@@ -12,6 +12,7 @@ import type {
   GitHubWorkflowRunDescriptor,
 } from '../github-app.boundary.js';
 import type { GitHubAppEnv } from '../../../infra/config/github-app-env.js';
+import type { ApplicationErrorDetails } from '../../../shared/errors/application-error.js';
 import { ConfigurationError } from '../../../shared/errors/configuration-error.js';
 import {
   GitHubRepositoryDiscoveryError,
@@ -127,12 +128,28 @@ const githubPullRequestReviewCommentsSchema = z.array(
 const GITHUB_API_VERSION = '2022-11-28';
 const DEFAULT_GITHUB_API_BASE_URL = 'https://api.github.com';
 const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_GITHUB_ERROR_MESSAGE = 'GitHub request failed.';
+const MAX_GITHUB_ERROR_MESSAGE_LENGTH = 200;
 
 export interface GitHubAppProviderOptions {
   apiBaseUrl?: string;
   fetchImplementation?: typeof fetch;
   now?: () => Date;
   appJwtFactory?: (config: GitHubAppEnv, now: Date) => string;
+}
+
+class GitHubApiRequestError extends Error {
+  public readonly details: ApplicationErrorDetails;
+
+  public constructor(details: ApplicationErrorDetails) {
+    super(
+      typeof details.githubResponseMessage === 'string'
+        ? details.githubResponseMessage
+        : DEFAULT_GITHUB_ERROR_MESSAGE,
+    );
+    this.name = 'GitHubApiRequestError';
+    this.details = details;
+  }
 }
 
 const maskIdentifier = (value: string): string => {
@@ -249,6 +266,10 @@ export class GitHubAppProvider implements GitHubAppBoundary {
         error instanceof GitHubWorkflowCatalogSyncError
       ) {
         throw error;
+      }
+
+      if (error instanceof GitHubApiRequestError) {
+        throw new GitHubWorkflowCatalogSyncError(error.details);
       }
 
       throw new GitHubWorkflowCatalogSyncError();
@@ -421,7 +442,11 @@ export class GitHubAppProvider implements GitHubAppBoundary {
     });
 
     if (!response.ok) {
-      throw new Error(`GitHub request failed with status ${response.status}.`);
+      throw new GitHubApiRequestError({
+        githubEndpoint: toGitHubEndpoint(input),
+        githubResponseStatus: response.status,
+        githubResponseMessage: await extractGitHubErrorMessage(response),
+      });
     }
 
     const payload: unknown = await response.json();
@@ -459,6 +484,63 @@ const createGitHubAppJwt = (config: GitHubAppEnv, now: Date): string => {
   ).toString('base64url');
 
   return `${signingInput}.${signature}`;
+};
+
+const toGitHubEndpoint = (input: string): string => {
+  try {
+    const url = new URL(input);
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return input;
+  }
+};
+
+const truncateGitHubErrorMessage = (value: string): string => {
+  const normalized = value.trim().replace(/\s+/g, ' ');
+
+  if (normalized.length <= MAX_GITHUB_ERROR_MESSAGE_LENGTH) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, MAX_GITHUB_ERROR_MESSAGE_LENGTH - 1)}…`;
+};
+
+const extractGitHubErrorMessage = async (response: Response): Promise<string> => {
+  const contentType = response.headers.get('content-type') ?? '';
+
+  if (contentType.includes('application/json')) {
+    try {
+      const payload: unknown = await response.json();
+
+      if (
+        typeof payload === 'object' &&
+        payload !== null &&
+        'message' in payload &&
+        typeof payload.message === 'string' &&
+        payload.message.trim().length > 0
+      ) {
+        return truncateGitHubErrorMessage(payload.message);
+      }
+    } catch {
+      return DEFAULT_GITHUB_ERROR_MESSAGE;
+    }
+  }
+
+  try {
+    const text = await response.text();
+
+    if (text.trim().length > 0) {
+      return truncateGitHubErrorMessage(text);
+    }
+  } catch {
+    return DEFAULT_GITHUB_ERROR_MESSAGE;
+  }
+
+  if (response.statusText.trim().length > 0) {
+    return truncateGitHubErrorMessage(response.statusText);
+  }
+
+  return DEFAULT_GITHUB_ERROR_MESSAGE;
 };
 
 const mapGitHubWorkflowRunDescriptor = (

--- a/backend/src/modules/repository-registry/repository.service.ts
+++ b/backend/src/modules/repository-registry/repository.service.ts
@@ -129,6 +129,7 @@ const serializeApplicationError = (error: unknown): Record<string, string | numb
     return {
       errorCode: error.code,
       errorStatusCode: error.statusCode,
+      ...(error.details ?? {}),
     };
   }
 

--- a/backend/src/modules/workflow-catalog/workflow.service.ts
+++ b/backend/src/modules/workflow-catalog/workflow.service.ts
@@ -114,6 +114,7 @@ const serializeApplicationError = (error: unknown): Record<string, string | numb
     return {
       errorCode: error.code,
       errorStatusCode: error.statusCode,
+      ...(error.details ?? {}),
     };
   }
 

--- a/backend/src/shared/errors/application-error.ts
+++ b/backend/src/shared/errors/application-error.ts
@@ -1,12 +1,22 @@
+export type ApplicationErrorDetailsValue = string | number | boolean | null;
+export type ApplicationErrorDetails = Record<string, ApplicationErrorDetailsValue>;
+
 export abstract class ApplicationError extends Error {
   public readonly statusCode: number;
   public readonly code: string;
+  public readonly details: ApplicationErrorDetails | null;
 
-  protected constructor(message: string, statusCode: number, code: string) {
+  protected constructor(
+    message: string,
+    statusCode: number,
+    code: string,
+    details: ApplicationErrorDetails | null = null,
+  ) {
     super(message);
     this.name = new.target.name;
     this.statusCode = statusCode;
     this.code = code;
+    this.details = details;
   }
 }
 

--- a/backend/src/tests/modules/github/github-app.provider.test.ts
+++ b/backend/src/tests/modules/github/github-app.provider.test.ts
@@ -187,14 +187,27 @@ describe('GitHubAppProvider', () => {
   });
 
   it('should raise a safe workflow catalog error when workflow sync fails', async () => {
-    const fetchImplementation = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(JSON.stringify({ message: 'rate limited' }), {
-        status: 403,
-        headers: {
-          'content-type': 'application/json',
-        },
-      }),
-    );
+    const fetchImplementation = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: 'installation-token' }), {
+          status: 201,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ message: 'Resource not accessible by integration' }),
+          {
+            status: 403,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
     const boundary = createGitHubAppBoundary(buildConfig(), {
       apiBaseUrl: 'https://api.github.test',
       fetchImplementation,
@@ -202,21 +215,23 @@ describe('GitHubAppProvider', () => {
       now: () => new Date('2026-03-29T12:00:00.000Z'),
     });
 
-    await expect(
-      boundary.listRepositoryWorkflows({
+    const error = await boundary
+      .listRepositoryWorkflows({
         owner: 'forgeops',
         name: 'backend',
-      }),
-    ).rejects.toBeInstanceOf(GitHubWorkflowCatalogSyncError);
-    await expect(
-      boundary.listRepositoryWorkflows({
-        owner: 'forgeops',
-        name: 'backend',
-      }),
-    ).rejects.toMatchObject({
+      })
+      .catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBeInstanceOf(GitHubWorkflowCatalogSyncError);
+    expect(error).toMatchObject({
       code: 'github_workflow_catalog_unavailable',
       message: 'GitHub workflow catalog is currently unavailable.',
       statusCode: 503,
+      details: {
+        githubEndpoint: '/repos/forgeops/backend/actions/workflows?per_page=100',
+        githubResponseStatus: 403,
+        githubResponseMessage: 'Resource not accessible by integration',
+      },
     });
   });
 

--- a/backend/src/tests/modules/repository-registry/repository.service.test.ts
+++ b/backend/src/tests/modules/repository-registry/repository.service.test.ts
@@ -320,7 +320,14 @@ describe('RepositoryService', () => {
       workflowCatalogSync: {
         syncByRepositoryId: vi
           .fn()
-          .mockRejectedValue(new GitHubWorkflowCatalogSyncError()),
+          .mockRejectedValue(
+            new GitHubWorkflowCatalogSyncError({
+              githubEndpoint:
+                '/repos/forgeops/backend/actions/workflows?per_page=100',
+              githubResponseStatus: 403,
+              githubResponseMessage: 'Resource not accessible by integration',
+            }),
+          ),
       },
       logger,
     });
@@ -338,6 +345,9 @@ describe('RepositoryService', () => {
         fullName: 'forgeops/backend',
         errorCode: 'github_workflow_catalog_unavailable',
         errorStatusCode: 503,
+        githubEndpoint: '/repos/forgeops/backend/actions/workflows?per_page=100',
+        githubResponseStatus: 403,
+        githubResponseMessage: 'Resource not accessible by integration',
       },
       'Repository ingestion failed.',
     );

--- a/backend/src/tests/modules/workflow-catalog/workflow.service.test.ts
+++ b/backend/src/tests/modules/workflow-catalog/workflow.service.test.ts
@@ -235,7 +235,11 @@ describe('WorkflowService', () => {
         assertConfigured: () => undefined,
         listInstallationRepositories: async () => [],
         listRepositoryWorkflows: async () => {
-          throw new GitHubWorkflowCatalogSyncError();
+          throw new GitHubWorkflowCatalogSyncError({
+            githubEndpoint: '/repos/forgeops/backend/actions/workflows?per_page=100',
+            githubResponseStatus: 403,
+            githubResponseMessage: 'Resource not accessible by integration',
+          });
         },
         listWorkflowRuns: async () => [],
         listWorkflowRunJobs: async () => [],
@@ -255,6 +259,9 @@ describe('WorkflowService', () => {
         fullName: 'forgeops/backend',
         errorCode: 'github_workflow_catalog_unavailable',
         errorStatusCode: 503,
+        githubEndpoint: '/repos/forgeops/backend/actions/workflows?per_page=100',
+        githubResponseStatus: 403,
+        githubResponseMessage: 'Resource not accessible by integration',
       },
       'Workflow catalog sync failed.',
     );


### PR DESCRIPTION
﻿## Resumo
Expõe com segurança o erro real do GitHub no fluxo de sincronização do catálogo de workflows durante o onboarding de repositórios. A mudança preserva o contrato funcional atual, mas deixa observável qual endpoint foi chamado, qual status HTTP voltou e qual mensagem curta foi devolvida pela API remota.

## O que foi alterado
- Enriqueci `ApplicationError` para carregar detalhes estruturados e tipados de erro, sem alterar o contrato principal de status e código.
- Ajustei o provider do GitHub App para propagar `githubEndpoint`, `githubResponseStatus` e `githubResponseMessage` quando a consulta ao catálogo de workflows falhar.
- Reaproveitei esses detalhes nos logs de `workflow_catalog_sync_failed` e `repository_ingestion_failed`.
- Atualizei os testes do provider e dos serviços para cobrir a nova observabilidade segura.

## Motivação
O onboarding de repositórios estava mascarando falhas do GitHub como `github_workflow_catalog_unavailable` sem expor causa suficiente para distinguir problema de permissão, instalação ou integração. Isso dificultava a investigação e levava a hipóteses sem evidência.

## Como validar
- Executar `npm run lint --prefix backend`.
- Executar `npm run typecheck --prefix backend`.
- Executar `npm run test --prefix backend -- src/tests/modules/github/github-app.provider.test.ts src/tests/modules/workflow-catalog/workflow.service.test.ts src/tests/modules/repository-registry/repository.service.test.ts`.
- Subir `postgres`, `redis` e `backend` com GitHub App configurado e auth local habilitada.
- Chamar `GET /api/v1/repositories/discovery` com token válido.
- Chamar `POST /api/v1/repositories` com token contendo `repositories:write`.
- Em caso de falha, verificar nos logs do backend os campos `githubEndpoint`, `githubResponseStatus` e `githubResponseMessage`.

## Riscos e impactos
- O erro funcional retornado ao cliente continua o mesmo; a mudança aumenta apenas a observabilidade segura no backend.
- `ApplicationError` passa a aceitar `details`, então outros usos futuros devem manter esses valores livres de dados sensíveis.
- O runtime validado nesta PR não reproduziu a falha anterior do catálogo; o fluxo atual sincronizou workflows com sucesso.

## Evidências
- `POST /api/v1/repositories` retornou `201` para `alessandrolsdev/forge-ops` no runtime atual.
- Os logs do backend registraram `workflow_catalog_sync_succeeded` e `repository_ingestion_succeeded`.
- Quando o token local não tinha `repositories:write`, o backend respondeu `403 forbidden`, confirmando que esse bloqueio era de autorização local e não da API do GitHub.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #125
