### PR TITLE
Corrige a base URL pública da API no frontend local

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ TRAEFIK_PROVIDER_OBSERVER_INTERVAL_SECONDS=30
 NODE_ENV=development
 PORT=3333
 LOG_LEVEL=info
+# Legacy non-containerized frontend mode (`pnpm dev`) uses this value directly.
+# The Docker frontend derives `http://api.forgeops.local[:FORGEOPS_PROXY_PORT]` automatically.
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3333
 DATABASE_URL=postgresql://forgeops:forgeops@localhost:5432/forgeops
 REDIS_URL=redis://localhost:6379

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM workspace-base AS frontend-dev
 
 WORKDIR /workspace/frontend
 
-CMD ["node", "../scripts/run-bin.mjs", "next", "dev", "--hostname", "0.0.0.0", "--port", "3000"]
+CMD ["node", "../scripts/start-frontend-dev.mjs"]
 
 FROM workspace-base AS backend-dev
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Variaveis locais principais:
 - `GITHUB_APP_PRIVATE_KEY`
 - `GITHUB_APP_WEBHOOK_SECRET`
 
-No modo Docker, `docker-compose.yml` sobrescreve `DATABASE_URL`, `REDIS_URL` e `NEXT_PUBLIC_API_BASE_URL` para usar service discovery e os dominios locais. O `.env` continua servindo como modo legado para execucao direta fora de containers.
+No modo Docker, `docker-compose.yml` sobrescreve `DATABASE_URL` e `REDIS_URL` para usar service discovery. O frontend containerizado deriva `NEXT_PUBLIC_API_BASE_URL` a partir de `FORGEOPS_PROXY_PORT`, mantendo `http://api.forgeops.local` quando a porta publicada e `80` e adicionando `:<porta>` quando o proxy local usa outra porta. O `.env` continua servindo como modo legado para execucao direta fora de containers.
 
 Configuracao do proxy local:
 - `TRAEFIK_DOCKER_PROVIDER_ENABLED=false`
@@ -145,13 +145,13 @@ docker compose up --build
 ```
 
 Servicos esperados:
-- frontend: `http://forgeops.local`
-- backend: `http://api.forgeops.local`
+- frontend: `http://forgeops.local` quando `FORGEOPS_PROXY_PORT=80`, ou `http://forgeops.local:<porta>` quando a porta publicada for diferente
+- backend: `http://api.forgeops.local` quando `FORGEOPS_PROXY_PORT=80`, ou `http://api.forgeops.local:<porta>` quando a porta publicada for diferente
 - proxy reverso: porta `80` apenas
 
 PostgreSQL e Redis permanecem acessiveis apenas na rede Docker durante o uso normal da aplicacao.
 
-Se a porta `80` ja estiver ocupada por outra stack local, ajuste apenas `FORGEOPS_PROXY_PORT` no `.env`. O roteamento continua o mesmo; muda apenas a porta publicada pelo proxy.
+Se a porta `80` ja estiver ocupada por outra stack local, ajuste apenas `FORGEOPS_PROXY_PORT` no `.env`. O roteamento continua o mesmo, muda apenas a porta publicada pelo proxy, e o frontend containerizado passa a embutir a base URL correta da API no bundle local.
 
 ### 4.1 Provider do Traefik: estavel vs. experimental
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     restart: unless-stopped
     environment:
       NODE_ENV: development
-      NEXT_PUBLIC_API_BASE_URL: http://api.forgeops.local
+      FORGEOPS_PROXY_PORT: ${FORGEOPS_PROXY_PORT:-80}
       WATCHPACK_POLLING: 'true'
       CHOKIDAR_USEPOLLING: 'true'
       NEXT_TELEMETRY_DISABLED: '1'

--- a/docs/architecture/local-dev-proxy.md
+++ b/docs/architecture/local-dev-proxy.md
@@ -6,7 +6,7 @@ O ambiente local do ForgeOps usa Traefik como proxy reverso para expor:
 - `forgeops.local` -> frontend
 - `api.forgeops.local` -> backend
 
-O objetivo principal e manter uma experiencia container-first com porta externa unica, sem depender de `localhost:3000` e `localhost:3333` no fluxo normal.
+O objetivo principal e manter uma experiencia container-first com porta externa unica, sem depender de `localhost:3000` e `localhost:3333` no fluxo normal. A porta externa publicada continua configuravel por `FORGEOPS_PROXY_PORT`; quando ela nao for `80`, os hosts estaveis passam a ser acessados com `:<porta>`.
 
 ## Provider estavel
 
@@ -127,13 +127,21 @@ Esses hosts existem para validacao controlada do provider experimental. O trafeg
    - `TRAEFIK_DOCKER_PROVIDER_ENABLED=false`
    - `docker compose up --build`
 2. Confirmar rotas principais:
-   - `forgeops.local`
-   - `api.forgeops.local`
+   - `forgeops.local` ou `forgeops.local:<FORGEOPS_PROXY_PORT>`
+   - `api.forgeops.local` ou `api.forgeops.local:<FORGEOPS_PROXY_PORT>`
 3. Ativar o modo experimental:
    - `TRAEFIK_DOCKER_PROVIDER_ENABLED=true`
 4. Inspecionar logs:
    - `docker compose logs proxy`
 5. Verificar se o observer registra `healthy` ou `degraded`
+
+## Base URL publica do frontend
+
+No modo containerizado, o frontend resolve `NEXT_PUBLIC_API_BASE_URL` a partir da mesma porta publicada pelo proxy:
+- `FORGEOPS_PROXY_PORT=80` -> `http://api.forgeops.local`
+- `FORGEOPS_PROXY_PORT=8082` -> `http://api.forgeops.local:8082`
+
+Isso evita drift entre a porta publicada pelo Traefik e a URL embutida no bundle do frontend para chamadas protegidas do navegador.
 
 ## Evolucao futura
 

--- a/docs/plans/local-product-smoke-validation.md
+++ b/docs/plans/local-product-smoke-validation.md
@@ -18,6 +18,7 @@ Validate that the local ForgeOps stack can run the current product slice end to 
 - `OPERATOR_AUTH_MODE=shared-secret`
 - `OPERATOR_AUTH_ISSUER=forgeops-local`
 - `OPERATOR_AUTH_AUDIENCE=forgeops-operator`
+- frontend containerizado resolvendo `NEXT_PUBLIC_API_BASE_URL=http://api.forgeops.local:8082`
 
 ## Validation summary
 
@@ -93,8 +94,8 @@ The validated data came from the local smoke dataset already present in the data
 - codex review summary linked to the pull request
 
 ### Frontend through proxy
-- `GET /` via `forgeops.local` returned `200`
-- `GET /repositories` via `forgeops.local` returned `200`
+- `GET /` via `forgeops.local:8082` returned `200`
+- `GET /repositories` via `forgeops.local:8082` returned `200`
 
 ## Updated smoke validation with real onboarding token
 

--- a/scripts/start-frontend-dev.mjs
+++ b/scripts/start-frontend-dev.mjs
@@ -1,0 +1,92 @@
+import { spawn } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export const isExecutedDirectly = () => {
+  return process.argv[1]
+    ? import.meta.url === pathToFileURL(process.argv[1]).href
+    : false;
+};
+
+export const normalizeProxyPort = (value) => {
+  const port = typeof value === 'string' ? value.trim() : '';
+
+  if (port.length === 0) {
+    return '80';
+  }
+
+  if (!/^\d+$/.test(port)) {
+    throw new Error('FORGEOPS_PROXY_PORT must be a numeric port.');
+  }
+
+  return port;
+};
+
+export const resolveLocalApiBaseUrl = ({
+  explicitBaseUrl,
+  proxyPort,
+  host = 'api.forgeops.local',
+  protocol = 'http',
+} = {}) => {
+  const overriddenBaseUrl =
+    typeof explicitBaseUrl === 'string' ? explicitBaseUrl.trim() : '';
+
+  if (overriddenBaseUrl.length > 0) {
+    return overriddenBaseUrl;
+  }
+
+  const effectivePort = normalizeProxyPort(proxyPort);
+  const origin = `${protocol}://${host}`;
+
+  return effectivePort === '80' ? origin : `${origin}:${effectivePort}`;
+};
+
+export const createFrontendDevEnv = (env = process.env) => {
+  const nextEnv = {
+    ...env,
+    NEXT_PUBLIC_API_BASE_URL: resolveLocalApiBaseUrl({
+      explicitBaseUrl: env.NEXT_PUBLIC_API_BASE_URL,
+      proxyPort: env.FORGEOPS_PROXY_PORT,
+    }),
+  };
+
+  return nextEnv;
+};
+
+export const startFrontendDev = (env = process.env) => {
+  const nextEnv = createFrontendDevEnv(env);
+  const runBinPath = fileURLToPath(new URL('./run-bin.mjs', import.meta.url));
+  const frontendDir = fileURLToPath(new URL('../frontend', import.meta.url));
+
+  process.env.NEXT_PUBLIC_API_BASE_URL = nextEnv.NEXT_PUBLIC_API_BASE_URL;
+  process.stdout.write(
+    `[forgeops] NEXT_PUBLIC_API_BASE_URL=${nextEnv.NEXT_PUBLIC_API_BASE_URL}\n`,
+  );
+
+  const child = spawn(
+    process.execPath,
+    [runBinPath, 'next', 'dev', '--hostname', '0.0.0.0', '--port', '3000'],
+    {
+      cwd: frontendDir,
+      env: nextEnv,
+      stdio: 'inherit',
+    },
+  );
+
+  child.on('error', (error) => {
+    process.stderr.write(`[forgeops] failed to start frontend dev server: ${error.message}\n`);
+    process.exit(1);
+  });
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    process.exit(code ?? 0);
+  });
+};
+
+if (isExecutedDirectly()) {
+  startFrontendDev();
+}

--- a/scripts/start-frontend-dev.test.mjs
+++ b/scripts/start-frontend-dev.test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createFrontendDevEnv,
+  isExecutedDirectly,
+  normalizeProxyPort,
+  resolveLocalApiBaseUrl,
+} from './start-frontend-dev.mjs';
+
+test('normalizeProxyPort should default to 80 when the env var is empty', () => {
+  assert.equal(normalizeProxyPort(undefined), '80');
+  assert.equal(normalizeProxyPort(''), '80');
+  assert.equal(normalizeProxyPort('  '), '80');
+});
+
+test('normalizeProxyPort should reject non-numeric values', () => {
+  assert.throws(() => normalizeProxyPort('abc'), /FORGEOPS_PROXY_PORT must be a numeric port\./);
+});
+
+test('resolveLocalApiBaseUrl should omit :80 for the default proxy port', () => {
+  assert.equal(
+    resolveLocalApiBaseUrl({
+      proxyPort: '80',
+    }),
+    'http://api.forgeops.local',
+  );
+});
+
+test('resolveLocalApiBaseUrl should include a non-default proxy port', () => {
+  assert.equal(
+    resolveLocalApiBaseUrl({
+      proxyPort: '8082',
+    }),
+    'http://api.forgeops.local:8082',
+  );
+});
+
+test('resolveLocalApiBaseUrl should preserve explicit overrides', () => {
+  assert.equal(
+    resolveLocalApiBaseUrl({
+      explicitBaseUrl: 'https://preview.example.com',
+      proxyPort: '8082',
+    }),
+    'https://preview.example.com',
+  );
+});
+
+test('createFrontendDevEnv should inject the computed public API base URL', () => {
+  const env = createFrontendDevEnv({
+    FORGEOPS_PROXY_PORT: '8082',
+    NODE_ENV: 'development',
+  });
+
+  assert.equal(env.NEXT_PUBLIC_API_BASE_URL, 'http://api.forgeops.local:8082');
+  assert.equal(env.NODE_ENV, 'development');
+});
+
+test('isExecutedDirectly should be false when imported into tests', () => {
+  assert.equal(isExecutedDirectly(), false);
+});


### PR DESCRIPTION
## Resumo
Corrige a injeção da base URL pública da API no frontend local para respeitar a porta real publicada pelo proxy via `FORGEOPS_PROXY_PORT`. A mudança elimina o hardcode implícito da porta 80 no bundle do Next e preserva o modo legado quando o proxy local usa a porta padrão.

## O que foi alterado
- Adicionado um bootstrap do frontend containerizado que deriva `NEXT_PUBLIC_API_BASE_URL` a partir de `FORGEOPS_PROXY_PORT`, omitindo `:80` quando a porta publicada é a padrão.
- Ajustado o `Dockerfile` do estágio `frontend-dev` para iniciar o Next por esse bootstrap.
- Removido o valor fixo de `NEXT_PUBLIC_API_BASE_URL` do `docker-compose.yml`, mantendo apenas `FORGEOPS_PROXY_PORT` como entrada do ambiente local containerizado.
- Alinhados `.env.example`, `README.md` e a documentação do proxy/smoke local com o novo contrato de resolução da URL pública.
- Adicionado teste de Node para a regra de montagem da base URL no script do bootstrap.

## Motivação
O frontend local estava compilando `NEXT_PUBLIC_API_BASE_URL=http://api.forgeops.local` mesmo quando o proxy era publicado em `http://api.forgeops.local:8082`. Como o valor público é embutido no bundle, o navegador continuava tentando falar com a porta 80 e falhava no smoke local da UI protegida.

## Como validar
- Executar `node --test scripts/start-frontend-dev.test.mjs`.
- Subir o ambiente com `FORGEOPS_PROXY_PORT=8082` e recriar o frontend containerizado.
- Conferir nos logs do frontend a linha `[forgeops] NEXT_PUBLIC_API_BASE_URL=http://api.forgeops.local:8082`.
- Inspecionar o bundle recompilado de `/repositories` e confirmar que o literal embutido usa `http://api.forgeops.local:8082`.
- Validar `http://forgeops.local:8082/` e `http://forgeops.local:8082/repositories` pelo proxy local.

## Riscos e impactos
- O comportamento do frontend containerizado agora depende explicitamente de `FORGEOPS_PROXY_PORT`, o que é desejado para manter coerência com o Traefik local.
- O modo legado fora de containers continua usando `NEXT_PUBLIC_API_BASE_URL` do `.env` e não foi alterado.
- Durante a validação local, o `next dev` registrou `ENOMEM` transitório no watch da rota `/repositories`, mas a aplicação estabilizou e as rotas voltaram a responder `200`; isso parece ruído operacional do ambiente local e não mudança de contrato da base URL.
- Os comandos host-side do workspace frontend (`typecheck` e `vitest`) não fecharam nesta sessão por limitação do ambiente Windows local fora do container.

## Evidências
- Log do frontend: `[forgeops] NEXT_PUBLIC_API_BASE_URL=http://api.forgeops.local:8082`.
- Bundle recompilado de `frontend/.next/server/app/repositories/page.js` com o literal `http://api.forgeops.local:8082`.
- `GET http://forgeops.local:8082/` respondeu `200`.
- `GET http://forgeops.local:8082/repositories` respondeu `200`.

## Checklist
- [ ] Alteração limitada ao objetivo da PR
- [ ] Sem mudanças desconexas
- [ ] Impactos principais descritos
- [ ] Validação documentada
- [ ] Riscos identificados

Closes #140