### PR TITLE
Corrige preflight local da API protegida via proxy

### DIFF
--- a/backend/src/app/create-server.ts
+++ b/backend/src/app/create-server.ts
@@ -1,4 +1,4 @@
-import Fastify from 'fastify';
+import Fastify, { type FastifyReply, type FastifyRequest } from 'fastify';
 import { registerRoutes } from './register-routes.js';
 import type { AppEnv } from '../infra/config/app-env.js';
 import type { OperatorAuthEnv } from '../infra/config/auth-env.js';
@@ -30,6 +30,70 @@ import { CodexReviewSummaryService } from '../modules/pull-request-insights/code
 import type { CodexReviewSummaryRepository } from '../modules/pull-request-insights/codex-review-summary.repository.js';
 import type { OperatorAuthVerifier } from '../shared/auth/operator-auth-verifier.js';
 
+const localCorsOrigins = [
+  /^http:\/\/forgeops\.local(?::\d+)?$/,
+  /^http:\/\/docker-frontend\.forgeops\.local(?::\d+)?$/,
+  /^http:\/\/localhost(?::\d+)?$/,
+];
+
+const isAllowedLocalCorsOrigin = (
+  origin: string | undefined,
+): origin is string => {
+  return typeof origin === 'string' && localCorsOrigins.some((pattern) => pattern.test(origin));
+};
+
+const appendVaryHeader = (reply: FastifyReply, value: string): void => {
+  const currentHeader = reply.getHeader('Vary');
+
+  if (typeof currentHeader !== 'string' || currentHeader.length === 0) {
+    reply.header('Vary', value);
+    return;
+  }
+
+  const values = currentHeader
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  if (!values.includes(value)) {
+    values.push(value);
+    reply.header('Vary', values.join(', '));
+  }
+};
+
+const applyLocalCorsHeaders = (
+  request: FastifyRequest,
+  reply: FastifyReply,
+): void => {
+  const origin = request.headers.origin;
+
+  if (!isAllowedLocalCorsOrigin(origin)) {
+    return;
+  }
+
+  reply.header('Access-Control-Allow-Origin', origin);
+  appendVaryHeader(reply, 'Origin');
+};
+
+const applyLocalPreflightHeaders = (
+  request: FastifyRequest,
+  reply: FastifyReply,
+): void => {
+  applyLocalCorsHeaders(request, reply);
+
+  const requestedHeaders = request.headers['access-control-request-headers'];
+
+  reply.header('Access-Control-Allow-Methods', 'GET, HEAD, POST, OPTIONS');
+  reply.header(
+    'Access-Control-Allow-Headers',
+    typeof requestedHeaders === 'string' && requestedHeaders.trim().length > 0
+      ? requestedHeaders
+      : 'authorization, content-type',
+  );
+  reply.header('Access-Control-Max-Age', '600');
+  appendVaryHeader(reply, 'Access-Control-Request-Headers');
+};
+
 export interface CreateServerOptions {
   env: AppEnv;
   authConfig?: OperatorAuthEnv | null;
@@ -46,6 +110,20 @@ export interface CreateServerOptions {
 export const createServer = (options: CreateServerOptions) => {
   const app = Fastify({
     logger: createLogger(options.env.LOG_LEVEL),
+  });
+
+  app.addHook('onRequest', async (request, reply) => {
+    if (request.method !== 'OPTIONS') {
+      return;
+    }
+
+    applyLocalPreflightHeaders(request, reply);
+    reply.status(204).send();
+  });
+
+  app.addHook('onSend', async (request, reply, payload) => {
+    applyLocalCorsHeaders(request, reply);
+    return payload;
   });
 
   app.decorateRequest('operatorPrincipal', null);

--- a/backend/src/infra/http/auth-guard.ts
+++ b/backend/src/infra/http/auth-guard.ts
@@ -40,6 +40,10 @@ export const createAuthGuard =
   async (request: FastifyRequest): Promise<void> => {
     request.operatorPrincipal = null;
 
+    if (request.method === 'OPTIONS') {
+      return;
+    }
+
     if (getAccessMode(request) === 'public') {
       return;
     }

--- a/backend/src/tests/app/create-server.test.ts
+++ b/backend/src/tests/app/create-server.test.ts
@@ -873,6 +873,52 @@ describe('createServer', () => {
     await server.close();
   });
 
+  it('should answer repository preflight requests without requiring operator auth', async () => {
+    const server = createProtectedServer({
+      repositories: [],
+    });
+
+    const response = await server.inject({
+      method: 'OPTIONS',
+      url: '/api/v1/repositories',
+      headers: {
+        origin: 'http://forgeops.local:8082',
+        'access-control-request-method': 'GET',
+        'access-control-request-headers': 'authorization',
+      },
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(response.headers['access-control-allow-origin']).toBe(
+      'http://forgeops.local:8082',
+    );
+    expect(response.headers['access-control-allow-headers']).toContain('authorization');
+
+    await server.close();
+  });
+
+  it('should include CORS headers on authenticated repository responses', async () => {
+    const server = createProtectedServer({
+      repositories: [],
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories',
+      headers: {
+        origin: 'http://forgeops.local:8082',
+        authorization: 'Bearer trusted-token',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['access-control-allow-origin']).toBe(
+      'http://forgeops.local:8082',
+    );
+
+    await server.close();
+  });
+
   it('should reject invalid repository payloads before service execution', async () => {
     const server = createProtectedServer();
 

--- a/backend/src/tests/server.test.ts
+++ b/backend/src/tests/server.test.ts
@@ -112,6 +112,62 @@ describe('resolveRuntimeServerOptions', () => {
     await server.close();
   });
 
+  it('should keep CORS preflight available even when operator auth is not configured', async () => {
+    const server = createRuntimeTestServer({
+      NODE_ENV: 'test',
+      PORT: '3333',
+      LOG_LEVEL: 'silent',
+    });
+
+    const response = await server.inject({
+      method: 'OPTIONS',
+      url: '/api/v1/repositories',
+      headers: {
+        origin: 'http://forgeops.local:8082',
+        'access-control-request-method': 'GET',
+        'access-control-request-headers': 'authorization',
+      },
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(response.headers['access-control-allow-origin']).toBe(
+      'http://forgeops.local:8082',
+    );
+    expect(response.headers['access-control-allow-headers']).toContain('authorization');
+
+    await server.close();
+  });
+
+  it('should keep CORS headers on protected responses even when auth is not configured', async () => {
+    const server = createRuntimeTestServer({
+      NODE_ENV: 'test',
+      PORT: '3333',
+      LOG_LEVEL: 'silent',
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/repositories',
+      headers: {
+        origin: 'http://forgeops.local:8082',
+        authorization: 'Bearer token',
+      },
+    });
+
+    expect(response.statusCode).toBe(503);
+    expect(response.headers['access-control-allow-origin']).toBe(
+      'http://forgeops.local:8082',
+    );
+    expect(response.json()).toEqual({
+      error: {
+        code: 'auth_not_configured',
+        message: 'Operator authentication is not configured.',
+      },
+    });
+
+    await server.close();
+  });
+
   it('should wire a runtime auth verifier when shared-secret auth is configured', async () => {
     const server = createRuntimeTestServer({
       NODE_ENV: 'test',


### PR DESCRIPTION
## Resumo
Corrige o bloqueio de preflight/CORS da API protegida no smoke local via proxy. A mudança evita que `OPTIONS` dependa da autenticação de operador e mantém os cabeçalhos CORS nas respostas reais, eliminando o `NetworkError` do navegador antes do request protegido.

## O que foi alterado
- Adicionado tratamento explícito de CORS local no bootstrap HTTP do backend para origins do ambiente de desenvolvimento via proxy.
- Adicionado retorno `204` para preflight permitido em rotas protegidas, sem relaxar a autenticação dos requests reais.
- Ajustado o auth guard para ignorar apenas `OPTIONS`.
- Criada cobertura de testes para preflight de `/api/v1/repositories` e para respostas protegidas com cabeçalhos CORS, inclusive no modo degradado sem auth configurada.

## Motivação
O frontend em `http://forgeops.local:8082` já apontava para a API via proxy, mas o navegador continuava falhando no fluxo protegido porque `OPTIONS /api/v1/repositories` era tratado como request autenticado e retornava erro antes da chamada real. Isso mantinha a UI em estado de `NetworkError` mesmo com backend e proxy saudáveis.

## Como validar
- Executar `npm.cmd --prefix backend run test -- --run src/tests/server.test.ts src/tests/app/create-server.test.ts`.
- Executar `npm.cmd --prefix backend run typecheck`.
- Subir o ambiente local e garantir que o backend receba `OPERATOR_AUTH_ENABLED=true`, `OPERATOR_AUTH_MODE=shared-secret`, `OPERATOR_AUTH_ISSUER=forgeops-local`, `OPERATOR_AUTH_AUDIENCE=forgeops-operator` e `OPERATOR_AUTH_SHARED_SECRET=forgeops-local-smoke-secret`.
- Validar o preflight com `curl.exe -i -X OPTIONS "http://api.forgeops.local:8082/api/v1/repositories" -H "Origin: http://forgeops.local:8082" -H "Access-Control-Request-Method: GET" -H "Access-Control-Request-Headers: authorization"`.
- Gerar um token local com `docker compose exec -T backend node /workspace/scripts/generate-local-operator-token.mjs --capability repositories:read --capability repositories:write`.
- Validar a chamada real com `curl.exe -i "http://api.forgeops.local:8082/api/v1/repositories" -H "Origin: http://forgeops.local:8082" -H "Authorization: Bearer <token>"`.

## Riscos e impactos
- O CORS local fica restrito aos origins previstos para o ambiente de desenvolvimento (`forgeops.local`, `docker-frontend.forgeops.local` e `localhost`).
- A autenticação dos requests reais permanece protegida; a exceção foi aplicada apenas ao preflight `OPTIONS`.
- O lint do backend continua bloqueado por um problema pré-existente de resolução de `globals` em `packages/eslint-config`, fora do escopo desta PR.

## Evidências
- `OPTIONS /api/v1/repositories` respondeu `204` com `Access-Control-Allow-Origin: http://forgeops.local:8082` e `Access-Control-Allow-Headers: authorization`.
- `GET /api/v1/repositories` respondeu `200` com token local e manteve `Access-Control-Allow-Origin: http://forgeops.local:8082`.

## Checklist
- [ ] Alteração limitada ao objetivo da PR
- [ ] Sem mudanças desconexas
- [ ] Impactos principais descritos
- [ ] Validação documentada
- [ ] Riscos identificados

Closes #138