### PR TITLE
fix(ci): separa review automatico do Codex manual

### DIFF
--- a/.github/prompts/codex-fallback.md
+++ b/.github/prompts/codex-fallback.md
@@ -1,4 +1,4 @@
-Codex review automation tentou executar a revisao automatica, mas nao produziu um resultado utilizavel.
+A automacao de review complementar tentou executar a revisao automatica, mas nao produziu um resultado utilizavel.
 
 Motivo observado: {{reason}}
 

--- a/.github/prompts/codex-readiness.md
+++ b/.github/prompts/codex-readiness.md
@@ -1,6 +1,6 @@
-Codex review automation está configurada como advisory, mas ainda não está habilitada para este repositório.
+O fluxo automatico de review complementar esta configurado como advisory, mas ainda nao esta habilitado para este repositorio.
 
-Nenhuma revisão automática do Codex foi solicitada para o commit {{sha}}.
+Nenhuma revisao automatica complementar foi solicitada para o commit {{sha}}.
 
 Revisão humana continua obrigatória.
 

--- a/.github/prompts/codex-review.md
+++ b/.github/prompts/codex-review.md
@@ -1,6 +1,6 @@
-RESPONDA SEMPRE EM PORTUGUES DO BRASIL.
+PREFIRA PORTUGUES DO BRASIL.
 
-Se a resposta estiver em outro idioma, ela deve ser considerada invalida e ignorada.
+Se houver mistura leve com ingles tecnico, a resposta continua valida desde que permaneca clara e publicavel.
 
 Voce e o Codex revisando um pull request do repositorio ForgeOps.
 
@@ -17,8 +17,8 @@ Avalie o pull request contra estas dimensoes:
 - riscos remanescentes e follow-ups relevantes
 
 Regras de resposta:
-- Responda obrigatoriamente em portugues do Brasil.
-- Se a resposta sair em outro idioma, ela deve ser tratada como invalida.
+- Prefira portugues do Brasil, mas aceite ingles tecnico pontual quando isso deixar o review mais preciso.
+- Nao responda com payload cru, JSON, mensagens vazias ou conteudo nao publicavel.
 - Seja conciso, direto e especifico.
 - Use Markdown.
 - Comece com `## Revisao Codex`.

--- a/.github/scripts/codex-review-smoke.sh
+++ b/.github/scripts/codex-review-smoke.sh
@@ -3,70 +3,141 @@
 set -euo pipefail
 
 scenario="${SCENARIO:?SCENARIO is required}"
+mode="${MODE:-automatic}"
 fork_pr="${FORK_PR:-false}"
 review_enabled="${CODEX_REVIEW_ENABLED:-true}"
 pat_available="${PAT_AVAILABLE:-false}"
-openai_present="${OPENAI_PRESENT:-false}"
-openai_result="${OPENAI_RESULT:-failed}"
 openrouter_present="${OPENROUTER_PRESENT:-false}"
 openrouter_result="${OPENROUTER_RESULT:-failed}"
+gemini_present="${GEMINI_PRESENT:-false}"
+gemini_result="${GEMINI_RESULT:-failed}"
+label_name="${LABEL_NAME:-}"
 
 comment_publisher="none"
 final_comment="false"
+manual_trigger_comment="false"
 review_provider="none"
 review_status="not_run"
 fallback_reason="none"
+openrouter_attempts="0"
+gemini_attempts="0"
 
 if [[ "$fork_pr" == "true" ]]; then
   echo "SCENARIO=$scenario"
+  echo "MODE=$mode"
   echo "PATH=skip_fork"
   echo "FINAL_COMMENT=false"
+  echo "MANUAL_TRIGGER_COMMENT=false"
   echo "COMMENT_PUBLISHER=none"
   echo "REVIEW_PROVIDER=none"
   echo "REVIEW_STATUS=skipped"
+  echo "OPENROUTER_ATTEMPTS=0"
+  echo "GEMINI_ATTEMPTS=0"
   echo "FALLBACK_REASON=fork_pr"
   exit 0
 fi
 
-if [[ "$pat_available" == "true" ]]; then
-  comment_publisher="maintainer_pat"
-else
-  comment_publisher="github_token"
+if [[ "$mode" == "manual" ]]; then
+  if [[ "$label_name" == "codex-review" && "$pat_available" == "true" ]]; then
+    manual_trigger_comment="true"
+    comment_publisher="maintainer_pat"
+    review_status="manual_codex_requested"
+  elif [[ "$label_name" == "codex-review" ]]; then
+    review_status="manual_codex_unavailable"
+    fallback_reason="pat_unavailable"
+  else
+    review_status="ignored_label"
+    fallback_reason="label_not_supported"
+  fi
+
+  echo "SCENARIO=$scenario"
+  echo "MODE=$mode"
+  echo "PATH=manual"
+  echo "FINAL_COMMENT=false"
+  echo "MANUAL_TRIGGER_COMMENT=$manual_trigger_comment"
+  echo "COMMENT_PUBLISHER=$comment_publisher"
+  echo "REVIEW_PROVIDER=none"
+  echo "REVIEW_STATUS=$review_status"
+  echo "OPENROUTER_ATTEMPTS=0"
+  echo "GEMINI_ATTEMPTS=0"
+  echo "FALLBACK_REASON=$fallback_reason"
+  exit 0
 fi
 
+comment_publisher="github_token"
 final_comment="true"
 
 if [[ "$review_enabled" != "true" ]]; then
   review_status="disabled"
   fallback_reason="codex_review_disabled"
 else
-  if [[ "$openai_present" == "true" && "$openai_result" == "completed" ]]; then
-    review_provider="openai"
-    review_status="completed"
-  elif [[ "$openrouter_present" == "true" && "$openrouter_result" == "completed" ]]; then
-    review_provider="openrouter"
-    review_status="completed"
-    if [[ "$openai_present" == "true" && "$openai_result" != "completed" ]]; then
-      fallback_reason="openai_${openai_result}"
-    fi
-  else
-    review_status="fallback_human"
-    if [[ "$openrouter_present" != "true" ]]; then
-      fallback_reason="openrouter_unavailable"
-    elif [[ "$openrouter_result" != "completed" ]]; then
-      fallback_reason="openrouter_${openrouter_result}"
-    elif [[ "$openai_present" != "true" ]]; then
-      fallback_reason="openai_unavailable"
+  if [[ "$openrouter_present" == "true" ]]; then
+    if [[ "$openrouter_result" == "completed" ]]; then
+      openrouter_attempts="1"
+      review_provider="openrouter"
+      review_status="completed"
+    elif [[ "$openrouter_result" == "completed_retry" ]]; then
+      openrouter_attempts="2"
+      review_provider="openrouter"
+      review_status="completed"
+      fallback_reason="openrouter_retried"
     else
-      fallback_reason="openai_${openai_result}"
+      openrouter_attempts="2"
+    fi
+  fi
+
+  if [[ "$review_status" != "completed" ]]; then
+    if [[ "$gemini_present" == "true" ]]; then
+      if [[ "$gemini_result" == "completed" ]]; then
+        gemini_attempts="1"
+        review_provider="gemini"
+        review_status="completed"
+        if [[ "$openrouter_present" != "true" ]]; then
+          fallback_reason="openrouter_unavailable"
+        elif [[ "$openrouter_result" != "completed" ]]; then
+          fallback_reason="openrouter_${openrouter_result}"
+        fi
+      elif [[ "$gemini_result" == "completed_retry" ]]; then
+        gemini_attempts="2"
+        review_provider="gemini"
+        review_status="completed"
+        if [[ "$openrouter_present" != "true" ]]; then
+          fallback_reason="openrouter_unavailable"
+        elif [[ "$openrouter_result" != "completed" ]]; then
+          fallback_reason="openrouter_${openrouter_result}"
+        fi
+      else
+        gemini_attempts="2"
+      fi
+    fi
+  fi
+
+  if [[ "$review_status" != "completed" ]]; then
+    review_status="fallback_advisory"
+    if [[ "$gemini_present" != "true" ]]; then
+      if [[ "$openrouter_present" != "true" ]]; then
+        fallback_reason="providers_unavailable"
+      else
+        fallback_reason="gemini_unavailable"
+      fi
+    elif [[ "$gemini_result" != "completed" && "$gemini_result" != "completed_retry" ]]; then
+      fallback_reason="gemini_${gemini_result}"
+    elif [[ "$openrouter_present" != "true" ]]; then
+      fallback_reason="openrouter_unavailable"
+    else
+      fallback_reason="openrouter_${openrouter_result}"
     fi
   fi
 fi
 
 echo "SCENARIO=$scenario"
-echo "PATH=standard"
+echo "MODE=$mode"
+echo "PATH=automatic"
 echo "FINAL_COMMENT=$final_comment"
+echo "MANUAL_TRIGGER_COMMENT=false"
 echo "COMMENT_PUBLISHER=$comment_publisher"
 echo "REVIEW_PROVIDER=$review_provider"
 echo "REVIEW_STATUS=$review_status"
+echo "OPENROUTER_ATTEMPTS=$openrouter_attempts"
+echo "GEMINI_ATTEMPTS=$gemini_attempts"
 echo "FALLBACK_REASON=$fallback_reason"

--- a/.github/workflows/codex-review-smoke.yml
+++ b/.github/workflows/codex-review-smoke.yml
@@ -28,66 +28,103 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - scenario: pat_invalid
-            fork_pr: "false"
-            review_enabled: "true"
-            pat_available: "false"
-            openai_present: "true"
-            openai_result: "completed"
-            openrouter_present: "true"
-            openrouter_result: "completed"
-            expected_final_comment: "true"
-            expected_comment_publisher: "github_token"
-            expected_review_provider: "openai"
-            expected_review_status: "completed"
-          - scenario: openai_unavailable
+          - scenario: automatic_happy_path
+            mode: automatic
             fork_pr: "false"
             review_enabled: "true"
             pat_available: "true"
-            openai_present: "true"
-            openai_result: "failed"
             openrouter_present: "true"
             openrouter_result: "completed"
+            gemini_present: "true"
+            gemini_result: "completed"
             expected_final_comment: "true"
-            expected_comment_publisher: "maintainer_pat"
+            expected_manual_trigger_comment: "false"
+            expected_comment_publisher: "github_token"
             expected_review_provider: "openrouter"
             expected_review_status: "completed"
-          - scenario: openrouter_unavailable
+            expected_openrouter_attempts: "1"
+            expected_gemini_attempts: "0"
+          - scenario: openrouter_retry_then_success
+            mode: automatic
             fork_pr: "false"
             review_enabled: "true"
             pat_available: "true"
-            openai_present: "true"
-            openai_result: "failed"
+            openrouter_present: "true"
+            openrouter_result: "completed_retry"
+            gemini_present: "true"
+            gemini_result: "completed"
+            expected_final_comment: "true"
+            expected_manual_trigger_comment: "false"
+            expected_comment_publisher: "github_token"
+            expected_review_provider: "openrouter"
+            expected_review_status: "completed"
+            expected_openrouter_attempts: "2"
+            expected_gemini_attempts: "0"
+          - scenario: openrouter_fallback_to_gemini
+            mode: automatic
+            fork_pr: "false"
+            review_enabled: "true"
+            pat_available: "true"
+            openrouter_present: "true"
+            openrouter_result: "failed"
+            gemini_present: "true"
+            gemini_result: "completed"
+            expected_final_comment: "true"
+            expected_manual_trigger_comment: "false"
+            expected_comment_publisher: "github_token"
+            expected_review_provider: "gemini"
+            expected_review_status: "completed"
+            expected_openrouter_attempts: "2"
+            expected_gemini_attempts: "1"
+          - scenario: providers_unavailable
+            mode: automatic
+            fork_pr: "false"
+            review_enabled: "true"
+            pat_available: "true"
             openrouter_present: "false"
             openrouter_result: "failed"
+            gemini_present: "false"
+            gemini_result: "failed"
             expected_final_comment: "true"
-            expected_comment_publisher: "maintainer_pat"
+            expected_manual_trigger_comment: "false"
+            expected_comment_publisher: "github_token"
             expected_review_provider: "none"
-            expected_review_status: "fallback_human"
+            expected_review_status: "fallback_advisory"
+            expected_openrouter_attempts: "0"
+            expected_gemini_attempts: "0"
           - scenario: fork_pr
+            mode: automatic
             fork_pr: "true"
             review_enabled: "true"
             pat_available: "true"
-            openai_present: "true"
-            openai_result: "completed"
             openrouter_present: "true"
             openrouter_result: "completed"
+            gemini_present: "true"
+            gemini_result: "completed"
             expected_final_comment: "false"
+            expected_manual_trigger_comment: "false"
             expected_comment_publisher: "none"
             expected_review_provider: "none"
             expected_review_status: "skipped"
-          - scenario: happy_path
+            expected_openrouter_attempts: "0"
+            expected_gemini_attempts: "0"
+          - scenario: manual_codex_label
+            mode: manual
             fork_pr: "false"
             review_enabled: "true"
             pat_available: "true"
-            openai_present: "true"
-            openai_result: "completed"
             openrouter_present: "true"
             openrouter_result: "completed"
-            expected_final_comment: "true"
+            gemini_present: "true"
+            gemini_result: "completed"
+            label_name: "codex-review"
+            expected_final_comment: "false"
+            expected_manual_trigger_comment: "true"
             expected_comment_publisher: "maintainer_pat"
-            expected_review_provider: "openai"
-            expected_review_status: "completed"
+            expected_review_provider: "none"
+            expected_review_status: "manual_codex_requested"
+            expected_openrouter_attempts: "0"
+            expected_gemini_attempts: "0"
 
     steps:
       - name: Checkout repository
@@ -99,13 +136,15 @@ jobs:
       - name: Run codex-review smoke scenario
         env:
           SCENARIO: ${{ matrix.scenario }}
+          MODE: ${{ matrix.mode }}
           FORK_PR: ${{ matrix.fork_pr }}
           CODEX_REVIEW_ENABLED: ${{ matrix.review_enabled }}
           PAT_AVAILABLE: ${{ matrix.pat_available }}
-          OPENAI_PRESENT: ${{ matrix.openai_present }}
-          OPENAI_RESULT: ${{ matrix.openai_result }}
           OPENROUTER_PRESENT: ${{ matrix.openrouter_present }}
           OPENROUTER_RESULT: ${{ matrix.openrouter_result }}
+          GEMINI_PRESENT: ${{ matrix.gemini_present }}
+          GEMINI_RESULT: ${{ matrix.gemini_result }}
+          LABEL_NAME: ${{ matrix.label_name }}
         shell: bash
         run: |
           set -euo pipefail
@@ -114,9 +153,12 @@ jobs:
       - name: Assert expected smoke path
         env:
           EXPECTED_FINAL_COMMENT: ${{ matrix.expected_final_comment }}
+          EXPECTED_MANUAL_TRIGGER_COMMENT: ${{ matrix.expected_manual_trigger_comment }}
           EXPECTED_COMMENT_PUBLISHER: ${{ matrix.expected_comment_publisher }}
           EXPECTED_REVIEW_PROVIDER: ${{ matrix.expected_review_provider }}
           EXPECTED_REVIEW_STATUS: ${{ matrix.expected_review_status }}
+          EXPECTED_OPENROUTER_ATTEMPTS: ${{ matrix.expected_openrouter_attempts }}
+          EXPECTED_GEMINI_ATTEMPTS: ${{ matrix.expected_gemini_attempts }}
         shell: bash
         run: |
           set -euo pipefail
@@ -124,6 +166,9 @@ jobs:
           log_path="$RUNNER_TEMP/codex-review-smoke.log"
 
           grep -q "^FINAL_COMMENT=${EXPECTED_FINAL_COMMENT}$" "$log_path"
+          grep -q "^MANUAL_TRIGGER_COMMENT=${EXPECTED_MANUAL_TRIGGER_COMMENT}$" "$log_path"
           grep -q "^COMMENT_PUBLISHER=${EXPECTED_COMMENT_PUBLISHER}$" "$log_path"
           grep -q "^REVIEW_PROVIDER=${EXPECTED_REVIEW_PROVIDER}$" "$log_path"
           grep -q "^REVIEW_STATUS=${EXPECTED_REVIEW_STATUS}$" "$log_path"
+          grep -q "^OPENROUTER_ATTEMPTS=${EXPECTED_OPENROUTER_ATTEMPTS}$" "$log_path"
+          grep -q "^GEMINI_ATTEMPTS=${EXPECTED_GEMINI_ATTEMPTS}$" "$log_path"

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -7,6 +7,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - labeled
     branches:
       - main
 
@@ -22,7 +23,7 @@ concurrency:
 jobs:
   codex-review:
     name: codex-review
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'labeled' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -43,10 +44,11 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork }}
         env:
           CODEX_REVIEW_ENABLED: ${{ vars.CODEX_REVIEW_ENABLED }}
-          CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || vars.CODEX_REVIEW_OPENROUTER_MODEL }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_MODEL: ${{ vars.GEMINI_MODEL }}
         shell: bash
         run: |
           set -euo pipefail
@@ -57,59 +59,21 @@ jobs:
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if [ -n "${CODEX_REVIEW_PAT:-}" ]; then
-            echo "pat_present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "pat_present=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [ -n "${OPENAI_API_KEY:-}" ]; then
-            echo "openai_present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "openai_present=false" >> "$GITHUB_OUTPUT"
-          fi
-
           if [ -n "${OPENROUTER_API_KEY:-}" ] && [ -n "${OPENROUTER_MODEL:-}" ]; then
             echo "openrouter_present=true" >> "$GITHUB_OUTPUT"
           else
             echo "openrouter_present=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Resolve commenter identity
-        id: commenter
-        if: ${{ !github.event.pull_request.head.repo.fork && steps.review-config.outputs.pat_present == 'true' }}
-        env:
-          CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          response_path="$RUNNER_TEMP/codex-review/commenter.json"
-          mkdir -p "$(dirname "$response_path")"
-          http_status=$(
-            curl -s \
-              -o "$response_path" \
-              -w "%{http_code}" \
-              -H "Authorization: token ${CODEX_REVIEW_PAT}" \
-              -H "Accept: application/vnd.github+json" \
-              https://api.github.com/user \
-              || true
-          )
-
-          if [ "$http_status" -ge 200 ] && [ "$http_status" -lt 300 ]; then
-            login=$(jq -r '.login // empty' "$response_path" 2>/dev/null || true)
+          resolved_gemini_key="${GEMINI_API_KEY:-${GOOGLE_API_KEY:-}}"
+          if [ -n "$resolved_gemini_key" ]; then
+            echo "gemini_present=true" >> "$GITHUB_OUTPUT"
           else
-            login=""
+            echo "gemini_present=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if [ -z "$login" ]; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "login=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "available=true" >> "$GITHUB_OUTPUT"
-          echo "login=$login" >> "$GITHUB_OUTPUT"
+          resolved_gemini_model="${GEMINI_MODEL:-gemini-2.5-flash}"
+          echo "gemini_model=$resolved_gemini_model" >> "$GITHUB_OUTPUT"
 
       - name: Collect pull request context
         id: pr-context
@@ -161,253 +125,9 @@ jobs:
 
           echo "context_dir=$output_dir" >> "$GITHUB_OUTPUT"
 
-      - name: Publish Codex trigger comment as maintainer
-        if: ${{ !github.event.pull_request.head.repo.fork && steps.review-config.outputs.enabled == 'true' && steps.commenter.outputs.available == 'true' }}
-        env:
-          CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}
-          COMMENTER_LOGIN: ${{ steps.commenter.outputs.login }}
-          PR_CONTEXT_DIR: ${{ steps.pr-context.outputs.context_dir }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          marker=$(cat "$GITHUB_WORKSPACE/.github/prompts/codex-comment-marker.txt")
-          pr_number=$(jq -r '.number' "$PR_CONTEXT_DIR/pr.json")
-          pr_sha=$(jq -r '.sha' "$PR_CONTEXT_DIR/pr.json")
-          comments_url="${{ github.api_url }}/repos/${{ github.repository }}/issues/$pr_number/comments"
-          comment_body_path="$RUNNER_TEMP/codex-review/trigger-comment.md"
-
-          {
-            printf '%s\n' "$marker"
-            printf '@codex review\n\n'
-            printf 'Responda em portugues do Brasil.\n\n'
-            printf 'Critrios obrigatorios:\n'
-            printf '%s\n' '- idioma: portugues (pt-BR)'
-            printf '%s\n\n' '- foco em arquitetura, riscos e testes'
-            printf 'Solicitacao automatica de revisao Codex para o commit %s.\n\n' "$pr_sha"
-            printf 'Esta revisao continua advisory e nao substitui a revisao humana.\n'
-          } > "$comment_body_path"
-
-          set +e
-          comments_payload=$(
-            curl -s \
-              -H "Authorization: Bearer $CODEX_REVIEW_PAT" \
-              -H "Accept: application/vnd.github+json" \
-              "$comments_url?per_page=100" \
-          )
-          comments_status=$?
-          set -e
-
-          if [ "$comments_status" -ne 0 ]; then
-            echo "Skipping maintainer trigger comment update because GitHub comment listing failed."
-            exit 0
-          fi
-
-          existing_comment_id=$(
-            printf '%s' "$comments_payload" \
-              | jq -r --arg login "$COMMENTER_LOGIN" --arg marker "$marker" '
-                  .[]
-                  | select(.user.login == $login and ((.body // "") | contains($marker)))
-                  | .id
-                ' \
-              | head -n 1
-          )
-
-          if [ -n "$existing_comment_id" ]; then
-            set +e
-            jq -n --rawfile body "$comment_body_path" '{body: $body}' \
-              | curl -s -X PATCH \
-                  "${{ github.api_url }}/repos/${{ github.repository }}/issues/comments/$existing_comment_id" \
-                  -H "Authorization: Bearer $CODEX_REVIEW_PAT" \
-                  -H "Accept: application/vnd.github+json" \
-                  -H "Content-Type: application/json" \
-                  --data @- \
-                  > /dev/null
-            patch_status=$?
-            set -e
-            if [ "$patch_status" -ne 0 ]; then
-              echo "Skipping maintainer trigger comment patch because GitHub patch request failed."
-            fi
-            exit 0
-          fi
-
-          set +e
-          jq -n --rawfile body "$comment_body_path" '{body: $body}' \
-            | curl -s -X POST \
-                "$comments_url" \
-                -H "Authorization: Bearer $CODEX_REVIEW_PAT" \
-                -H "Accept: application/vnd.github+json" \
-                -H "Content-Type: application/json" \
-                --data @- \
-                > /dev/null
-          post_status=$?
-          set -e
-          if [ "$post_status" -ne 0 ]; then
-            echo "Skipping maintainer trigger comment creation because GitHub post request failed."
-          fi
-
-      - name: Run automated review via OpenAI API
-        id: openai-review
-        if: ${{ !github.event.pull_request.head.repo.fork && steps.review-config.outputs.enabled == 'true' && steps.review-config.outputs.openai_present == 'true' }}
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          PR_CONTEXT_DIR: ${{ steps.pr-context.outputs.context_dir }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          validate_review_language() {
-            local review_path="$1"
-            local provider_label="$2"
-            local review_text
-            local review_lower
-
-            if [ ! -s "$review_path" ]; then
-              return 1
-            fi
-
-            review_text=$(cat "$review_path")
-            review_lower=$(printf '%s' "$review_text" | tr '[:upper:]' '[:lower:]')
-
-            if printf '%s' "$review_lower" | grep -qiE '\b(the|and|with|this|that|from|for|are|should|could|would|issue|file|tests)\b'; then
-              echo "${provider_label} review language validation flagged probable English content."
-              return 1
-            fi
-
-            if ! printf '%s' "$review_lower" | grep -qiE '\b(revisao|risco|arquivo|correcao|teste|achados|materiais|residual|repositorio|arquitetura|seguranca)\b|[áéíóúãõç]'; then
-              echo "${provider_label} review language validation did not detect enough PT-BR signals."
-              return 1
-            fi
-
-            return 0
-          }
-
-          request_path="$RUNNER_TEMP/codex-review/openai-request.json"
-          response_path="$RUNNER_TEMP/codex-review/openai-response.json"
-          review_path="$RUNNER_TEMP/codex-review/openai-review.md"
-          prompt_path="$GITHUB_WORKSPACE/.github/prompts/codex-review.md"
-          diff_path="$PR_CONTEXT_DIR/pr.diff"
-
-          jq -n \
-            --rawfile prompt "$prompt_path" \
-            --slurpfile pr "$PR_CONTEXT_DIR/pr.json" \
-            --rawfile diff "$diff_path" \
-            '{
-              model: "gpt-5.4",
-              store: false,
-              reasoning: {
-                effort: "none"
-              },
-              text: {
-                verbosity: "low"
-              },
-              instructions: $prompt,
-              input: [
-                {
-                  role: "user",
-                  content: [
-                    {
-                      type: "input_text",
-                      text: (
-                        "PR title:\n" + ($pr[0].title // "(empty)") +
-                        "\n\nPR body:\n" + ($pr[0].body // "(empty)") +
-                        "\n\nUnified diff:\n" + $diff
-                      )
-                    }
-                  ]
-                }
-              ]
-            }' > "$request_path"
-
-          set +e
-          http_status=$(
-            curl -sS \
-              -o "$response_path" \
-              -w "%{http_code}" \
-              https://api.openai.com/v1/responses \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -H "Content-Type: application/json" \
-              --data @"$request_path"
-          )
-          curl_exit=$?
-          set -e
-
-          if [ "$curl_exit" -ne 0 ]; then
-            echo "status=failed" >> "$GITHUB_OUTPUT"
-            echo "provider=openai" >> "$GITHUB_OUTPUT"
-            echo "fallback_reason=A chamada para a OpenAI API falhou antes de retornar um payload." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]; then
-            echo "status=failed" >> "$GITHUB_OUTPUT"
-            echo "provider=openai" >> "$GITHUB_OUTPUT"
-            echo "fallback_reason=A OpenAI API respondeu com status HTTP $http_status." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          jq -r '
-            def text_value:
-              if . == null then
-                empty
-              elif type == "string" then
-                .
-              elif type == "object" then
-                .text // .value // empty
-              else
-                empty
-              end;
-
-            [
-              (.output_text? | strings),
-              (
-                .output[]?
-                | select(.type == "message")
-                | .content[]?
-                | select((.type // "") == "output_text" or (.type // "") == "text")
-                | .text
-                | text_value
-              ),
-              (
-                .output[]?
-                | .content[]?
-                | select((.type // "") == "output_text" or (.type // "") == "text")
-                | .text
-                | text_value
-              ),
-              (
-                .content[]?
-                | select((.type // "") == "output_text" or (.type // "") == "text")
-                | .text
-                | text_value
-              )
-            ]
-            | map(select(length > 0))
-            | unique
-            | join("\n\n")
-          ' "$response_path" > "$review_path"
-
-          if [ ! -s "$review_path" ] || [ "$(cat "$review_path")" = "null" ]; then
-            echo "status=no_usable_output" >> "$GITHUB_OUTPUT"
-            echo "provider=openai" >> "$GITHUB_OUTPUT"
-            echo "fallback_reason=A OpenAI API respondeu, mas nao gerou texto publicavel no formato esperado." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if ! validate_review_language "$review_path" "OpenAI"; then
-            echo "status=no_usable_output" >> "$GITHUB_OUTPUT"
-            echo "provider=openai" >> "$GITHUB_OUTPUT"
-            echo "fallback_reason=A OpenAI API respondeu em idioma diferente do portugues do Brasil." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "status=completed" >> "$GITHUB_OUTPUT"
-          echo "provider=openai" >> "$GITHUB_OUTPUT"
-          echo "review_path=$review_path" >> "$GITHUB_OUTPUT"
-
-      - name: Run automated review via OpenRouter fallback
+      - name: Run automated review via OpenRouter
         id: openrouter-review
-        if: ${{ !github.event.pull_request.head.repo.fork && steps.review-config.outputs.enabled == 'true' && steps.review-config.outputs.openrouter_present == 'true' && steps.openai-review.outputs.status != 'completed' }}
+        if: ${{ !github.event.pull_request.head.repo.fork && steps.review-config.outputs.enabled == 'true' && steps.review-config.outputs.openrouter_present == 'true' }}
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || vars.CODEX_REVIEW_OPENROUTER_MODEL }}
@@ -416,30 +136,30 @@ jobs:
         run: |
           set -euo pipefail
 
-          validate_review_language() {
+          ensure_publishable_review() {
             local review_path="$1"
-            local provider_label="$2"
-            local review_text
-            local review_lower
 
             if [ ! -s "$review_path" ]; then
               return 1
             fi
 
-            review_text=$(cat "$review_path")
-            review_lower=$(printf '%s' "$review_text" | tr '[:upper:]' '[:lower:]')
-
-            if printf '%s' "$review_lower" | grep -qiE '\b(the|and|with|this|that|from|for|are|should|could|would|issue|file|tests)\b'; then
-              echo "${provider_label} review language validation flagged probable English content."
-              return 1
-            fi
-
-            if ! printf '%s' "$review_lower" | grep -qiE '\b(revisao|risco|arquivo|correcao|teste|achados|materiais|residual|repositorio|arquitetura|seguranca)\b|[áéíóúãõç]'; then
-              echo "${provider_label} review language validation did not detect enough PT-BR signals."
+            if [ "$(cat "$review_path")" = "null" ]; then
               return 1
             fi
 
             return 0
+          }
+
+          log_language_quality() {
+            local review_path="$1"
+            local provider_label="$2"
+            local review_lower
+
+            review_lower=$(tr '[:upper:]' '[:lower:]' < "$review_path")
+
+            if ! printf '%s' "$review_lower" | grep -qiE '\b(revisao|risco|arquivo|correcao|teste|achado|arquitetura|seguranca)\b'; then
+              echo "${provider_label} review published with weak PT-BR signals; accepting because the content is still publishable."
+            fi
           }
 
           request_path="$RUNNER_TEMP/codex-review/openrouter-request.json"
@@ -447,6 +167,8 @@ jobs:
           review_path="$RUNNER_TEMP/codex-review/openrouter-review.md"
           prompt_path="$GITHUB_WORKSPACE/.github/prompts/codex-review.md"
           diff_path="$PR_CONTEXT_DIR/pr.diff"
+          fallback_reason="A OpenRouter API nao produziu um review publicavel."
+          attempts=0
 
           jq -n \
             --arg model "$OPENROUTER_MODEL" \
@@ -472,117 +194,251 @@ jobs:
               ]
             }' > "$request_path"
 
-          echo "OpenRouter model: $OPENROUTER_MODEL"
-          echo "OpenRouter prompt size (bytes): $(wc -c < "$prompt_path")"
-          echo "OpenRouter PR diff size (bytes): $(wc -c < "$diff_path")"
-
-          set +e
-          http_status=$(
-            curl -sS \
-              -o "$response_path" \
-              -w "%{http_code}" \
-              https://openrouter.ai/api/v1/chat/completions \
-              -H "Authorization: Bearer $OPENROUTER_API_KEY" \
-              -H "Content-Type: application/json" \
-              -H "HTTP-Referer: https://github.com/${{ github.repository }}" \
-              -H "X-Title: ForgeOps Codex Review" \
-              --data @"$request_path"
-          )
-          curl_exit=$?
-          set -e
-
-          if [ "$curl_exit" -ne 0 ]; then
-            echo "status=failed" >> "$GITHUB_OUTPUT"
-            echo "provider=openrouter" >> "$GITHUB_OUTPUT"
-            echo "fallback_reason=A chamada para a OpenRouter API falhou antes de retornar um payload." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]; then
-            echo "status=failed" >> "$GITHUB_OUTPUT"
-            echo "provider=openrouter" >> "$GITHUB_OUTPUT"
-            echo "fallback_reason=A OpenRouter API respondeu com status HTTP $http_status." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "OpenRouter API raw response:"
-          cat "$response_path"
-          echo
-          echo "OpenRouter API response summary:"
-          jq '{
-            id,
-            model,
-            choices_count: ([.choices[]?] | length),
-            first_choice_finish_reason: .choices[0]?.finish_reason,
-            first_choice_role: .choices[0]?.message?.role,
-            first_choice_content_type: (.choices[0]?.message?.content | type)
-          }' "$response_path"
-
-          jq -r '
-            def text_value:
-              if . == null then
-                empty
-              elif type == "string" then
-                .
-              elif type == "object" then
-                .text // empty
-              else
-                empty
-              end;
-
-            [
-              (.choices[0]?.message?.content | text_value),
-              (.choices[]?.message?.content | text_value),
-              (
-                .choices[0]?.message?.content[]?
-                | select((.type // "") == "text")
-                | (.text // empty)
-              ),
-              (
-                .choices[]?.message?.content[]?
-                | select((.type // "") == "text")
-                | (.text // empty)
-              )
-            ]
-            | map(select(length > 0))
-            | unique
-            | join("\n\n")
-          ' "$response_path" > "$review_path"
-
-          echo "OpenRouter parsed review size (bytes): $(wc -c < "$review_path")"
-
-          if [ ! -s "$review_path" ] || [ "$(cat "$review_path")" = "null" ]; then
-            echo "status=no_usable_output" >> "$GITHUB_OUTPUT"
-            echo "provider=openrouter" >> "$GITHUB_OUTPUT"
-            fallback_reason=$(
-              jq -r '
-                if (.error? != null) then
-                  "A OpenRouter API retornou um objeto de erro no payload."
-                elif ([.choices[]?] | length) == 0 then
-                  "A OpenRouter API respondeu sem `choices`."
-                elif (.choices[0]?.message? == null) then
-                  "A OpenRouter API respondeu sem `message` na primeira choice."
-                elif (.choices[0]?.message?.content == null) then
-                  "A OpenRouter API respondeu sem `message.content` na primeira choice."
-                else
-                  "A OpenRouter API respondeu, mas nao gerou texto publicavel no formato esperado."
-                end
-              ' "$response_path"
+          for attempt in 1 2; do
+            attempts="$attempt"
+            set +e
+            http_status=$(
+              curl -sS \
+                -o "$response_path" \
+                -w "%{http_code}" \
+                https://openrouter.ai/api/v1/chat/completions \
+                -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "HTTP-Referer: https://github.com/${{ github.repository }}" \
+                -H "X-Title: ForgeOps Codex Review" \
+                --data @"$request_path"
             )
-            echo "fallback_reason=$fallback_reason" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+            curl_exit=$?
+            set -e
 
-          if ! validate_review_language "$review_path" "OpenRouter"; then
-            echo "status=no_usable_output" >> "$GITHUB_OUTPUT"
-            echo "provider=openrouter" >> "$GITHUB_OUTPUT"
-            echo "fallback_reason=A OpenRouter API respondeu em idioma diferente do portugues do Brasil." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+            if [ "$curl_exit" -ne 0 ]; then
+              fallback_reason="A chamada para a OpenRouter API falhou antes de retornar um payload."
+            elif [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]; then
+              remote_message=$(
+                jq -r '.error?.message // .message // empty' "$response_path" 2>/dev/null || true
+              )
+              if [ -n "$remote_message" ]; then
+                fallback_reason="A OpenRouter API respondeu com status HTTP $http_status: $remote_message"
+              else
+                fallback_reason="A OpenRouter API respondeu com status HTTP $http_status."
+              fi
+            else
+              jq -r '
+                def text_value:
+                  if . == null then
+                    empty
+                  elif type == "string" then
+                    .
+                  elif type == "object" then
+                    .text // empty
+                  else
+                    empty
+                  end;
 
-          echo "status=completed" >> "$GITHUB_OUTPUT"
+                [
+                  (.choices[0]?.message?.content | text_value),
+                  (.choices[]?.message?.content | text_value),
+                  (
+                    .choices[0]?.message?.content[]?
+                    | select((.type // "") == "text")
+                    | (.text // empty)
+                  ),
+                  (
+                    .choices[]?.message?.content[]?
+                    | select((.type // "") == "text")
+                    | (.text // empty)
+                  )
+                ]
+                | map(select(length > 0))
+                | unique
+                | join("\n\n")
+              ' "$response_path" > "$review_path"
+
+              if ensure_publishable_review "$review_path"; then
+                log_language_quality "$review_path" "OpenRouter"
+                echo "status=completed" >> "$GITHUB_OUTPUT"
+                echo "provider=openrouter" >> "$GITHUB_OUTPUT"
+                echo "review_path=$review_path" >> "$GITHUB_OUTPUT"
+                echo "attempts=$attempts" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+
+              fallback_reason=$(
+                jq -r '
+                  if (.error? != null) then
+                    "A OpenRouter API retornou um objeto de erro no payload."
+                  elif ([.choices[]?] | length) == 0 then
+                    "A OpenRouter API respondeu sem `choices`."
+                  elif (.choices[0]?.message? == null) then
+                    "A OpenRouter API respondeu sem `message` na primeira choice."
+                  elif (.choices[0]?.message?.content == null) then
+                    "A OpenRouter API respondeu sem `message.content` na primeira choice."
+                  else
+                    "A OpenRouter API respondeu, mas nao gerou texto publicavel no formato esperado."
+                  end
+                ' "$response_path"
+              )
+            fi
+
+            if [ "$attempt" -lt 2 ]; then
+              echo "OpenRouter attempt $attempt failed; retrying once before falling back."
+            fi
+          done
+
+          echo "status=failed" >> "$GITHUB_OUTPUT"
           echo "provider=openrouter" >> "$GITHUB_OUTPUT"
-          echo "review_path=$review_path" >> "$GITHUB_OUTPUT"
+          echo "fallback_reason=$fallback_reason" >> "$GITHUB_OUTPUT"
+          echo "attempts=$attempts" >> "$GITHUB_OUTPUT"
+
+      - name: Run automated review via Gemini fallback
+        id: gemini-review
+        if: ${{ !github.event.pull_request.head.repo.fork && steps.review-config.outputs.enabled == 'true' && steps.review-config.outputs.gemini_present == 'true' && steps.openrouter-review.outputs.status != 'completed' }}
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_MODEL: ${{ steps.review-config.outputs.gemini_model }}
+          PR_CONTEXT_DIR: ${{ steps.pr-context.outputs.context_dir }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ensure_publishable_review() {
+            local review_path="$1"
+
+            if [ ! -s "$review_path" ]; then
+              return 1
+            fi
+
+            if [ "$(cat "$review_path")" = "null" ]; then
+              return 1
+            fi
+
+            return 0
+          }
+
+          log_language_quality() {
+            local review_path="$1"
+            local provider_label="$2"
+            local review_lower
+
+            review_lower=$(tr '[:upper:]' '[:lower:]' < "$review_path")
+
+            if ! printf '%s' "$review_lower" | grep -qiE '\b(revisao|risco|arquivo|correcao|teste|achado|arquitetura|seguranca)\b'; then
+              echo "${provider_label} review published with weak PT-BR signals; accepting because the content is still publishable."
+            fi
+          }
+
+          resolved_gemini_api_key="${GEMINI_API_KEY:-${GOOGLE_API_KEY:-}}"
+          request_path="$RUNNER_TEMP/codex-review/gemini-request.json"
+          response_path="$RUNNER_TEMP/codex-review/gemini-response.json"
+          review_path="$RUNNER_TEMP/codex-review/gemini-review.md"
+          prompt_path="$GITHUB_WORKSPACE/.github/prompts/codex-review.md"
+          diff_path="$PR_CONTEXT_DIR/pr.diff"
+          fallback_reason="A Gemini API nao produziu um review publicavel."
+          attempts=0
+
+          jq -n \
+            --rawfile prompt "$prompt_path" \
+            --slurpfile pr "$PR_CONTEXT_DIR/pr.json" \
+            --rawfile diff "$diff_path" \
+            '{
+              systemInstruction: {
+                role: "system",
+                parts: [
+                  {
+                    text: $prompt
+                  }
+                ]
+              },
+              generationConfig: {
+                temperature: 0.1
+              },
+              contents: [
+                {
+                  role: "user",
+                  parts: [
+                    {
+                      text: (
+                        "PR title:\n" + ($pr[0].title // "(empty)") +
+                        "\n\nPR body:\n" + ($pr[0].body // "(empty)") +
+                        "\n\nUnified diff:\n" + $diff
+                      )
+                    }
+                  ]
+                }
+              ]
+            }' > "$request_path"
+
+          for attempt in 1 2; do
+            attempts="$attempt"
+            set +e
+            http_status=$(
+              curl -sS \
+                -o "$response_path" \
+                -w "%{http_code}" \
+                "https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${resolved_gemini_api_key}" \
+                -H "Content-Type: application/json" \
+                --data @"$request_path"
+            )
+            curl_exit=$?
+            set -e
+
+            if [ "$curl_exit" -ne 0 ]; then
+              fallback_reason="A chamada para a Gemini API falhou antes de retornar um payload."
+            elif [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]; then
+              remote_message=$(
+                jq -r '.error?.message // .message // empty' "$response_path" 2>/dev/null || true
+              )
+              if [ -n "$remote_message" ]; then
+                fallback_reason="A Gemini API respondeu com status HTTP $http_status: $remote_message"
+              else
+                fallback_reason="A Gemini API respondeu com status HTTP $http_status."
+              fi
+            else
+              jq -r '
+                [
+                  .candidates[]?.content?.parts[]?.text
+                ]
+                | map(select(type == "string" and length > 0))
+                | unique
+                | join("\n\n")
+              ' "$response_path" > "$review_path"
+
+              if ensure_publishable_review "$review_path"; then
+                log_language_quality "$review_path" "Gemini"
+                echo "status=completed" >> "$GITHUB_OUTPUT"
+                echo "provider=gemini" >> "$GITHUB_OUTPUT"
+                echo "review_path=$review_path" >> "$GITHUB_OUTPUT"
+                echo "attempts=$attempts" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+
+              fallback_reason=$(
+                jq -r '
+                  if (.error? != null) then
+                    "A Gemini API retornou um objeto de erro no payload."
+                  elif ([.candidates[]?] | length) == 0 then
+                    "A Gemini API respondeu sem `candidates`."
+                  elif (.candidates[0]?.content? == null) then
+                    "A Gemini API respondeu sem `content` no primeiro candidate."
+                  elif ([.candidates[0]?.content?.parts[]?] | length) == 0 then
+                    "A Gemini API respondeu sem `parts` no primeiro candidate."
+                  else
+                    "A Gemini API respondeu, mas nao gerou texto publicavel no formato esperado."
+                  end
+                ' "$response_path"
+              )
+            fi
+
+            if [ "$attempt" -lt 2 ]; then
+              echo "Gemini attempt $attempt failed; retrying once before falling back."
+            fi
+          done
+
+          echo "status=failed" >> "$GITHUB_OUTPUT"
+          echo "provider=gemini" >> "$GITHUB_OUTPUT"
+          echo "fallback_reason=$fallback_reason" >> "$GITHUB_OUTPUT"
+          echo "attempts=$attempts" >> "$GITHUB_OUTPUT"
 
       - name: Resolve review result
         id: review-result
@@ -591,17 +447,30 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${{ steps.openai-review.outputs.status }}" = "completed" ]; then
-            echo "status=completed" >> "$GITHUB_OUTPUT"
-            echo "provider=${{ steps.openai-review.outputs.provider }}" >> "$GITHUB_OUTPUT"
-            echo "review_path=${{ steps.openai-review.outputs.review_path }}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           if [ "${{ steps.openrouter-review.outputs.status }}" = "completed" ]; then
             echo "status=completed" >> "$GITHUB_OUTPUT"
             echo "provider=${{ steps.openrouter-review.outputs.provider }}" >> "$GITHUB_OUTPUT"
             echo "review_path=${{ steps.openrouter-review.outputs.review_path }}" >> "$GITHUB_OUTPUT"
+            echo "fallback_reason=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ steps.gemini-review.outputs.status }}" = "completed" ]; then
+            echo "status=completed" >> "$GITHUB_OUTPUT"
+            echo "provider=${{ steps.gemini-review.outputs.provider }}" >> "$GITHUB_OUTPUT"
+            echo "review_path=${{ steps.gemini-review.outputs.review_path }}" >> "$GITHUB_OUTPUT"
+            if [ -n "${{ steps.openrouter-review.outputs.fallback_reason }}" ]; then
+              echo "fallback_reason=${{ steps.openrouter-review.outputs.fallback_reason }}" >> "$GITHUB_OUTPUT"
+            else
+              echo "fallback_reason=" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+
+          if [ -n "${{ steps.gemini-review.outputs.status }}" ]; then
+            echo "status=${{ steps.gemini-review.outputs.status }}" >> "$GITHUB_OUTPUT"
+            echo "provider=${{ steps.gemini-review.outputs.provider }}" >> "$GITHUB_OUTPUT"
+            echo "fallback_reason=${{ steps.gemini-review.outputs.fallback_reason }}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -612,27 +481,17 @@ jobs:
             exit 0
           fi
 
-          if [ -n "${{ steps.openai-review.outputs.status }}" ]; then
-            echo "status=${{ steps.openai-review.outputs.status }}" >> "$GITHUB_OUTPUT"
-            echo "provider=${{ steps.openai-review.outputs.provider }}" >> "$GITHUB_OUTPUT"
-            echo "fallback_reason=${{ steps.openai-review.outputs.fallback_reason }}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           echo "status=failed" >> "$GITHUB_OUTPUT"
           echo "provider=none" >> "$GITHUB_OUTPUT"
           echo "fallback_reason=Nenhum provider de review automatizado estava configurado para este repositorio." >> "$GITHUB_OUTPUT"
 
-      - name: Publish Codex review status
+      - name: Publish review status
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}
         env:
           CODEX_REVIEW_ENABLED: ${{ steps.review-config.outputs.enabled }}
-          CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}
           GITHUB_TOKEN: ${{ github.token }}
-          COMMENTER_AVAILABLE: ${{ steps.commenter.outputs.available }}
-          COMMENTER_LOGIN: ${{ steps.commenter.outputs.login }}
-          OPENAI_PRESENT: ${{ steps.review-config.outputs.openai_present }}
           OPENROUTER_PRESENT: ${{ steps.review-config.outputs.openrouter_present }}
+          GEMINI_PRESENT: ${{ steps.review-config.outputs.gemini_present }}
           REVIEW_STATUS: ${{ steps.review-result.outputs.status }}
           REVIEW_PROVIDER: ${{ steps.review-result.outputs.provider }}
           REVIEW_PATH: ${{ steps.review-result.outputs.review_path }}
@@ -649,14 +508,8 @@ jobs:
           pr_sha=$(jq -r '.sha' "$PR_CONTEXT_DIR/pr.json")
           comments_url="${{ github.api_url }}/repos/${{ github.repository }}/issues/$pr_number/comments"
           comment_body_path="$RUNNER_TEMP/codex-review/final-comment.md"
-
-          if [ "${COMMENTER_AVAILABLE:-false}" = "true" ] && [ -n "${CODEX_REVIEW_PAT:-}" ]; then
-            auth_token="$CODEX_REVIEW_PAT"
-            expected_login="$COMMENTER_LOGIN"
-          else
-            auth_token="$GITHUB_TOKEN"
-            expected_login="github-actions[bot]"
-          fi
+          auth_token="$GITHUB_TOKEN"
+          expected_login="github-actions[bot]"
 
           render_template() {
             local template_path="$1"
@@ -672,19 +525,17 @@ jobs:
               printf '%s\n' "$marker"
               render_template "$readiness_template"
             } > "$comment_body_path"
-          elif [ "$OPENAI_PRESENT" != "true" ] && [ "$OPENROUTER_PRESENT" != "true" ]; then
+          elif [ "$OPENROUTER_PRESENT" != "true" ] && [ "$GEMINI_PRESENT" != "true" ]; then
             {
               printf '%s\n' "$marker"
-              printf '@codex review\n\n'
-              printf 'Codex review automation esta habilitada, mas nenhum provider automatizado esta configurado para este repositorio.\n\n'
-              printf 'Configure `OPENAI_API_KEY` ou o par `OPENROUTER_API_KEY` + `OPENROUTER_MODEL`.\n\n'
+              printf 'O review automatico complementar esta habilitado, mas nenhum provider automatizado esta configurado para este repositorio.\n\n'
+              printf 'Configure `OPENROUTER_API_KEY` + `OPENROUTER_MODEL` e/ou `GEMINI_API_KEY`.\n\n'
               printf 'Revisao humana continua obrigatoria.\n'
             } > "$comment_body_path"
           elif [ "$REVIEW_STATUS" = "completed" ] && [ -n "$REVIEW_PATH" ] && [ -f "$REVIEW_PATH" ]; then
             review_text=$(cat "$REVIEW_PATH")
             {
               printf '%s\n' "$marker"
-              printf '@codex review\n\n'
               printf 'Revisao automatica complementar concluida via %s para o commit %s.\n\n' "$REVIEW_PROVIDER" "$pr_sha"
               printf '%s\n\n' "$review_text"
               printf 'Esta revisao e advisory e nao substitui a revisao humana.\n'
@@ -692,7 +543,6 @@ jobs:
           else
             {
               printf '%s\n' "$marker"
-              printf '@codex review\n\n'
               render_template "$fallback_template"
             } > "$comment_body_path"
           fi
@@ -753,4 +603,178 @@ jobs:
           set -e
           if [ "$post_status" -ne 0 ]; then
             echo "Unable to create final status comment."
+          fi
+
+  manual-codex-review:
+    name: manual-codex-review
+    if: ${{ !github.event.pull_request.draft && github.event.action == 'labeled' && github.event.label.name == 'codex-review' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Skip fork pull requests
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          echo "Manual Codex review is skipped for fork pull requests to avoid exposing review automation to untrusted contexts."
+
+      - name: Check manual review configuration
+        id: manual-config
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        env:
+          CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${CODEX_REVIEW_PAT:-}" ]; then
+            echo "pat_present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pat_present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve commenter identity
+        id: commenter
+        if: ${{ !github.event.pull_request.head.repo.fork && steps.manual-config.outputs.pat_present == 'true' }}
+        env:
+          CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          response_path="$RUNNER_TEMP/codex-review/commenter.json"
+          mkdir -p "$(dirname "$response_path")"
+          http_status=$(
+            curl -s \
+              -o "$response_path" \
+              -w "%{http_code}" \
+              -H "Authorization: token ${CODEX_REVIEW_PAT}" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/user \
+              || true
+          )
+
+          if [ "$http_status" -ge 200 ] && [ "$http_status" -lt 300 ]; then
+            login=$(jq -r '.login // empty' "$response_path" 2>/dev/null || true)
+          else
+            login=""
+          fi
+
+          if [ -z "$login" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "login=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "available=true" >> "$GITHUB_OUTPUT"
+          echo "login=$login" >> "$GITHUB_OUTPUT"
+
+      - name: Collect pull request context
+        id: pr-context
+        if: ${{ !github.event.pull_request.head.repo.fork && steps.commenter.outputs.available == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          output_dir="$RUNNER_TEMP/codex-review"
+          pr_json_path="$output_dir/pr.json"
+          pr_number=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
+          pr_sha=$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")
+
+          mkdir -p "$output_dir"
+
+          jq -n \
+            --arg sha "$pr_sha" \
+            --argjson number "$pr_number" \
+            '{
+              sha: $sha,
+              number: $number
+            }' > "$pr_json_path"
+
+          echo "context_dir=$output_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Publish manual Codex trigger comment as maintainer
+        if: ${{ !github.event.pull_request.head.repo.fork && steps.commenter.outputs.available == 'true' }}
+        env:
+          CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}
+          COMMENTER_LOGIN: ${{ steps.commenter.outputs.login }}
+          PR_CONTEXT_DIR: ${{ steps.pr-context.outputs.context_dir }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          marker=$(cat "$GITHUB_WORKSPACE/.github/prompts/codex-comment-marker.txt")
+          pr_number=$(jq -r '.number' "$PR_CONTEXT_DIR/pr.json")
+          pr_sha=$(jq -r '.sha' "$PR_CONTEXT_DIR/pr.json")
+          comments_url="${{ github.api_url }}/repos/${{ github.repository }}/issues/$pr_number/comments"
+          comment_body_path="$RUNNER_TEMP/codex-review/manual-trigger-comment.md"
+
+          {
+            printf '%s\n' "$marker"
+            printf '@codex review\n\n'
+            printf 'Solicitacao manual de revisao premium do Codex para o commit %s via label `codex-review`.\n\n' "$pr_sha"
+            printf 'Foque em arquitetura, riscos, testes e seguranca.\n'
+          } > "$comment_body_path"
+
+          set +e
+          comments_payload=$(
+            curl -s \
+              -H "Authorization: Bearer $CODEX_REVIEW_PAT" \
+              -H "Accept: application/vnd.github+json" \
+              "$comments_url?per_page=100" \
+          )
+          comments_status=$?
+          set -e
+
+          if [ "$comments_status" -ne 0 ]; then
+            echo "Skipping manual Codex trigger comment update because GitHub comment listing failed."
+            exit 0
+          fi
+
+          existing_comment_id=$(
+            printf '%s' "$comments_payload" \
+              | jq -r --arg login "$COMMENTER_LOGIN" --arg marker "$marker" '
+                  .[]
+                  | select(.user.login == $login and ((.body // "") | contains($marker)))
+                  | .id
+                ' \
+              | head -n 1
+          )
+
+          if [ -n "$existing_comment_id" ]; then
+            set +e
+            jq -n --rawfile body "$comment_body_path" '{body: $body}' \
+              | curl -s -X PATCH \
+                  "${{ github.api_url }}/repos/${{ github.repository }}/issues/comments/$existing_comment_id" \
+                  -H "Authorization: Bearer $CODEX_REVIEW_PAT" \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Content-Type: application/json" \
+                  --data @- \
+                  > /dev/null
+            patch_status=$?
+            set -e
+            if [ "$patch_status" -ne 0 ]; then
+              echo "Skipping manual Codex trigger comment patch because GitHub patch request failed."
+            fi
+            exit 0
+          fi
+
+          set +e
+          jq -n --rawfile body "$comment_body_path" '{body: $body}' \
+            | curl -s -X POST \
+                "$comments_url" \
+                -H "Authorization: Bearer $CODEX_REVIEW_PAT" \
+                -H "Accept: application/vnd.github+json" \
+                -H "Content-Type: application/json" \
+                --data @- \
+                > /dev/null
+          post_status=$?
+          set -e
+          if [ "$post_status" -ne 0 ]; then
+            echo "Skipping manual Codex trigger comment creation because GitHub post request failed."
           fi

--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ O repositório possui um workflow advisory de review automatizado em `.github/wo
 Resumo do comportamento atual:
 1. Um pull request para `main` dispara o workflow.
 2. O workflow ignora PRs de fork e PRs draft.
-3. Se `CODEX_REVIEW_PAT` estiver valido, o comentario inicial `@codex review` e publicado como usuario real.
-4. O workflow tenta gerar um review automatizado via OpenAI.
-5. Se o caminho principal nao produzir um review utilizavel, entra o fallback via OpenRouter.
+3. O fluxo automatico tenta gerar um review complementar via OpenRouter.
+4. Se o caminho principal nao produzir um review utilizavel, entra o fallback via Gemini 2.5 Flash.
+5. Cada provider automatico tem um retry unico antes de o workflow passar para o proximo fallback.
 6. Se nenhum provider produzir conteudo publicavel, o workflow publica um comentario advisory explicando o motivo observado.
-7. Quando o PAT nao estiver disponivel, a publicacao final cai para `GITHUB_TOKEN`, preservando o comentario de status como `github-actions[bot]`.
+7. O comentario final do fluxo automatico sai sempre via `GITHUB_TOKEN`, preservando o bot como autor.
+8. O Codex fica reservado para o fluxo manual premium via `label codex-review`, com comentario publicado como usuario real quando `CODEX_REVIEW_PAT` estiver valido.
 
 Documentacao detalhada:
 - [Arquitetura do Codex Review](docs/architecture/codex-review.md)
@@ -193,16 +194,22 @@ pnpm --filter @forgeops/backend prisma:generate
 O `codex-review` usa configuracao de GitHub Actions, nao o `.env` local da aplicacao. As variaveis e segredos mais importantes sao:
 
 - `CODEX_REVIEW_PAT`
-  secret opcional para publicar comentarios como usuario real
+  secret opcional para publicar a solicitacao manual de `@codex review` como usuario real
 - `OPENROUTER_API_KEY`
-  secret para o provider de fallback
+  secret para o provider automatico primario
 - `OPENROUTER_MODEL`
   repository variable preferencial para o modelo da OpenRouter
+- `GEMINI_API_KEY`
+  secret preferencial para o fallback automatico via Gemini 2.5 Flash
+- `GOOGLE_API_KEY`
+  alias aceito para o fallback automatico via Gemini 2.5 Flash
+- `GEMINI_MODEL`
+  repository variable opcional; sem definicao explicita o workflow usa `gemini-2.5-flash`
 
 Observacoes:
-- o workflow tambem suporta `OPENAI_API_KEY` para o caminho principal de review automatizado
+- o fluxo automatico nao chama mais `@codex review`
 - por compatibilidade operacional, o workflow ainda aceita `CODEX_REVIEW_OPENROUTER_MODEL` como alias legado
-- sem `CODEX_REVIEW_PAT`, o comentario final continua sendo publicado via `GITHUB_TOKEN`
+- sem `CODEX_REVIEW_PAT`, o fluxo automatico continua funcionando e comentando como bot; apenas o gatilho manual do Codex fica indisponivel
 
 ## Testes e validacoes
 

--- a/docs/architecture/codex-review.md
+++ b/docs/architecture/codex-review.md
@@ -2,47 +2,51 @@
 
 ## Objetivo
 
-O `codex-review` e um workflow advisory de revisao automatizada para pull requests do ForgeOps. Ele existe para ampliar a revisao humana com sinais tecnicos sobre risco, escopo, testes, seguranca e fronteiras arquiteturais.
-
-O workflow nao bloqueia merge por si so e nao modifica conteudo do repositório.
+O `codex-review` e um workflow advisory de revisao automatizada para pull requests do ForgeOps. Ele amplia a revisao humana com sinais tecnicos sobre risco, escopo, testes, seguranca e fronteiras arquiteturais, mas nao bloqueia merge nem modifica conteudo do repositorio.
 
 ## Fluxo completo
 
 1. Um PR nao-draft e aberto, atualizado ou marcado como pronto para review contra `main`.
 2. O workflow `codex-review` dispara no GitHub Actions.
 3. PRs de fork sao ignorados para nao expor automacao a contexto nao confiavel.
-4. O workflow resolve a configuracao de review:
+4. O workflow resolve a configuracao automatica:
    - `CODEX_REVIEW_ENABLED`
-   - `CODEX_REVIEW_PAT`
-   - `OPENAI_API_KEY`
    - `OPENROUTER_API_KEY`
    - `OPENROUTER_MODEL`
-5. Se `CODEX_REVIEW_PAT` estiver disponivel e valido, o comentario inicial `@codex review` e publicado como usuario real.
-6. O workflow coleta contexto do PR:
+   - `GEMINI_API_KEY` ou `GOOGLE_API_KEY`
+   - `GEMINI_MODEL`
+5. O workflow coleta contexto do PR:
    - titulo
    - corpo
    - SHA
    - diff unificado
-7. O workflow tenta gerar um review automatizado via OpenAI.
-8. Se a resposta da OpenAI nao for utilizavel, entra o fallback via OpenRouter.
-9. Se nenhum provider gerar texto publicavel, o workflow publica um comentario advisory explicando o motivo observado.
-10. O comentario final sempre e tentado em PRs nao-fork:
-   - com `CODEX_REVIEW_PAT` quando o commenter autenticado estiver disponivel
-   - com `GITHUB_TOKEN` quando o PAT estiver ausente ou invalido
+6. O review automatizado tenta OpenRouter como provider primario.
+7. Se OpenRouter falhar ou nao gerar conteudo publicavel, o workflow faz um retry unico.
+8. Se ainda assim nao houver saida utilizavel, o workflow tenta Gemini 2.5 Flash.
+9. Se Gemini falhar ou nao gerar conteudo publicavel, o workflow faz um retry unico.
+10. Se nenhum provider gerar texto publicavel, o workflow publica um comentario advisory explicando o motivo observado.
+11. O comentario final do fluxo automatico sempre e publicado via `GITHUB_TOKEN`, preservando o bot como autor.
+12. O Codex fica reservado para o fluxo manual premium:
+    - o usuario aplica a label `codex-review`
+    - o workflow publica `@codex review` como usuario real quando `CODEX_REVIEW_PAT` estiver disponivel e valido
 
 ## Decisoes arquiteturais
 
-### PAT opcional para comentario como usuario
+### Codex fora do fluxo automatico
 
-`CODEX_REVIEW_PAT` nao e requisito para o workflow funcionar. Ele existe para melhorar a experiencia operacional, permitindo que o comentario inicial e, quando possivel, o comentario final sejam publicados como usuario real.
+O Codex nao roda mais automaticamente no review padrao. Isso reduz custo e mantem o fluxo automatico com providers mais baratos antes do fallback advisory.
+
+### PAT opcional para fluxo manual premium
+
+`CODEX_REVIEW_PAT` nao e requisito para o fluxo automatico funcionar. Ele existe para permitir o gatilho manual premium do Codex por label, sempre como usuario real.
 
 Sem PAT valido:
-- o trigger como usuario pode nao ocorrer
-- o comentario final continua sendo publicado como bot via `GITHUB_TOKEN`
+- o fluxo automatico continua publicando como bot via `GITHUB_TOKEN`
+- o gatilho manual de `@codex review` por label fica indisponivel
 
 ### Fallback para `GITHUB_TOKEN`
 
-O comentario final nao depende do PAT. Isso evita:
+O comentario final do fluxo automatico nao depende do PAT. Isso evita:
 - falha silenciosa em caso de token invalido
 - ausencia de comentario de status
 - divergencia entre comportamento real e expectativa operacional
@@ -66,24 +70,33 @@ As instrucoes e mensagens do workflow ficam em `.github/prompts/` para manter:
 
 Ordem de tentativa atual:
 
-1. Codex disparado por comentario `@codex review`
-2. Review automatizado via OpenAI
-3. Review automatizado via OpenRouter
-4. Comentario final de fallback humano
+1. OpenRouter
+2. Retry unico via OpenRouter
+3. Gemini 2.5 Flash
+4. Retry unico via Gemini 2.5 Flash
+5. Comentario final advisory
+6. Codex manual por `label codex-review`
 
 Isso permite combinar:
-- review nativo do Codex no GitHub
-- review automatizado por API
+- review automatizado de baixo custo por API
 - transparencia quando nenhum caminho produz saida util
+- Codex reservado para revisoes manuais de maior valor
 
 ## Criterios de utilidade do review automatizado
 
 O workflow tenta validar se a resposta:
 - contem texto publicavel
-- parece estar em portugues do Brasil
 - aborda risco tecnico de forma utilizavel
 
-Quando a saida falha nesses criterios, ela e tratada como invalida e o fluxo segue para o fallback seguinte.
+Idioma passa a ser criterio brando:
+- portugues do Brasil continua preferencial
+- ingles tecnico pontual nao invalida um review util
+
+Falha dura acontece apenas quando houver:
+- erro real de API
+- resposta vazia
+- parse invalido
+- conteudo claramente nao publicavel
 
 ## Riscos operacionais
 
@@ -100,6 +113,7 @@ Impacto:
 
 Mitigacao:
 - fallback entre providers
+- retry unico por provider
 - comentario final com motivo observado
 - manutencao do modo advisory
 
@@ -109,9 +123,9 @@ O shape da resposta da API pode variar. Se o parser nao extrair texto util:
 - o workflow nao falha por isso
 - o comentario final informa que nao houve conteudo publicavel
 
-### Erro de autenticacao
+### Erro de autenticacao do PAT
 
-Falhas em `CODEX_REVIEW_PAT` nao devem impedir a publicacao final. O sistema degrada para `GITHUB_TOKEN` quando necessario.
+Falhas em `CODEX_REVIEW_PAT` nao devem impedir o fluxo automatico. O sistema continua comentando como bot e so perde o gatilho manual premium.
 
 ## Fronteiras de seguranca
 

--- a/docs/guides/debug-codex-review.md
+++ b/docs/guides/debug-codex-review.md
@@ -9,12 +9,16 @@ Este guia ajuda a diagnosticar falhas no workflow `codex-review`.
 3. Identifique o run correspondente ao PR.
 4. Revise os steps nesta ordem:
    - `Check review configuration`
-   - `Resolve commenter identity`
    - `Collect pull request context`
-   - `Run automated review via OpenAI API`
-   - `Run automated review via OpenRouter fallback`
+   - `Run automated review via OpenRouter`
+   - `Run automated review via Gemini fallback`
    - `Resolve review result`
-   - `Publish Codex review status`
+   - `Publish review status`
+
+Se o gatilho manual premium foi acionado por label, revise:
+- `Check manual review configuration`
+- `Resolve commenter identity`
+- `Publish manual Codex trigger comment as maintainer`
 
 ## Perguntas de diagnostico
 
@@ -24,34 +28,23 @@ Confirme:
 - o PR aponta para `main`
 - o PR nao esta em draft
 - nao se trata de fork
+- no fluxo manual, a label aplicada foi exatamente `codex-review`
 
-### O comentario inicial foi publicado?
+### O comentario automatico final apareceu?
 
-Se o comentario `@codex review` nao apareceu como usuario real:
+Se nao apareceu:
+- verifique o step `Publish review status`
+- confirme se houve erro de listagem, patch ou post de comentario
+- confirme que o run nao foi cancelado antes do step final
+
+### O comentario manual `@codex review` apareceu?
+
+Se o comentario manual nao apareceu como usuario real:
 - verifique `CODEX_REVIEW_PAT`
 - verifique o step `Resolve commenter identity`
 - confirme que o PAT tem permissao suficiente para ler PRs e comentar em issues
 
-### O comentario final apareceu?
-
-Se nao apareceu:
-- verifique o step `Publish Codex review status`
-- confirme se houve erro de listagem, patch ou post de comentario
-- confirme que o run nao foi cancelado antes do step final
-
 ## Como validar API keys
-
-### OpenAI
-
-Sinais de problema:
-- HTTP 401
-- HTTP 429
-- payload com erro de quota
-
-Conferencias:
-- o secret `OPENAI_API_KEY` existe no repositório
-- a chave possui quota ativa
-- nao houve revogacao ou expiracao
 
 ### OpenRouter
 
@@ -66,17 +59,53 @@ Conferencias:
 - a variable `OPENROUTER_MODEL` existe
 - o modelo configurado esta disponivel no provider
 
+### Gemini
+
+Sinais de problema:
+- HTTP 401 ou 403
+- payload com `.error`
+- resposta sem `candidates`
+- `GEMINI_API_KEY` e `GOOGLE_API_KEY` ausentes
+
+Conferencias:
+- o secret `GEMINI_API_KEY` ou `GOOGLE_API_KEY` existe
+- a variable `GEMINI_MODEL` esta valida quando definida
+- o modelo configurado esta disponivel no provider
+
 ## Como interpretar logs do GitHub Actions
 
 ### `Check review configuration`
 
 Mostra se o workflow detectou:
 - `enabled`
-- `pat_present`
-- `openai_present`
 - `openrouter_present`
+- `gemini_present`
 
-Se `openrouter_present=false`, o fallback OpenRouter nao sera tentado.
+Se ambos forem `false`, o workflow cai direto em comentario advisory.
+
+### `Run automated review via OpenRouter`
+
+Possiveis saidas:
+- `status=completed`
+- `status=failed`
+
+Os logs distinguem:
+- erro de chamada
+- HTTP nao-2xx
+- payload sem conteudo publicavel
+- retry unico antes do fallback
+
+### `Run automated review via Gemini fallback`
+
+Possiveis saidas:
+- `status=completed`
+- `status=failed`
+
+Os logs distinguem:
+- erro de chamada
+- HTTP nao-2xx
+- payload sem `candidates`
+- retry unico antes do advisory final
 
 ### `Resolve commenter identity`
 
@@ -85,59 +114,47 @@ Verifique:
 - se `available=true`
 - se o login foi resolvido
 
-Se `available=false`, o comentario final ainda deve cair para `GITHUB_TOKEN`.
-
-### `Run automated review via OpenAI API`
-
-Possiveis saidas:
-- `status=completed`
-- `status=failed`
-- `status=no_usable_output`
-
-### `Run automated review via OpenRouter fallback`
-
-Possiveis saidas:
-- `status=completed`
-- `status=failed`
-- `status=no_usable_output`
-
-Os logs tambem costumam ajudar a distinguir:
-- ausencia de `choices`
-- ausencia de `message.content`
-- payload de erro do provider
+Se `available=false`, o fluxo manual premium nao conseguira publicar `@codex review`.
 
 ## Cenarios comuns
 
-### `insufficient_quota`
+### OpenRouter indisponivel
 
-Sinal:
-- status HTTP 429 ou mensagem de quota insuficiente
+Sinais:
+- erro de rede
+- HTTP 401, 403 ou 429
+- payload com `.error`
 
-Leitura:
-- autenticacao pode estar correta
-- o problema e billing/quota do provider
+Comportamento esperado:
+- retry unico
+- fallback para Gemini
 
-Acao:
-- renovar quota
-- usar provider alternativo
-- confirmar se o comentario final reportou o motivo observado
+### Gemini indisponivel
+
+Sinais:
+- erro de rede
+- HTTP 401, 403 ou 429
+- payload com `.error`
+
+Comportamento esperado:
+- retry unico
+- comentario advisory final se OpenRouter tambem nao tiver produzido review
 
 ### PAT invalido
 
 Sinais:
 - `Resolve commenter identity` nao encontra login
-- comentario inicial como usuario nao aparece
+- comentario manual `@codex review` nao aparece como usuario real
 
 Comportamento esperado:
-- o comentario final ainda deve ser publicado como bot
-
-Se isso nao ocorrer, o problema esta no path final de publicacao.
+- o fluxo automatico continua publicando como bot
+- apenas o gatilho manual premium fica indisponivel
 
 ### Parsing vazio
 
 Sinais:
-- `status=no_usable_output`
 - logs mostrando payload sem texto publicavel
+- transicao para retry unico e depois para o fallback seguinte
 
 Acao:
 - revisar prompt versionado em `.github/prompts/`
@@ -149,10 +166,10 @@ Acao:
 1. Confirmar que o workflow realmente disparou.
 2. Confirmar que o PR nao era fork nem draft.
 3. Verificar configuracao detectada no step inicial.
-4. Verificar se OpenAI respondeu.
-5. Verificar se OpenRouter respondeu.
-6. Confirmar se o comentario final foi publicado.
-7. Validar se o motivo observado no comentario final bate com os logs.
+4. Verificar se OpenRouter respondeu e se houve retry.
+5. Verificar se Gemini respondeu e se houve retry.
+6. Confirmar se o comentario final foi publicado pelo bot.
+7. Se houve label manual, confirmar se `@codex review` foi publicado pelo usuario correto.
 
 ## Documentacao relacionada
 

--- a/docs/workflows/codex-review.md
+++ b/docs/workflows/codex-review.md
@@ -3,10 +3,10 @@
 ## Objetivo
 
 O workflow `codex-review` adiciona uma camada advisory de revisao automatizada sobre pull requests para `main`, combinando:
-- comentario de trigger para o Codex
-- tentativa de review automatizado por API
-- fallback de provider
+- review automatizado barato por API
+- fallback entre providers
 - comentario final transparente quando nenhum review util e produzido
+- gatilho manual premium do Codex por label
 
 ## Quando dispara
 
@@ -18,6 +18,7 @@ Eventos:
 - `synchronize`
 - `reopened`
 - `ready_for_review`
+- `labeled`
 
 Restricoes:
 - apenas para PRs contra `main`
@@ -41,9 +42,11 @@ Esse conjunto permite:
 ### Variaveis de repositorio
 
 - `CODEX_REVIEW_ENABLED`
-  liga ou desliga a automacao
+  liga ou desliga o review automatico
 - `OPENROUTER_MODEL`
   modelo preferencial da OpenRouter
+- `GEMINI_MODEL`
+  modelo preferencial da Gemini; sem definicao explicita o workflow usa `gemini-2.5-flash`
 
 Compatibilidade:
 - `CODEX_REVIEW_OPENROUTER_MODEL` ainda e aceito como alias legado
@@ -51,24 +54,31 @@ Compatibilidade:
 ### Secrets
 
 - `CODEX_REVIEW_PAT`
-  opcional, para comentar como usuario real
-- `OPENAI_API_KEY`
-  provider principal de review automatizado
+  opcional, para publicar `@codex review` como usuario real no fluxo manual
 - `OPENROUTER_API_KEY`
-  provider de fallback
+  provider automatico primario
+- `GEMINI_API_KEY`
+  provider automatico secundario
+- `GOOGLE_API_KEY`
+  alias aceito para o fallback Gemini
 
 ## Cadeia de fallback
 
-O workflow segue esta ordem:
+O fluxo automatico segue esta ordem:
 
-1. comentario inicial `@codex review` como usuario real, se `CODEX_REVIEW_PAT` estiver disponivel
-2. review automatizado via OpenAI
-3. review automatizado via OpenRouter
-4. comentario final de fallback humano
+1. OpenRouter
+2. retry unico via OpenRouter
+3. Gemini 2.5 Flash
+4. retry unico via Gemini 2.5 Flash
+5. comentario final advisory
 
-Comentario final:
-- com PAT valido: como usuario real
-- sem PAT valido: via `GITHUB_TOKEN` como bot
+Comentario final do fluxo automatico:
+- sempre via `GITHUB_TOKEN`
+- sempre como bot
+
+Fluxo manual premium:
+- aplicar `label codex-review`
+- publicar `@codex review` como usuario real, se `CODEX_REVIEW_PAT` estiver disponivel
 
 ## Comportamento em fork PR
 
@@ -80,50 +90,61 @@ Motivo:
 
 ## Estrutura de alto nivel do job
 
-1. Checkout do repositório
+### Fluxo automatico
+
+1. Checkout do repositorio
 2. Skip de fork PR
 3. Check de configuracao
-4. Resolucao opcional do commenter autenticado
-5. Coleta do contexto do PR e diff
-6. Publicacao do trigger `@codex review`
-7. Tentativa via OpenAI
-8. Fallback via OpenRouter
+4. Coleta do contexto do PR e diff
+5. Tentativa via OpenRouter
+6. Retry unico via OpenRouter, se necessario
+7. Fallback via Gemini
+8. Retry unico via Gemini, se necessario
 9. Resolucao do resultado final
-10. Publicacao do comentario final
+10. Publicacao do comentario final pelo bot
+
+### Fluxo manual por label
+
+1. Checkout do repositorio
+2. Skip de fork PR
+3. Check de `CODEX_REVIEW_PAT`
+4. Resolucao do commenter autenticado
+5. Publicacao de `@codex review` como usuario real
 
 ## O que o workflow publica
 
-### Trigger comment
-
-Quando possivel, publica:
-- `@codex review`
-- instrucao de resposta em portugues do Brasil
-- foco em arquitetura, riscos e testes
-
-### Final comment
+### Comentario final automatico
 
 Pode publicar:
 - review automatizado complementar
 - comentario de readiness/advisory
 - fallback explicando o motivo observado
 
+### Comentario manual premium
+
+Quando possivel, publica:
+- `@codex review`
+- contexto curto de solicitacao manual
+- foco em arquitetura, riscos, testes e seguranca
+
 ## Falhas esperadas e degradacao
 
 O workflow e desenhado para degradar sem quebrar o PR:
 
-- PAT ausente ou invalido
-  comentario final deve continuar
-- OpenAI indisponivel
-  tenta OpenRouter
 - OpenRouter indisponivel
-  cai em fallback humano
+  tenta retry unico e depois Gemini
+- Gemini indisponivel
+  tenta retry unico e depois cai em advisory
 - parsing sem texto util
-  publica comentario com motivo observado
+  tenta retry unico e depois passa para o proximo fallback
+- `CODEX_REVIEW_PAT` ausente ou invalido
+  o fluxo automatico continua; apenas o gatilho manual do Codex fica indisponivel
 
 ## Arquivos relacionados
 
 - workflow principal: `.github/workflows/codex-review.yml`
 - smoke coverage: `.github/workflows/codex-review-smoke.yml`
+- smoke logic: `.github/scripts/codex-review-smoke.sh`
 - prompt principal: `.github/prompts/codex-review.md`
 - fallback message: `.github/prompts/codex-fallback.md`
 - readiness message: `.github/prompts/codex-readiness.md`


### PR DESCRIPTION
## Resumo
Reorganiza o fluxo de review automatizado para usar providers de menor custo antes do fallback advisory e remove o Codex do caminho automatico padrao. Tambem reserva o Codex para o gatilho manual por `label codex-review`, preservando o bot como autor do comentario automatico.

## O que foi alterado
- Reorquestra o workflow `.github/workflows/codex-review.yml` para executar OpenRouter como provider automatico primario, Gemini 2.5 Flash como fallback automatico secundario e advisory como ultimo estagio.
- Remove a chamada automatica do comando manual do Codex e fixa o comentario final automatico em `github-actions[bot]`.
- Adiciona retry unico por provider e relaxa a validacao de idioma para criterio brando de qualidade.
- Adiciona o caminho manual premium por `label codex-review`, publicando o comentario manual do Codex como usuario real quando `CODEX_REVIEW_PAT` estiver disponivel.
- Atualiza smoke coverage, prompts e documentacao para refletir o novo contrato do fluxo automatico e manual.

## Motivacao
O fluxo automatico anterior misturava providers mais caros com o gatilho do Codex e usava validacao de idioma mais rigida do que o necessario para reviews advisory uteis. Esta mudanca reduz custo operacional, preserva resiliencia do review automatico e deixa o Codex reservado para acionamento manual de maior valor.

## Como validar
- Executar o smoke script em cenarios representativos:
  - `bash --noprofile --norc -lc 'cd /c/Github/forge-ops && SCENARIO=automatic_happy_path MODE=automatic FORK_PR=false CODEX_REVIEW_ENABLED=true PAT_AVAILABLE=true OPENROUTER_PRESENT=true OPENROUTER_RESULT=completed GEMINI_PRESENT=true GEMINI_RESULT=completed ./.github/scripts/codex-review-smoke.sh'`
  - `bash --noprofile --norc -lc 'cd /c/Github/forge-ops && SCENARIO=openrouter_fallback_to_gemini MODE=automatic FORK_PR=false CODEX_REVIEW_ENABLED=true PAT_AVAILABLE=true OPENROUTER_PRESENT=true OPENROUTER_RESULT=failed GEMINI_PRESENT=true GEMINI_RESULT=completed ./.github/scripts/codex-review-smoke.sh'`
  - `bash --noprofile --norc -lc 'cd /c/Github/forge-ops && SCENARIO=manual_codex_label MODE=manual FORK_PR=false PAT_AVAILABLE=true LABEL_NAME=codex-review ./.github/scripts/codex-review-smoke.sh'`
  - `bash --noprofile --norc -lc 'cd /c/Github/forge-ops && SCENARIO=providers_unavailable MODE=automatic FORK_PR=false CODEX_REVIEW_ENABLED=true PAT_AVAILABLE=true OPENROUTER_PRESENT=false OPENROUTER_RESULT=failed GEMINI_PRESENT=false GEMINI_RESULT=failed ./.github/scripts/codex-review-smoke.sh'`
- Validar sintaxe YAML:
  - `python -c "from pathlib import Path; import yaml; [yaml.safe_load(Path(p).read_text(encoding='utf-8')) for p in ['.github/workflows/codex-review.yml', '.github/workflows/codex-review-smoke.yml']]"`
- Executar `git diff --check`.

## Riscos e impactos
- O fluxo automatico passa a depender de configuracao de `GEMINI_API_KEY` ou `GOOGLE_API_KEY` para o segundo provider; sem isso, o workflow cai diretamente em advisory apos OpenRouter.
- O gatilho manual por label depende de `CODEX_REVIEW_PAT`; sem PAT valido, o caminho premium nao publica o comentario manual do Codex.
- O fluxo automatico deixa de publicar o comando manual do Codex, o que altera a expectativa operacional de quem acompanhava o comportamento anterior.

## Evidencias
- `git diff --check` sem erros.
- Parsing YAML bem-sucedido para `.github/workflows/codex-review.yml` e `.github/workflows/codex-review-smoke.yml`.
- Smoke local validado para caminho feliz, fallback OpenRouter -> Gemini, advisory sem providers e gatilho manual por label.

## Checklist
- [x] Alteracao limitada ao objetivo da PR
- [x] Sem mudancas desconexas
- [x] Impactos principais descritos
- [x] Validacao documentada
- [x] Riscos identificados

Closes #129