### PR TITLE
fix(ci): separa concorrencia do review automatico e manual

### DIFF
--- a/.github/workflows/codex-review-smoke.yml
+++ b/.github/workflows/codex-review-smoke.yml
@@ -10,6 +10,7 @@ on:
       - fix/**
     paths:
       - .github/workflows/codex-review.yml
+      - .github/workflows/manual-codex-review.yml
       - .github/workflows/codex-review-smoke.yml
       - .github/prompts/codex-review.md
       - .github/prompts/codex-fallback.md

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -7,7 +7,6 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-      - labeled
     branches:
       - main
 
@@ -17,13 +16,13 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.event.action == 'labeled' && format('codex-review-manual-{0}-{1}', github.event.pull_request.number, github.event.label.name) || format('codex-review-auto-{0}', github.event.pull_request.number) }}
+  group: ${{ format('codex-review-auto-{0}', github.event.pull_request.number) }}
   cancel-in-progress: true
 
 jobs:
   codex-review:
     name: codex-review
-    if: ${{ !github.event.pull_request.draft && github.event.action != 'labeled' }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -603,178 +602,4 @@ jobs:
           set -e
           if [ "$post_status" -ne 0 ]; then
             echo "Unable to create final status comment."
-          fi
-
-  manual-codex-review:
-    name: manual-codex-review
-    if: ${{ !github.event.pull_request.draft && github.event.action == 'labeled' && github.event.label.name == 'codex-review' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Skip fork pull requests
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        run: |
-          echo "Manual Codex review is skipped for fork pull requests to avoid exposing review automation to untrusted contexts."
-
-      - name: Check manual review configuration
-        id: manual-config
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        env:
-          CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [ -n "${CODEX_REVIEW_PAT:-}" ]; then
-            echo "pat_present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "pat_present=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Resolve commenter identity
-        id: commenter
-        if: ${{ !github.event.pull_request.head.repo.fork && steps.manual-config.outputs.pat_present == 'true' }}
-        env:
-          CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          response_path="$RUNNER_TEMP/codex-review/commenter.json"
-          mkdir -p "$(dirname "$response_path")"
-          http_status=$(
-            curl -s \
-              -o "$response_path" \
-              -w "%{http_code}" \
-              -H "Authorization: token ${CODEX_REVIEW_PAT}" \
-              -H "Accept: application/vnd.github+json" \
-              https://api.github.com/user \
-              || true
-          )
-
-          if [ "$http_status" -ge 200 ] && [ "$http_status" -lt 300 ]; then
-            login=$(jq -r '.login // empty' "$response_path" 2>/dev/null || true)
-          else
-            login=""
-          fi
-
-          if [ -z "$login" ]; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "login=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "available=true" >> "$GITHUB_OUTPUT"
-          echo "login=$login" >> "$GITHUB_OUTPUT"
-
-      - name: Collect pull request context
-        id: pr-context
-        if: ${{ !github.event.pull_request.head.repo.fork && steps.commenter.outputs.available == 'true' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          output_dir="$RUNNER_TEMP/codex-review"
-          pr_json_path="$output_dir/pr.json"
-          pr_number=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
-          pr_sha=$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")
-
-          mkdir -p "$output_dir"
-
-          jq -n \
-            --arg sha "$pr_sha" \
-            --argjson number "$pr_number" \
-            '{
-              sha: $sha,
-              number: $number
-            }' > "$pr_json_path"
-
-          echo "context_dir=$output_dir" >> "$GITHUB_OUTPUT"
-
-      - name: Publish manual Codex trigger comment as maintainer
-        if: ${{ !github.event.pull_request.head.repo.fork && steps.commenter.outputs.available == 'true' }}
-        env:
-          CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}
-          COMMENTER_LOGIN: ${{ steps.commenter.outputs.login }}
-          PR_CONTEXT_DIR: ${{ steps.pr-context.outputs.context_dir }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          marker=$(cat "$GITHUB_WORKSPACE/.github/prompts/codex-comment-marker.txt")
-          pr_number=$(jq -r '.number' "$PR_CONTEXT_DIR/pr.json")
-          pr_sha=$(jq -r '.sha' "$PR_CONTEXT_DIR/pr.json")
-          comments_url="${{ github.api_url }}/repos/${{ github.repository }}/issues/$pr_number/comments"
-          comment_body_path="$RUNNER_TEMP/codex-review/manual-trigger-comment.md"
-
-          {
-            printf '%s\n' "$marker"
-            printf '@codex review\n\n'
-            printf 'Solicitacao manual de revisao premium do Codex para o commit %s via label `codex-review`.\n\n' "$pr_sha"
-            printf 'Foque em arquitetura, riscos, testes e seguranca.\n'
-          } > "$comment_body_path"
-
-          set +e
-          comments_payload=$(
-            curl -s \
-              -H "Authorization: Bearer $CODEX_REVIEW_PAT" \
-              -H "Accept: application/vnd.github+json" \
-              "$comments_url?per_page=100" \
-          )
-          comments_status=$?
-          set -e
-
-          if [ "$comments_status" -ne 0 ]; then
-            echo "Skipping manual Codex trigger comment update because GitHub comment listing failed."
-            exit 0
-          fi
-
-          existing_comment_id=$(
-            printf '%s' "$comments_payload" \
-              | jq -r --arg login "$COMMENTER_LOGIN" --arg marker "$marker" '
-                  .[]
-                  | select(.user.login == $login and ((.body // "") | contains($marker)))
-                  | .id
-                ' \
-              | head -n 1
-          )
-
-          if [ -n "$existing_comment_id" ]; then
-            set +e
-            jq -n --rawfile body "$comment_body_path" '{body: $body}' \
-              | curl -s -X PATCH \
-                  "${{ github.api_url }}/repos/${{ github.repository }}/issues/comments/$existing_comment_id" \
-                  -H "Authorization: Bearer $CODEX_REVIEW_PAT" \
-                  -H "Accept: application/vnd.github+json" \
-                  -H "Content-Type: application/json" \
-                  --data @- \
-                  > /dev/null
-            patch_status=$?
-            set -e
-            if [ "$patch_status" -ne 0 ]; then
-              echo "Skipping manual Codex trigger comment patch because GitHub patch request failed."
-            fi
-            exit 0
-          fi
-
-          set +e
-          jq -n --rawfile body "$comment_body_path" '{body: $body}' \
-            | curl -s -X POST \
-                "$comments_url" \
-                -H "Authorization: Bearer $CODEX_REVIEW_PAT" \
-                -H "Accept: application/vnd.github+json" \
-                -H "Content-Type: application/json" \
-                --data @- \
-                > /dev/null
-          post_status=$?
-          set -e
-          if [ "$post_status" -ne 0 ]; then
-            echo "Skipping manual Codex trigger comment creation because GitHub post request failed."
           fi

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -17,7 +17,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: codex-review-${{ github.event.pull_request.number }}
+  group: ${{ github.event.action == 'labeled' && format('codex-review-manual-{0}-{1}', github.event.pull_request.number, github.event.label.name) || format('codex-review-auto-{0}', github.event.pull_request.number) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/manual-codex-review.yml
+++ b/.github/workflows/manual-codex-review.yml
@@ -1,0 +1,192 @@
+name: Manual Codex Review
+
+on:
+  pull_request:
+    types:
+      - labeled
+    branches:
+      - main
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: ${{ format('codex-review-manual-{0}-{1}', github.event.pull_request.number, github.event.label.name) }}
+  cancel-in-progress: true
+
+jobs:
+  manual-codex-review:
+    name: manual-codex-review
+    if: ${{ !github.event.pull_request.draft && github.event.label.name == 'codex-review' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Skip fork pull requests
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          echo "Manual Codex review is skipped for fork pull requests to avoid exposing review automation to untrusted contexts."
+
+      - name: Check manual review configuration
+        id: manual-config
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        env:
+          CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${CODEX_REVIEW_PAT:-}" ]; then
+            echo "pat_present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pat_present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve commenter identity
+        id: commenter
+        if: ${{ !github.event.pull_request.head.repo.fork && steps.manual-config.outputs.pat_present == 'true' }}
+        env:
+          CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          response_path="$RUNNER_TEMP/codex-review/commenter.json"
+          mkdir -p "$(dirname "$response_path")"
+          http_status=$(
+            curl -s \
+              -o "$response_path" \
+              -w "%{http_code}" \
+              -H "Authorization: token ${CODEX_REVIEW_PAT}" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/user \
+              || true
+          )
+
+          if [ "$http_status" -ge 200 ] && [ "$http_status" -lt 300 ]; then
+            login=$(jq -r '.login // empty' "$response_path" 2>/dev/null || true)
+          else
+            login=""
+          fi
+
+          if [ -z "$login" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "login=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "available=true" >> "$GITHUB_OUTPUT"
+          echo "login=$login" >> "$GITHUB_OUTPUT"
+
+      - name: Collect pull request context
+        id: pr-context
+        if: ${{ !github.event.pull_request.head.repo.fork && steps.commenter.outputs.available == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          output_dir="$RUNNER_TEMP/codex-review"
+          pr_json_path="$output_dir/pr.json"
+          pr_number=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
+          pr_sha=$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")
+
+          mkdir -p "$output_dir"
+
+          jq -n \
+            --arg sha "$pr_sha" \
+            --argjson number "$pr_number" \
+            '{
+              sha: $sha,
+              number: $number
+            }' > "$pr_json_path"
+
+          echo "context_dir=$output_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Publish manual Codex trigger comment as maintainer
+        if: ${{ !github.event.pull_request.head.repo.fork && steps.commenter.outputs.available == 'true' }}
+        env:
+          CODEX_REVIEW_PAT: ${{ secrets.CODEX_REVIEW_PAT }}
+          COMMENTER_LOGIN: ${{ steps.commenter.outputs.login }}
+          PR_CONTEXT_DIR: ${{ steps.pr-context.outputs.context_dir }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          marker=$(cat "$GITHUB_WORKSPACE/.github/prompts/codex-comment-marker.txt")
+          pr_number=$(jq -r '.number' "$PR_CONTEXT_DIR/pr.json")
+          pr_sha=$(jq -r '.sha' "$PR_CONTEXT_DIR/pr.json")
+          comments_url="${{ github.api_url }}/repos/${{ github.repository }}/issues/$pr_number/comments"
+          comment_body_path="$RUNNER_TEMP/codex-review/manual-trigger-comment.md"
+
+          {
+            printf '%s\n' "$marker"
+            printf '@codex review\n\n'
+            printf 'Solicitacao manual de revisao premium do Codex para o commit %s via label `codex-review`.\n\n' "$pr_sha"
+            printf 'Foque em arquitetura, riscos, testes e seguranca.\n'
+          } > "$comment_body_path"
+
+          set +e
+          comments_payload=$(
+            curl -s \
+              -H "Authorization: Bearer $CODEX_REVIEW_PAT" \
+              -H "Accept: application/vnd.github+json" \
+              "$comments_url?per_page=100" \
+          )
+          comments_status=$?
+          set -e
+
+          if [ "$comments_status" -ne 0 ]; then
+            echo "Skipping manual Codex trigger comment update because GitHub comment listing failed."
+            exit 0
+          fi
+
+          existing_comment_id=$(
+            printf '%s' "$comments_payload" \
+              | jq -r --arg login "$COMMENTER_LOGIN" --arg marker "$marker" '
+                  .[]
+                  | select(.user.login == $login and ((.body // "") | contains($marker)))
+                  | .id
+                ' \
+              | head -n 1
+          )
+
+          if [ -n "$existing_comment_id" ]; then
+            set +e
+            jq -n --rawfile body "$comment_body_path" '{body: $body}' \
+              | curl -s -X PATCH \
+                  "${{ github.api_url }}/repos/${{ github.repository }}/issues/comments/$existing_comment_id" \
+                  -H "Authorization: Bearer $CODEX_REVIEW_PAT" \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Content-Type: application/json" \
+                  --data @- \
+                  > /dev/null
+            patch_status=$?
+            set -e
+            if [ "$patch_status" -ne 0 ]; then
+              echo "Skipping manual Codex trigger comment patch because GitHub patch request failed."
+            fi
+            exit 0
+          fi
+
+          set +e
+          jq -n --rawfile body "$comment_body_path" '{body: $body}' \
+            | curl -s -X POST \
+                "$comments_url" \
+                -H "Authorization: Bearer $CODEX_REVIEW_PAT" \
+                -H "Accept: application/vnd.github+json" \
+                -H "Content-Type: application/json" \
+                --data @- \
+                > /dev/null
+          post_status=$?
+          set -e
+          if [ "$post_status" -ne 0 ]; then
+            echo "Skipping manual Codex trigger comment creation because GitHub post request failed."
+          fi

--- a/docs/architecture/codex-review.md
+++ b/docs/architecture/codex-review.md
@@ -7,7 +7,7 @@ O `codex-review` e um workflow advisory de revisao automatizada para pull reques
 ## Fluxo completo
 
 1. Um PR nao-draft e aberto, atualizado ou marcado como pronto para review contra `main`.
-2. O workflow `codex-review` dispara no GitHub Actions.
+2. O workflow automatico `codex-review` dispara no GitHub Actions.
 3. PRs de fork sao ignorados para nao expor automacao a contexto nao confiavel.
 4. O workflow resolve a configuracao automatica:
    - `CODEX_REVIEW_ENABLED`
@@ -26,7 +26,7 @@ O `codex-review` e um workflow advisory de revisao automatizada para pull reques
 9. Se Gemini falhar ou nao gerar conteudo publicavel, o workflow faz um retry unico.
 10. Se nenhum provider gerar texto publicavel, o workflow publica um comentario advisory explicando o motivo observado.
 11. O comentario final do fluxo automatico sempre e publicado via `GITHUB_TOKEN`, preservando o bot como autor.
-12. O Codex fica reservado para o fluxo manual premium:
+12. O Codex fica reservado para o workflow manual premium `manual-codex-review`:
     - o usuario aplica a label `codex-review`
     - o frontend do ForgeOps pode solicitar essa mesma label pelo backend
     - o workflow publica `@codex review` como usuario real quando `CODEX_REVIEW_PAT` estiver disponivel e valido
@@ -36,6 +36,10 @@ O `codex-review` e um workflow advisory de revisao automatizada para pull reques
 ### Codex fora do fluxo automatico
 
 O Codex nao roda mais automaticamente no review padrao. Isso reduz custo e mantem o fluxo automatico com providers mais baratos antes do fallback advisory.
+
+### Workflow manual separado do automatico
+
+O evento `pull_request:labeled` fica isolado em um workflow proprio. Isso evita que labels operacionais comuns gerem runs extras no workflow automatico e garante que o primeiro review OpenRouter ou Gemini comece assim que a PR entra no fluxo normal.
 
 ### PAT opcional para fluxo manual premium
 
@@ -76,7 +80,7 @@ Ordem de tentativa atual:
 3. Review automatizado via Gemini 2.5 Flash
 4. Retry unico do Gemini
 5. Comentario final advisory via bot
-6. Codex apenas no fluxo manual por label `codex-review`
+6. Codex apenas no workflow manual por label `codex-review`
 
 Isso permite combinar:
 - review automatizado por API com custo mais baixo

--- a/docs/workflows/codex-review.md
+++ b/docs/workflows/codex-review.md
@@ -1,8 +1,8 @@
-# Workflow `codex-review`
+# Workflows de review automatizado
 
 ## Objetivo
 
-O workflow `codex-review` adiciona uma camada advisory de revisao automatizada sobre pull requests para `main`, combinando:
+Os workflows de review adicionam uma camada advisory de revisao automatizada sobre pull requests para `main`, combinando:
 - review automatizado barato por API
 - fallback entre providers
 - comentario final transparente quando nenhum review util e produzido
@@ -10,16 +10,16 @@ O workflow `codex-review` adiciona uma camada advisory de revisao automatizada s
 
 ## Quando dispara
 
-Trigger:
-- `pull_request`
-- `pull_request_target`
+Workflow automatico:
+- `.github/workflows/codex-review.yml`
+- trigger `pull_request`
+- eventos `opened`, `synchronize`, `reopened`, `ready_for_review`
 
-Eventos:
-- `opened`
-- `synchronize`
-- `reopened`
-- `ready_for_review`
-- `labeled`
+Workflow manual premium:
+- `.github/workflows/manual-codex-review.yml`
+- trigger `pull_request`
+- evento `labeled`
+- executa apenas quando `github.event.label.name == 'codex-review'`
 
 Restricoes:
 - apenas para PRs contra `main`
@@ -91,7 +91,7 @@ Motivo:
 - nao expor automacao e secrets a contexto nao confiavel
 - manter principio de menor privilegio
 
-## Estrutura de alto nivel do job
+## Estrutura de alto nivel dos jobs
 
 ### Fluxo automatico
 
@@ -157,7 +157,8 @@ Falha dura acontece apenas quando houver:
 
 ## Arquivos relacionados
 
-- workflow principal: `.github/workflows/codex-review.yml`
+- workflow automatico: `.github/workflows/codex-review.yml`
+- workflow manual: `.github/workflows/manual-codex-review.yml`
 - smoke coverage: `.github/workflows/codex-review-smoke.yml`
 - smoke logic: `.github/scripts/codex-review-smoke.sh`
 - prompt principal: `.github/prompts/codex-review.md`


### PR DESCRIPTION
﻿## Resumo
Corrige a concorr?ncia do workflow de review para impedir que eventos `pull_request:labeled` de metadata cancelem o run autom?tico iniciado ao abrir a PR. A mudan?a preserva o contrato atual: OpenRouter continua no fluxo autom?tico, e o Codex segue restrito ao fluxo manual por label.

## O que foi alterado
- Ajusta a chave de `concurrency` em `.github/workflows/codex-review.yml`.
- Separa o agrupamento entre o caminho autom?tico da PR e os eventos `labeled`.
- Mant?m `cancel-in-progress: true`, mas impede que labels comuns como `chore`, `backend` e `priority:p1` matem o review autom?tico em andamento.

## Motiva??o
Na PR `#134`, o workflow autom?tico de review n?o apareceu porque o run disparado no evento `opened` foi cancelado por eventos `labeled` gerados logo ap?s a cria??o da PR. O run sobrevivente era um `pull_request:labeled`, e por contrato ele n?o executa o job autom?tico. O problema, portanto, estava na concorr?ncia compartilhada entre eventos autom?ticos e eventos de label.

## Como validar
- Abrir uma PR contra `main` com o workflow `codex-review.yml` j? atualizado.
- Aplicar labels comuns de metadata logo ap?s abrir a PR.
- Verificar no GitHub Actions que:
  - o run autom?tico iniciado no evento `opened` n?o ? cancelado pelos eventos `labeled`
  - o job `codex-review` segue executando o caminho autom?tico
  - o fluxo manual continua reservado ? label `codex-review`
- Confirmar que o coment?rio autom?tico volta a aparecer quando o provider produzir review public?vel.

## Riscos e impactos
- O risco t?cnico ? baixo porque a mudan?a altera apenas a segmenta??o de concorr?ncia do workflow.
- Eventos `labeled` continuar?o gerando runs pr?prios, mas n?o devem mais interromper o caminho autom?tico.
- A PR n?o altera providers, prompts, publica??o do coment?rio nem o fluxo manual do Codex.

## Evid?ncias
- Na PR `#134`, o run `24223238477` iniciou o caminho autom?tico e foi cancelado durante `Run automated review via OpenRouter`.
- Logo ap?s a abertura da PR, os eventos `labeled` para `chore`, `backend`, `infra` e `priority:p1` dispararam novos runs do mesmo workflow.
- Como a chave de `concurrency` era ?nica por n?mero da PR, esses eventos cancelaram o run autom?tico em andamento.
- O run final `24223243699` terminou `skipped`, porque o job autom?tico ignora `github.event.action == 'labeled'`.

## Checklist
- [x] Altera??o limitada ao objetivo da PR
- [x] Sem mudan?as desconexas
- [x] Impactos principais descritos
- [x] Valida??o documentada
- [x] Riscos identificados

Closes #135
