### PR TITLE
feat(ui): adiciona solicitação manual de review do Codex

### DIFF
--- a/backend/src/modules/github/github-app.boundary.ts
+++ b/backend/src/modules/github/github-app.boundary.ts
@@ -99,6 +99,10 @@ export interface GitHubAppBoundary {
     repository: GitHubRepositoryDescriptor,
     pullRequestNumber: number,
   ): Promise<GitHubPullRequestReviewCommentDescriptor[]>;
+  requestPullRequestCodexReview?(
+    repository: GitHubRepositoryDescriptor,
+    pullRequestNumber: number,
+  ): Promise<void>;
 }
 
 export interface GitHubAppStatus {

--- a/backend/src/modules/github/github-app.errors.ts
+++ b/backend/src/modules/github/github-app.errors.ts
@@ -54,6 +54,17 @@ export class GitHubPullRequestReviewSyncError extends ApplicationError {
   }
 }
 
+export class GitHubPullRequestReviewRequestError extends ApplicationError {
+  constructor(details: ApplicationErrorDetails | null = null) {
+    super(
+      'GitHub manual Codex review request is currently unavailable.',
+      503,
+      'github_pull_request_review_request_unavailable',
+      details,
+    );
+  }
+}
+
 export class GitHubWebhookVerificationError extends ApplicationError {
   constructor() {
     super(

--- a/backend/src/modules/github/providers/github-app.provider.ts
+++ b/backend/src/modules/github/providers/github-app.provider.ts
@@ -17,6 +17,7 @@ import { ConfigurationError } from '../../../shared/errors/configuration-error.j
 import {
   GitHubRepositoryDiscoveryError,
   GitHubPullRequestSyncError,
+  GitHubPullRequestReviewRequestError,
   GitHubPullRequestReviewSyncError,
   GitHubWorkflowCatalogSyncError,
   GitHubWorkflowRunsSyncError,
@@ -125,11 +126,18 @@ const githubPullRequestReviewCommentsSchema = z.array(
   }),
 );
 
+const githubIssueLabelsSchema = z.array(
+  z.object({
+    name: z.string().trim().min(1),
+  }),
+);
+
 const GITHUB_API_VERSION = '2022-11-28';
 const DEFAULT_GITHUB_API_BASE_URL = 'https://api.github.com';
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_GITHUB_ERROR_MESSAGE = 'GitHub request failed.';
 const MAX_GITHUB_ERROR_MESSAGE_LENGTH = 200;
+const MANUAL_CODEX_REVIEW_LABEL = 'codex-review';
 
 export interface GitHubAppProviderOptions {
   apiBaseUrl?: string;
@@ -396,6 +404,45 @@ export class GitHubAppProvider implements GitHubAppBoundary {
       }
 
       throw new GitHubPullRequestReviewSyncError();
+    }
+  }
+
+  public async requestPullRequestCodexReview(
+    repository: GitHubRepositoryDescriptor,
+    pullRequestNumber: number,
+  ): Promise<void> {
+    this.assertConfigured();
+
+    try {
+      const installationToken = await this.createInstallationAccessToken();
+
+      await this.requestJson(
+        `${this.apiBaseUrl}/repos/${repository.owner}/${repository.name}/issues/${pullRequestNumber}/labels`,
+        {
+          method: 'POST',
+          headers: {
+            ...this.createJsonHeaders(`Bearer ${installationToken}`),
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            labels: [MANUAL_CODEX_REVIEW_LABEL],
+          }),
+        },
+        githubIssueLabelsSchema,
+      );
+    } catch (error) {
+      if (
+        error instanceof ConfigurationError ||
+        error instanceof GitHubPullRequestReviewRequestError
+      ) {
+        throw error;
+      }
+
+      if (error instanceof GitHubApiRequestError) {
+        throw new GitHubPullRequestReviewRequestError(error.details);
+      }
+
+      throw new GitHubPullRequestReviewRequestError();
     }
   }
 

--- a/backend/src/modules/pull-request-insights/pull-request.controller.ts
+++ b/backend/src/modules/pull-request-insights/pull-request.controller.ts
@@ -4,6 +4,7 @@ import type { ForgeOpsFastifyInstance } from '../../app/register-routes.js';
 import type { PullRequest } from './pull-request.entity.js';
 import type {
   PullRequestDetail,
+  PullRequestCodexReviewRequest,
   PullRequestService,
 } from './pull-request.service.js';
 
@@ -83,6 +84,19 @@ interface GetPullRequestDetailRoute extends RouteGenericInterface {
   Reply: PullRequestDetailResponse;
 }
 
+interface RequestPullRequestCodexReviewRoute extends RouteGenericInterface {
+  Params: {
+    repositoryId: string;
+    pullRequestId: string;
+  };
+  Reply: {
+    pullRequestId: string;
+    pullRequestNumber: number;
+    label: 'codex-review';
+    status: 'requested';
+  };
+}
+
 const toPullRequestResponse = (pullRequest: PullRequest): PullRequestResponse => {
   return {
     id: pullRequest.id,
@@ -125,6 +139,17 @@ const toPullRequestDetailResponse = (
   };
 };
 
+const toPullRequestCodexReviewRequestResponse = (
+  request: PullRequestCodexReviewRequest,
+) => {
+  return {
+    pullRequestId: request.pullRequestId,
+    pullRequestNumber: request.pullRequestNumber,
+    label: request.label,
+    status: request.status,
+  };
+};
+
 export const registerPullRequestRoutes = (
   app: ForgeOpsFastifyInstance,
   pullRequestService: PullRequestService,
@@ -163,6 +188,29 @@ export const registerPullRequestRoutes = (
       );
 
       return toPullRequestDetailResponse(detail);
+    },
+  );
+
+  app.post<RequestPullRequestCodexReviewRoute>(
+    '/api/v1/repositories/:repositoryId/pull-requests/:pullRequestId/codex-review-request',
+    {
+      config: {
+        access: 'protected',
+        requiredCapability: 'repositories:write',
+      },
+    },
+    async (request, reply) => {
+      const { repositoryId, pullRequestId } = pullRequestDetailParamsSchema.parse(
+        request.params,
+      );
+      const codexReviewRequest = await pullRequestService.requestCodexReviewById(
+        repositoryId,
+        pullRequestId,
+      );
+
+      return reply
+        .code(202)
+        .send(toPullRequestCodexReviewRequestResponse(codexReviewRequest));
     },
   );
 };

--- a/backend/src/modules/pull-request-insights/pull-request.service.ts
+++ b/backend/src/modules/pull-request-insights/pull-request.service.ts
@@ -57,6 +57,15 @@ export interface PullRequestDetail {
   }>;
 }
 
+export interface PullRequestCodexReviewRequest {
+  pullRequestId: string;
+  pullRequestNumber: number;
+  label: 'codex-review';
+  status: 'requested';
+}
+
+const MANUAL_CODEX_REVIEW_LABEL = 'codex-review' as const;
+
 export class PullRequestService {
   constructor(private readonly options: PullRequestServiceOptions) {}
 
@@ -155,6 +164,77 @@ export class PullRequestService {
           finishedAt: workflow.finishedAt,
         })),
     };
+  }
+
+  async requestCodexReviewById(
+    repositoryId: string,
+    pullRequestId: string,
+  ): Promise<PullRequestCodexReviewRequest> {
+    const repository =
+      await this.options.repositoryRegistryRepository.findById(repositoryId);
+
+    if (!repository) {
+      throw new RepositoryNotFoundError();
+    }
+
+    const pullRequest = await this.options.pullRequestRepository.findById(
+      pullRequestId,
+    );
+
+    if (!pullRequest || pullRequest.repositoryId !== repositoryId) {
+      throw new PullRequestNotFoundError();
+    }
+
+    const requestPullRequestCodexReview =
+      this.options.githubBoundary.requestPullRequestCodexReview;
+
+    if (!requestPullRequestCodexReview) {
+      throw new Error('GitHub manual review requests are not configured.');
+    }
+
+    try {
+      await requestPullRequestCodexReview(
+        {
+          owner: repository.owner,
+          name: repository.name,
+        },
+        pullRequest.number,
+      );
+
+      this.logger.info(
+        {
+          event: 'pull_request_codex_review_requested',
+          repositoryId: repository.id,
+          fullName: repository.fullName,
+          pullRequestId: pullRequest.id,
+          githubPrNumber: pullRequest.number,
+          reviewLabel: MANUAL_CODEX_REVIEW_LABEL,
+        },
+        'Manual Codex review request submitted.',
+      );
+
+      return {
+        pullRequestId: pullRequest.id,
+        pullRequestNumber: pullRequest.number,
+        label: MANUAL_CODEX_REVIEW_LABEL,
+        status: 'requested',
+      };
+    } catch (error) {
+      this.logger.error(
+        {
+          event: 'pull_request_codex_review_request_failed',
+          repositoryId: repository.id,
+          fullName: repository.fullName,
+          pullRequestId: pullRequest.id,
+          githubPrNumber: pullRequest.number,
+          reviewLabel: MANUAL_CODEX_REVIEW_LABEL,
+          ...serializeApplicationError(error),
+        },
+        'Manual Codex review request failed.',
+      );
+
+      throw error;
+    }
   }
 
   async syncByRepositoryId(repositoryId: string): Promise<PullRequest[]> {

--- a/backend/src/tests/app/create-server.test.ts
+++ b/backend/src/tests/app/create-server.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createServer } from '../../app/create-server.js';
 import {
   GitHubRepositoryDiscoveryError,
@@ -179,6 +179,10 @@ const createProtectedServer = (overrides?: {
     state: Workflow['state'];
     sourceType: Workflow['sourceType'];
   }>;
+  requestPullRequestCodexReview?: (
+    repository: { owner: string; name: string },
+    pullRequestNumber: number,
+  ) => Promise<void>;
   capabilities?: string[];
 }) => {
   const repositoryStore = [...(overrides?.repositories ?? [])];
@@ -253,6 +257,8 @@ const createProtectedServer = (overrides?: {
       listWorkflowRunJobs: async () => [],
       listPullRequests: async () => [],
       listPullRequestReviewComments: async () => [],
+      requestPullRequestCodexReview:
+        overrides?.requestPullRequestCodexReview ?? (async () => undefined),
     },
     repositoryRegistryRepository: {
       list: async () => [...repositoryStore],
@@ -1918,6 +1924,88 @@ describe('createServer', () => {
       },
       workflows: [],
     });
+
+    await server.close();
+  });
+
+  it('should require authentication for manual Codex review requests', async () => {
+    const server = createProtectedServer({
+      repositories: [buildRepository()],
+      pullRequests: [buildPullRequest()],
+    });
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/v1/repositories/repo_123/pull-requests/pr_123/codex-review-request',
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'authentication_required',
+        message: 'Authentication is required.',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should require repositories:write to request a manual Codex review', async () => {
+    const server = createProtectedServer({
+      repositories: [buildRepository()],
+      pullRequests: [buildPullRequest()],
+      capabilities: ['repositories:read'],
+    });
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/v1/repositories/repo_123/pull-requests/pr_123/codex-review-request',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'forbidden',
+        message: 'You are not allowed to perform this action.',
+      },
+    });
+
+    await server.close();
+  });
+
+  it('should request a manual Codex review by applying the codex-review label', async () => {
+    const requestPullRequestCodexReview = vi.fn().mockResolvedValue(undefined);
+    const server = createProtectedServer({
+      repositories: [buildRepository()],
+      pullRequests: [buildPullRequest()],
+      requestPullRequestCodexReview,
+    });
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/v1/repositories/repo_123/pull-requests/pr_123/codex-review-request',
+      headers: {
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(202);
+    expect(response.json()).toEqual({
+      pullRequestId: 'pr_123',
+      pullRequestNumber: 42,
+      label: 'codex-review',
+      status: 'requested',
+    });
+    expect(requestPullRequestCodexReview).toHaveBeenCalledWith(
+      {
+        owner: 'forgeops',
+        name: 'backend',
+      },
+      42,
+    );
 
     await server.close();
   });

--- a/docs/architecture/codex-review.md
+++ b/docs/architecture/codex-review.md
@@ -14,35 +14,37 @@ O workflow nao bloqueia merge por si so e nao modifica conteudo do repositório.
 4. O workflow resolve a configuracao de review:
    - `CODEX_REVIEW_ENABLED`
    - `CODEX_REVIEW_PAT`
-   - `OPENAI_API_KEY`
    - `OPENROUTER_API_KEY`
+   - `GEMINI_API_KEY` ou `GOOGLE_API_KEY`
    - `OPENROUTER_MODEL`
-5. Se `CODEX_REVIEW_PAT` estiver disponivel e valido, o comentario inicial `@codex review` e publicado como usuario real.
-6. O workflow coleta contexto do PR:
+5. O workflow coleta contexto do PR:
    - titulo
    - corpo
    - SHA
    - diff unificado
-7. O workflow tenta gerar um review automatizado via OpenAI.
-8. Se a resposta da OpenAI nao for utilizavel, entra o fallback via OpenRouter.
-9. Se nenhum provider gerar texto publicavel, o workflow publica um comentario advisory explicando o motivo observado.
-10. O comentario final sempre e tentado em PRs nao-fork:
-   - com `CODEX_REVIEW_PAT` quando o commenter autenticado estiver disponivel
-   - com `GITHUB_TOKEN` quando o PAT estiver ausente ou invalido
+6. O workflow tenta gerar um review automatizado via OpenRouter.
+7. Se a resposta da OpenRouter nao for utilizavel, faz um retry unico antes de avancar.
+8. Se a resposta continuar inutilizavel, entra o fallback automatico via Gemini 2.5 Flash.
+9. Se o Gemini falhar ou nao produzir texto publicavel, faz um retry unico antes de desistir.
+10. Se nenhum provider gerar texto publicavel, o workflow publica um comentario advisory explicando o motivo observado.
+11. O comentario final do fluxo automatico e sempre publicado via bot com `GITHUB_TOKEN`.
+12. O Codex so entra no fluxo manual, quando a PR recebe a label `codex-review`.
+13. O frontend do ForgeOps reutiliza esse mesmo gatilho manual ao aplicar a label `codex-review` pelo backend.
+14. Se `CODEX_REVIEW_PAT` estiver disponivel e valido, o job manual publica `@codex review` como usuario real.
 
 ## Decisoes arquiteturais
 
-### PAT opcional para comentario como usuario
+### PAT opcional para trigger manual como usuario
 
-`CODEX_REVIEW_PAT` nao e requisito para o workflow funcionar. Ele existe para melhorar a experiencia operacional, permitindo que o comentario inicial e, quando possivel, o comentario final sejam publicados como usuario real.
+`CODEX_REVIEW_PAT` nao e requisito para o workflow automatico. Ele existe para o fluxo manual premium publicar `@codex review` como usuario real quando a PR recebe a label `codex-review`.
 
 Sem PAT valido:
-- o trigger como usuario pode nao ocorrer
-- o comentario final continua sendo publicado como bot via `GITHUB_TOKEN`
+- o fluxo automatico continua sendo publicado pelo bot
+- o trigger manual do Codex nao e publicado
 
 ### Fallback para `GITHUB_TOKEN`
 
-O comentario final nao depende do PAT. Isso evita:
+O comentario final automatico nao depende do PAT. Isso evita:
 - falha silenciosa em caso de token invalido
 - ausencia de comentario de status
 - divergencia entre comportamento real e expectativa operacional
@@ -66,24 +68,27 @@ As instrucoes e mensagens do workflow ficam em `.github/prompts/` para manter:
 
 Ordem de tentativa atual:
 
-1. Codex disparado por comentario `@codex review`
-2. Review automatizado via OpenAI
-3. Review automatizado via OpenRouter
-4. Comentario final de fallback humano
+1. Review automatizado via OpenRouter
+2. Retry unico da OpenRouter
+3. Review automatizado via Gemini 2.5 Flash
+4. Retry unico do Gemini
+5. Comentario final advisory via bot
+6. Codex apenas no fluxo manual por label `codex-review`
 
 Isso permite combinar:
-- review nativo do Codex no GitHub
-- review automatizado por API
+- review automatizado por API com custo mais baixo
+- fallback resiliente entre providers
+- Codex reservado para uso manual de maior valor
 - transparencia quando nenhum caminho produz saida util
 
 ## Criterios de utilidade do review automatizado
 
 O workflow tenta validar se a resposta:
 - contem texto publicavel
-- parece estar em portugues do Brasil
+- mantem preferencia por portugues, mas aceita ingles tecnico pontual
 - aborda risco tecnico de forma utilizavel
 
-Quando a saida falha nesses criterios, ela e tratada como invalida e o fluxo segue para o fallback seguinte.
+Quando a saida falha por erro real de API, parse invalido, resposta vazia ou texto claramente nao publicavel, o fluxo segue para o retry unico ou fallback seguinte.
 
 ## Riscos operacionais
 

--- a/docs/workflows/codex-review.md
+++ b/docs/workflows/codex-review.md
@@ -3,15 +3,15 @@
 ## Objetivo
 
 O workflow `codex-review` adiciona uma camada advisory de revisao automatizada sobre pull requests para `main`, combinando:
-- comentario de trigger para o Codex
-- tentativa de review automatizado por API
+- review automatizado por API de baixo custo
 - fallback de provider
-- comentario final transparente quando nenhum review util e produzido
+- fallback advisory transparente quando nenhum review util e produzido
 
 ## Quando dispara
 
 Trigger:
 - `pull_request`
+- `pull_request_target`
 
 Eventos:
 - `opened`
@@ -21,7 +21,7 @@ Eventos:
 
 Restricoes:
 - apenas para PRs contra `main`
-- nao roda para PR draft
+- o review automatico nao roda para PR draft
 - ignora PRs de fork
 
 ## Permissoes
@@ -51,24 +51,30 @@ Compatibilidade:
 ### Secrets
 
 - `CODEX_REVIEW_PAT`
-  opcional, para comentar como usuario real
-- `OPENAI_API_KEY`
-  provider principal de review automatizado
+  opcional, para o fluxo manual premium publicar `@codex review` como usuario real
 - `OPENROUTER_API_KEY`
-  provider de fallback
+  provider automatico primario
+- `GEMINI_API_KEY` ou `GOOGLE_API_KEY`
+  provider automatico secundario
 
 ## Cadeia de fallback
 
 O workflow segue esta ordem:
 
-1. comentario inicial `@codex review` como usuario real, se `CODEX_REVIEW_PAT` estiver disponivel
-2. review automatizado via OpenAI
-3. review automatizado via OpenRouter
-4. comentario final de fallback humano
+1. review automatizado via OpenRouter
+2. retry unico na OpenRouter quando a resposta nao for publicavel
+3. review automatizado via Gemini 2.5 Flash
+4. retry unico no Gemini quando a resposta nao for publicavel
+5. comentario advisory final
 
-Comentario final:
-- com PAT valido: como usuario real
-- sem PAT valido: via `GITHUB_TOKEN` como bot
+Comentario final do fluxo automatico:
+- sempre via `GITHUB_TOKEN` como bot
+- nunca chama o Codex
+
+Fluxo manual premium:
+- label `codex-review`
+- botao no frontend do ForgeOps que aplica a mesma label
+- comentario `@codex review` publicado como usuario real somente quando `CODEX_REVIEW_PAT` estiver valido
 
 ## Comportamento em fork PR
 
@@ -83,42 +89,43 @@ Motivo:
 1. Checkout do repositório
 2. Skip de fork PR
 3. Check de configuracao
-4. Resolucao opcional do commenter autenticado
+4. Resolucao dos providers automaticos
 5. Coleta do contexto do PR e diff
-6. Publicacao do trigger `@codex review`
-7. Tentativa via OpenAI
-8. Fallback via OpenRouter
-9. Resolucao do resultado final
-10. Publicacao do comentario final
+6. Tentativa via OpenRouter
+7. Retry unico da OpenRouter, se necessario
+8. Tentativa via Gemini
+9. Retry unico do Gemini, se necessario
+10. Publicacao do comentario final automatico
+11. Quando a PR recebe a label `codex-review`, o job manual publica `@codex review` como usuario real
 
 ## O que o workflow publica
 
-### Trigger comment
-
-Quando possivel, publica:
-- `@codex review`
-- instrucao de resposta em portugues do Brasil
-- foco em arquitetura, riscos e testes
-
-### Final comment
+### Comentario automatico final
 
 Pode publicar:
 - review automatizado complementar
 - comentario de readiness/advisory
 - fallback explicando o motivo observado
 
+### Trigger manual do Codex
+
+Publica `@codex review` apenas quando:
+- a PR recebe a label `codex-review`
+- `CODEX_REVIEW_PAT` esta disponivel e valido
+- o comentario precisa sair como usuario real
+
 ## Falhas esperadas e degradacao
 
 O workflow e desenhado para degradar sem quebrar o PR:
 
 - PAT ausente ou invalido
-  comentario final deve continuar
-- OpenAI indisponivel
-  tenta OpenRouter
-- OpenRouter indisponivel
+  o fluxo automatico continua e o trigger manual nao e publicado
+- OpenRouter indisponivel ou sem resposta publicavel
+  tenta retry unico e depois Gemini
+- Gemini indisponivel ou sem resposta publicavel
   cai em fallback humano
-- parsing sem texto util
-  publica comentario com motivo observado
+- parse invalido, resposta vazia ou texto claramente nao publicavel
+  avanca para o proximo provider ou advisory final
 
 ## Arquivos relacionados
 

--- a/frontend/src/features/repositories/repositories-view.tsx
+++ b/frontend/src/features/repositories/repositories-view.tsx
@@ -277,6 +277,25 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
     },
   });
 
+  const requestPullRequestCodexReviewMutation = useMutation({
+    mutationFn: () =>
+      client.requestPullRequestCodexReview(
+        accessToken,
+        selectedRepositoryId!,
+        selectedPullRequestId!,
+      ),
+    onSuccess: (request) => {
+      setStatusMessage(
+        `Manual Codex review requested for PR #${request.pullRequestNumber} via label ${request.label}.`,
+      );
+    },
+    onError: (error) => {
+      setStatusMessage(
+        getErrorMessage(error, 'Unable to request a manual Codex review right now.'),
+      );
+    },
+  });
+
   const monitoredRepositoryNames = new Set(
     monitoredRepositories.map((repository) => repository.fullName),
   );
@@ -583,6 +602,17 @@ export function RepositoriesView({ client = createApiClient() }: RepositoriesVie
           <p className="empty-state">Pull request detail is unavailable.</p>
         ) : (
           <div className="workflow-run-detail">
+            <div className="workflow-runs-list__actions">
+              <Button
+                onClick={() => requestPullRequestCodexReviewMutation.mutate()}
+                disabled={requestPullRequestCodexReviewMutation.isPending}
+              >
+                {requestPullRequestCodexReviewMutation.isPending
+                  ? 'Requesting Codex review...'
+                  : 'Request Codex review'}
+              </Button>
+            </div>
+
             <div className="workflow-runs-list__meta">
               <span className="repository-list__badge repository-list__badge--neutral">
                 status: {pullRequestDetail.status}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -144,6 +144,13 @@ const pullRequestDetailResponseSchema = z.object({
   ),
 });
 
+const requestPullRequestCodexReviewResponseSchema = z.object({
+  pullRequestId: z.string().min(1),
+  pullRequestNumber: z.number().int().positive(),
+  label: z.literal('codex-review'),
+  status: z.literal('requested'),
+});
+
 const workflowRunItemSchema = z.object({
   id: z.string().min(1),
   workflowId: z.string().min(1),
@@ -212,6 +219,9 @@ export type CreateRepositoryInput = z.infer<typeof createRepositoryInputSchema>;
 export type WorkflowCatalogItem = z.infer<typeof workflowCatalogItemSchema>;
 export type PullRequestItem = z.infer<typeof pullRequestItemSchema>;
 export type PullRequestDetailResponse = z.infer<typeof pullRequestDetailResponseSchema>;
+export type PullRequestCodexReviewRequestResponse = z.infer<
+  typeof requestPullRequestCodexReviewResponseSchema
+>;
 export type WorkflowRunItem = z.infer<typeof workflowRunItemSchema>;
 export type WorkflowRunJobItem = z.infer<typeof workflowRunJobItemSchema>;
 export type WorkflowRunDetailResponse = z.infer<typeof workflowRunDetailResponseSchema>;
@@ -248,6 +258,11 @@ export interface ForgeOpsApiClient {
     repositoryId: string,
     pullRequestId: string,
   ): Promise<PullRequestDetailResponse>;
+  requestPullRequestCodexReview(
+    accessToken: string,
+    repositoryId: string,
+    pullRequestId: string,
+  ): Promise<PullRequestCodexReviewRequestResponse>;
   getWorkflowRuns(
     accessToken: string,
     repositoryId: string,
@@ -384,6 +399,29 @@ export const createApiClient = (options: CreateApiClientOptions = {}): ForgeOpsA
       }
 
       return pullRequestDetailResponseSchema.parse(await response.json());
+    },
+
+    async requestPullRequestCodexReview(
+      accessToken: string,
+      repositoryId: string,
+      pullRequestId: string,
+    ): Promise<PullRequestCodexReviewRequestResponse> {
+      const response = await fetcher(
+        `${baseUrl}/api/v1/repositories/${repositoryId}/pull-requests/${pullRequestId}/codex-review-request`,
+        {
+          method: 'POST',
+          headers: buildHeaders(accessToken),
+        },
+      );
+
+      if (!response.ok) {
+        throw await createApiError(
+          response,
+          `Failed to request Codex review (${response.status})`,
+        );
+      }
+
+      return requestPullRequestCodexReviewResponseSchema.parse(await response.json());
     },
 
     async getWorkflowRuns(

--- a/frontend/src/tests/api-client.test.ts
+++ b/frontend/src/tests/api-client.test.ts
@@ -411,6 +411,48 @@ describe('createApiClient', () => {
     );
   });
 
+  it('should request a manual Codex review for a pull request', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          pullRequestId: 'pr_123',
+          pullRequestNumber: 42,
+          label: 'codex-review',
+          status: 'requested',
+        }),
+        {
+          status: 202,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+      ),
+    );
+    const client = createApiClient({
+      baseUrl: 'http://localhost:3333',
+      fetcher,
+    });
+
+    await expect(
+      client.requestPullRequestCodexReview('trusted-token', 'repo_123', 'pr_123'),
+    ).resolves.toEqual({
+      pullRequestId: 'pr_123',
+      pullRequestNumber: 42,
+      label: 'codex-review',
+      status: 'requested',
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      'http://localhost:3333/api/v1/repositories/repo_123/pull-requests/pr_123/codex-review-request',
+      {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer trusted-token',
+        },
+      },
+    );
+  });
+
   it('should fetch workflow run detail with jobs', async () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(

--- a/frontend/src/tests/repositories-view.test.tsx
+++ b/frontend/src/tests/repositories-view.test.tsx
@@ -38,6 +38,7 @@ describe('RepositoriesView', () => {
       }),
       getWorkflowRuns: vi.fn(),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -182,6 +183,7 @@ describe('RepositoriesView', () => {
         },
         jobs: [],
       }),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository,
     };
 
@@ -257,6 +259,7 @@ describe('RepositoriesView', () => {
       }),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -300,6 +303,7 @@ describe('RepositoriesView', () => {
       getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -337,6 +341,7 @@ describe('RepositoriesView', () => {
       getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -378,6 +383,7 @@ describe('RepositoriesView', () => {
       getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -461,6 +467,7 @@ describe('RepositoriesView', () => {
       getPullRequestDetail,
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -493,6 +500,88 @@ describe('RepositoriesView', () => {
       'repo_123',
       'pr_123',
     );
+  });
+
+  it('should request a manual Codex review from the pull request detail view', async () => {
+    const requestPullRequestCodexReview = vi
+      .fn<ForgeOpsApiClient['requestPullRequestCodexReview']>()
+      .mockResolvedValue({
+        pullRequestId: 'pr_123',
+        pullRequestNumber: 42,
+        label: 'codex-review',
+        status: 'requested',
+      });
+    const client: ForgeOpsApiClient = {
+      getHealth: vi.fn(),
+      getRepositories: vi.fn().mockResolvedValue([
+        {
+          id: 'repo_123',
+          githubRepoId: '123456789',
+          owner: 'forgeops',
+          name: 'backend',
+          fullName: 'forgeops/backend',
+          defaultBranch: 'main',
+          isActive: true,
+          createdAt: '2026-03-28T00:00:00.000Z',
+          updatedAt: '2026-03-28T00:00:00.000Z',
+        },
+      ]),
+      getRepositoryDiscovery: vi.fn().mockResolvedValue([]),
+      getRepositoryWorkflows: vi.fn().mockResolvedValue([]),
+      getPullRequests: vi.fn().mockResolvedValue([
+        {
+          id: 'pr_123',
+          githubPrId: '987654321',
+          number: 42,
+          title: 'Add pull request insights',
+          state: 'open',
+          author: 'alessandrolsdev',
+          baseBranch: 'main',
+          headBranch: 'feature/pull-request-insights',
+          createdAt: '2026-03-31T18:20:00.000Z',
+          updatedAt: '2026-03-31T18:20:00.000Z',
+        },
+      ]),
+      getPullRequestDetail: vi.fn().mockResolvedValue({
+        id: 'pr_123',
+        number: 42,
+        title: 'Add pull request insights',
+        status: 'open',
+        author: 'alessandrolsdev',
+        summary: null,
+        workflows: [],
+      }),
+      getWorkflowRuns: vi.fn().mockResolvedValue([]),
+      getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview,
+      createRepository: vi.fn(),
+    };
+
+    renderRepositoriesView(client);
+
+    fireEvent.change(screen.getByLabelText('Operator bearer token'), {
+      target: { value: 'trusted-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use access token' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Request Codex review' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Request Codex review' }));
+
+    await waitFor(() => {
+      expect(requestPullRequestCodexReview).toHaveBeenCalledWith(
+        'trusted-token',
+        'repo_123',
+        'pr_123',
+      );
+      expect(
+        screen.getByText(
+          'Manual Codex review requested for PR #42 via label codex-review.',
+        ),
+      ).toBeInTheDocument();
+    });
   });
 
   it('should render pull request detail loading state', async () => {
@@ -530,6 +619,7 @@ describe('RepositoriesView', () => {
       getPullRequestDetail: vi.fn().mockImplementation(() => new Promise(() => undefined)),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -596,6 +686,7 @@ describe('RepositoriesView', () => {
       }),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -657,6 +748,7 @@ describe('RepositoriesView', () => {
         .mockRejectedValue(new ApiClientError('Pull request detail is unavailable.', 503)),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -714,6 +806,7 @@ describe('RepositoriesView', () => {
       getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockImplementation(() => new Promise(() => undefined)),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -763,6 +856,7 @@ describe('RepositoriesView', () => {
       getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -816,6 +910,7 @@ describe('RepositoriesView', () => {
         .fn()
         .mockRejectedValue(new ApiClientError('Workflow runs are currently unavailable.', 503)),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -914,6 +1009,7 @@ describe('RepositoriesView', () => {
         },
       ]),
       getWorkflowRunDetail,
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -994,6 +1090,7 @@ describe('RepositoriesView', () => {
         },
       ]),
       getWorkflowRunDetail: vi.fn().mockImplementation(() => new Promise(() => undefined)),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -1082,6 +1179,7 @@ describe('RepositoriesView', () => {
         },
         jobs: [],
       }),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -1156,6 +1254,7 @@ describe('RepositoriesView', () => {
       getWorkflowRunDetail: vi
         .fn()
         .mockRejectedValue(new ApiClientError('Workflow run detail is unavailable.', 503)),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -1242,6 +1341,7 @@ describe('RepositoriesView', () => {
       getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository,
     };
 
@@ -1288,6 +1388,7 @@ describe('RepositoriesView', () => {
       getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn(),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 
@@ -1340,6 +1441,7 @@ describe('RepositoriesView', () => {
       getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi
         .fn()
         .mockRejectedValue(
@@ -1393,6 +1495,7 @@ describe('RepositoriesView', () => {
       getPullRequestDetail: vi.fn(),
       getWorkflowRuns: vi.fn().mockResolvedValue([]),
       getWorkflowRunDetail: vi.fn(),
+      requestPullRequestCodexReview: vi.fn(),
       createRepository: vi.fn(),
     };
 


### PR DESCRIPTION
## Resumo
Adiciona no ForgeOps uma ação rastreável para solicitar review manual do Codex a partir do detalhe do pull request. O frontend agora reutiliza o mesmo gatilho canônico por label `codex-review`, sem criar um fluxo paralelo ao workflow manual já definido.

## O que foi alterado
- adiciona no backend uma rota protegida para solicitar review manual do Codex em um pull request existente
- reaproveita o GitHub App provider para aplicar a label `codex-review` no PR via API do GitHub
- expõe no client do frontend a mutação para solicitar o review manual
- adiciona no detalhe do pull request um botão para disparar a solicitação manual com feedback de sucesso/erro
- atualiza testes de backend e frontend para cobrir auth, capability, contrato HTTP e interação da UI
- atualiza a documentação do fluxo manual para deixar explícito que o botão reutiliza a mesma label do workflow

## Motivação
Depois da separação entre review automático barato e Codex manual na `#129`, faltava tornar esse gatilho manual utilizável dentro do produto. Sem essa ação no frontend, o fluxo manual continuava dependente de intervenção direta no GitHub e não fechava a experiência de uso local e operacional do ForgeOps.

## Como validar
- Executar `npm run lint`
- Executar `npm run typecheck`
- Executar `npm --prefix backend run test -- --run src/tests/app/create-server.test.ts`
- Executar `npm --prefix frontend run test -- --run src/tests/api-client.test.ts src/tests/repositories-view.test.tsx`
- Abrir a tela de repositórios no frontend, selecionar um PR monitorado e acionar o botão `Request Codex review`
- Confirmar que o backend responde `202` em `POST /api/v1/repositories/:repositoryId/pull-requests/:pullRequestId/codex-review-request`
- Confirmar que a label `codex-review` é aplicada ao PR e que o workflow manual continua sendo o único responsável por publicar `@codex review`

## Riscos e impactos
- A nova rota exige `repositories:write`; tokens locais sem essa capability continuarão recebendo `403`, o que é esperado para manter o contrato de autorização.
- O fluxo depende de o GitHub App ter permissão para aplicar labels no PR/issue correspondente.
- O método novo no boundary foi mantido opcional para evitar churn em stubs que não participam do fluxo manual; o runtime real continua coberto pelo provider concreto.
- O impacto é baixo e concentrado ao fluxo manual de review; o caminho automático da `#129` não foi alterado.

## Evidências
- `npm run lint`
- `npm run typecheck`
- `npm --prefix backend run test -- --run src/tests/app/create-server.test.ts`
- `npm --prefix frontend run test -- --run src/tests/api-client.test.ts src/tests/repositories-view.test.tsx`

## Checklist
- [ ] Alteração limitada ao objetivo da PR
- [ ] Sem mudanças desconexas
- [ ] Impactos principais descritos
- [ ] Validação documentada
- [ ] Riscos identificados

Closes #130