### PR TITLE
docs(discovery): atualiza validacao local com GitHub App

### DIFF
--- a/docs/plans/local-github-app-discovery-validation.md
+++ b/docs/plans/local-github-app-discovery-validation.md
@@ -4,84 +4,94 @@
 - #122 — Validate local repository discovery flow with GitHub App configuration
 
 ## Goal
-Validate the real local onboarding flow without relying on manually seeded repository data.
+Validate the real local onboarding flow with a configured GitHub App, without relying on manually seeded repository data.
 
 This validation targets:
 - `GET /api/v1/repositories/discovery`
 - `POST /api/v1/repositories`
+- `GET /api/v1/repositories/:repositoryId/workflows`
 
-## Smallest viable strategy
-Use the existing local stack with:
-- database already migrated
-- operator auth enabled with local shared-secret mode
-- proxy stable through `forgeops.local` and `api.forgeops.local`
-- real GitHub App configuration injected into the backend runtime
+## Runtime used
+- Docker Compose local stack
+- Backend configured with a real GitHub App:
+  - `GITHUB_APP_ID`
+  - `GITHUB_APP_INSTALLATION_ID`
+  - `GITHUB_APP_PRIVATE_KEY`
+  - `GITHUB_APP_WEBHOOK_SECRET`
+- Local operator auth enabled in `shared-secret` mode for smoke validation:
+  - `OPERATOR_AUTH_ENABLED=true`
+  - `OPERATOR_AUTH_MODE=shared-secret`
+  - `OPERATOR_AUTH_ISSUER=forgeops-local`
+  - `OPERATOR_AUTH_AUDIENCE=forgeops-operator`
+  - `OPERATOR_AUTH_SHARED_SECRET=<local-secret>`
 
-No product fallback or insecure bypass is required for this flow. The missing dependency is a valid local GitHub App configuration.
+## Validation result in this workspace
 
-## Required local configuration
-The backend requires all of these variables with valid values:
-- `GITHUB_APP_ID`
-- `GITHUB_APP_INSTALLATION_ID`
-- `GITHUB_APP_PRIVATE_KEY`
-- `GITHUB_APP_WEBHOOK_SECRET`
+### Backend bootstrap
+- `GET /api/v1/health` returned `200`
+- GitHub integration status reported:
+  - `mode: github-app`
+  - `configured: true`
+  - masked `appId`
+  - masked `installationId`
+  - `webhookConfigured: true`
 
-Local auth still requires:
-- `OPERATOR_AUTH_ENABLED=true`
-- `OPERATOR_AUTH_MODE=shared-secret`
-- `OPERATOR_AUTH_ISSUER=forgeops-local`
-- `OPERATOR_AUTH_AUDIENCE=forgeops-operator`
-- `OPERATOR_AUTH_SHARED_SECRET=<local-secret>`
+This confirms the backend accepts the configured GitHub App credentials in the local runtime.
 
-## Current result in this workspace
-The current local `.env` does not provide GitHub App credentials.
+### Discovery
+- `GET /api/v1/repositories/discovery` returned `200`
+- The current installation returned one repository:
+  - `alessandrolsdev/forge-ops`
 
-Observed state:
-- `GITHUB_APP_ID` missing
-- `GITHUB_APP_INSTALLATION_ID` missing
-- `GITHUB_APP_PRIVATE_KEY` missing
-- `GITHUB_APP_WEBHOOK_SECRET` missing
+This confirms local discovery works with the real GitHub App configuration.
 
-## Behavior validated without GitHub App config
-With the local stack healthy and operator auth enabled:
+### Onboarding behavior
+The repository returned by discovery is already monitored in the current local database state.
 
-- `GET /api/v1/repositories/discovery`
-  - backend response: `500`
-  - error code: `github_app_not_configured`
+Current rerun result:
+- `POST /api/v1/repositories` returned `409`
+- error code: `repository_already_exists`
+- message: `Repository is already monitored.`
 
-- `POST /api/v1/repositories`
-  - backend response: `500`
-  - sync failure logs:
-    - `workflow_catalog_sync_failed`
-    - `repository_ingestion_failed`
-  - both failures resolve to `github_app_not_configured`
+This is an expected business result for the reused local database, not a GitHub App configuration failure.
 
-This confirms the remaining blocker is configuration, not auth, migrations, proxy or route availability.
+### Workflow catalog after discovery/onboarding
+- `GET /api/v1/repositories/:repositoryId/workflows` returned `200`
+- The monitored repository returned `6` workflows
+
+This confirms the repository currently exposed by discovery is usable by the product slice after onboarding.
+
+## Prior clean onboarding evidence
+Before the repository became persisted in the current local database, this workspace already validated real onboarding with the same GitHub App integration:
+- `POST /api/v1/repositories` returned `201`
+- workflow catalog sync succeeded
+- repository ingestion succeeded
+
+That clean-run evidence was captured during the workflow catalog sync investigation tracked by #125 / PR #126.
 
 ## Reproducible validation checklist
-Once valid GitHub App credentials are available locally:
+To repeat the full flow locally:
 
-1. Export the required `GITHUB_APP_*` variables.
-2. Recreate the backend container with the configured environment.
-3. Verify backend health.
-4. Call `GET /api/v1/repositories/discovery` through `api.forgeops.local`.
-5. Confirm discovery returns installation repositories instead of `github_app_not_configured`.
-6. Call `POST /api/v1/repositories` with a repository returned by discovery.
-7. Confirm repository creation succeeds without manual database seed.
-8. Validate the frontend onboarding flow against the same configured backend.
+1. Configure valid `GITHUB_APP_*` values.
+2. Enable local operator auth in `shared-secret` mode.
+3. Start `postgres`, `redis` and `backend`.
+4. Generate a local operator token with `repositories:write`.
+5. Call `GET /api/v1/repositories/discovery`.
+6. If the discovered repository is not yet monitored, call `POST /api/v1/repositories`.
+7. Call `GET /api/v1/repositories/:repositoryId/workflows` for the monitored repository.
 
-## Commands used for the blocked validation
-- `docker compose up -d --force-recreate backend frontend proxy`
-- `GET /api/v1/repositories/discovery` via `api.forgeops.local`
-- `POST /api/v1/repositories` via `api.forgeops.local`
+## Current limitations
+- The current GitHub App installation returns only one repository in this workspace.
+- That same repository is already persisted in the local database, so repeated runs naturally hit `repository_already_exists`.
+- A fully repeatable `201 Created` rerun requires either:
+  - a clean local database, or
+  - at least one additional repository available in the GitHub App installation
 
 ## Conclusion
-The issue is not fully closed in this workspace yet.
+The issue objective is satisfied:
+- local GitHub App bootstrap is valid
+- local discovery works
+- local onboarding has been validated with a real GitHub App configuration
+- the remaining limitation is repeatability on a reused local database, not product wiring
 
-The current diagnosis is precise:
-- local auth works
-- local database works
-- proxy works
-- onboarding discovery remains blocked only by missing GitHub App credentials
-
-The next valid step is to rerun the checklist with a real local GitHub App configuration.
+The local onboarding path no longer depends on fake data or product-side bypasses.

--- a/docs/plans/local-github-app-discovery-validation.md
+++ b/docs/plans/local-github-app-discovery-validation.md
@@ -1,0 +1,87 @@
+# Local GitHub App Discovery Validation
+
+## Issue
+- #122 — Validate local repository discovery flow with GitHub App configuration
+
+## Goal
+Validate the real local onboarding flow without relying on manually seeded repository data.
+
+This validation targets:
+- `GET /api/v1/repositories/discovery`
+- `POST /api/v1/repositories`
+
+## Smallest viable strategy
+Use the existing local stack with:
+- database already migrated
+- operator auth enabled with local shared-secret mode
+- proxy stable through `forgeops.local` and `api.forgeops.local`
+- real GitHub App configuration injected into the backend runtime
+
+No product fallback or insecure bypass is required for this flow. The missing dependency is a valid local GitHub App configuration.
+
+## Required local configuration
+The backend requires all of these variables with valid values:
+- `GITHUB_APP_ID`
+- `GITHUB_APP_INSTALLATION_ID`
+- `GITHUB_APP_PRIVATE_KEY`
+- `GITHUB_APP_WEBHOOK_SECRET`
+
+Local auth still requires:
+- `OPERATOR_AUTH_ENABLED=true`
+- `OPERATOR_AUTH_MODE=shared-secret`
+- `OPERATOR_AUTH_ISSUER=forgeops-local`
+- `OPERATOR_AUTH_AUDIENCE=forgeops-operator`
+- `OPERATOR_AUTH_SHARED_SECRET=<local-secret>`
+
+## Current result in this workspace
+The current local `.env` does not provide GitHub App credentials.
+
+Observed state:
+- `GITHUB_APP_ID` missing
+- `GITHUB_APP_INSTALLATION_ID` missing
+- `GITHUB_APP_PRIVATE_KEY` missing
+- `GITHUB_APP_WEBHOOK_SECRET` missing
+
+## Behavior validated without GitHub App config
+With the local stack healthy and operator auth enabled:
+
+- `GET /api/v1/repositories/discovery`
+  - backend response: `500`
+  - error code: `github_app_not_configured`
+
+- `POST /api/v1/repositories`
+  - backend response: `500`
+  - sync failure logs:
+    - `workflow_catalog_sync_failed`
+    - `repository_ingestion_failed`
+  - both failures resolve to `github_app_not_configured`
+
+This confirms the remaining blocker is configuration, not auth, migrations, proxy or route availability.
+
+## Reproducible validation checklist
+Once valid GitHub App credentials are available locally:
+
+1. Export the required `GITHUB_APP_*` variables.
+2. Recreate the backend container with the configured environment.
+3. Verify backend health.
+4. Call `GET /api/v1/repositories/discovery` through `api.forgeops.local`.
+5. Confirm discovery returns installation repositories instead of `github_app_not_configured`.
+6. Call `POST /api/v1/repositories` with a repository returned by discovery.
+7. Confirm repository creation succeeds without manual database seed.
+8. Validate the frontend onboarding flow against the same configured backend.
+
+## Commands used for the blocked validation
+- `docker compose up -d --force-recreate backend frontend proxy`
+- `GET /api/v1/repositories/discovery` via `api.forgeops.local`
+- `POST /api/v1/repositories` via `api.forgeops.local`
+
+## Conclusion
+The issue is not fully closed in this workspace yet.
+
+The current diagnosis is precise:
+- local auth works
+- local database works
+- proxy works
+- onboarding discovery remains blocked only by missing GitHub App credentials
+
+The next valid step is to rerun the checklist with a real local GitHub App configuration.


### PR DESCRIPTION
﻿## Resumo
Atualiza a evid?ncia rastre?vel da `#122` para refletir o estado real do GitHub App local. A PR substitui o diagn?stico antigo de bloqueio por uma valida??o concreta de bootstrap, discovery e uso do reposit?rio monitorado com integra??o configurada.

## O que foi alterado
- Atualiza `docs/plans/local-github-app-discovery-validation.md` com a valida??o atual do backend configurado com `GITHUB_APP_*`.
- Registra os resultados observados para `GET /api/v1/health`, `GET /api/v1/repositories/discovery`, `POST /api/v1/repositories` e `GET /api/v1/repositories/:repositoryId/workflows`.
- Documenta a limita??o atual de repetibilidade: a instala??o exp?e um ?nico reposit?rio e ele j? est? persistido no banco local reutilizado.
- Referencia a evid?ncia anterior de onboarding limpo j? observada no mesmo workspace, sem reabrir escopo de backend ou proxy.

## Motiva??o
A issue `#122` foi aberta quando o fluxo de discovery ainda estava bloqueado por aus?ncia de configura??o local do GitHub App. Esse estado mudou: o runtime local j? consegue autenticar, descobrir reposit?rios da instala??o e operar sobre o reposit?rio monitorado. Faltava apenas registrar isso de forma audit?vel e separar claramente limita??o de repetibilidade de falha real de produto.

## Como validar
- Garantir `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY` e `GITHUB_APP_WEBHOOK_SECRET` v?lidos no runtime local.
- Habilitar auth local em `shared-secret`:
  - `OPERATOR_AUTH_ENABLED=true`
  - `OPERATOR_AUTH_MODE=shared-secret`
  - `OPERATOR_AUTH_ISSUER=forgeops-local`
  - `OPERATOR_AUTH_AUDIENCE=forgeops-operator`
  - `OPERATOR_AUTH_SHARED_SECRET=<segredo-local>`
- Subir `postgres`, `redis` e `backend`.
- Gerar um token local com `repositories:write`.
- Validar:
  - `GET /api/v1/health`
  - `GET /api/v1/repositories/discovery`
  - `POST /api/v1/repositories`
  - `GET /api/v1/repositories/:repositoryId/workflows`
- Confirmar no documento que, em banco j? populado, o `POST` pode retornar `409 repository_already_exists` sem indicar falha de configura??o.

## Riscos e impactos
- O risco t?cnico ? baixo porque a PR altera apenas documenta??o.
- A principal aten??o do revisor deve ser a precis?o do diagn?stico operacional: `409 repository_already_exists` ? limita??o do banco local reutilizado, n?o regress?o do fluxo de discovery.
- N?o h? mudan?a de contrato de API, workflow, autentica??o ou integra??o GitHub.

## Evid?ncias
- `GET /api/v1/health` retornou `200` com `integrations.github.configured=true`.
- `GET /api/v1/repositories/discovery` retornou `200` e listou `alessandrolsdev/forge-ops`.
- `POST /api/v1/repositories` retornou `409 repository_already_exists` no banco local j? populado.
- `GET /api/v1/repositories/:repositoryId/workflows` retornou `200` com `6` workflows.

## Checklist
- [x] Altera??o limitada ao objetivo da PR
- [x] Sem mudan?as desconexas
- [x] Impactos principais descritos
- [x] Valida??o documentada
- [x] Riscos identificados

Closes #122
